### PR TITLE
fix: invalid DOM property 'class' on Earn page

### DIFF
--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -482,7 +482,7 @@ export default function Earn() {
                       <hr className="m-0" />
                     </div>
                   )}
-                  <div class="mt-4">
+                  <div className="mt-4">
                     <rb.Button
                       variant="dark"
                       type="submit"


### PR DESCRIPTION
Fixing a small oversight on the Earn page. `class` => `className`.