### PR TITLE
feat: prevent address reuse on Jam page

### DIFF
--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -352,9 +352,10 @@ export default function Jam() {
                 }
                 const isAddressReused = (destination, inputAddresses) => {
                   if (!destination) return false
+
+                  const knownAddress = walletInfo?.addressSummary[destination] || false
+                  const alreadyUsed = knownAddress && walletInfo?.addressSummary[destination]?.status !== 'new'
                   const duplicateEntry = inputAddresses.filter((it) => it === destination).length > 1
-                  const alreadyUsed =
-                    walletInfo?.addressSummary[destination] && walletInfo?.addressSummary[destination]?.status !== 'new'
 
                   return alreadyUsed || duplicateEntry
                 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -386,7 +386,8 @@
     "complete_wallet_title": "Complete Wallet",
     "complete_wallet_subtitle": "This will use all of your non-frozen funds.",
     "description_destination_addresses": "You can choose to send your funds to an external wallet after completion automatically. However, this feature requires you to provide multiple destination addresses to preserve your privacy.",
-    "error_invalid_destionation_address": "Please enter valid a destination address.",
+    "feedback_invalid_destination_address": "Please enter valid a destination address.",
+    "feedback_reused_destination_address": "This address is already used. To preserve your privacy please choose another one.",
     "toggle_internal_destination_title": "Send to external wallet",
     "toggle_internal_destination_subtitle": "Specify destination addresses to send funds to an external wallet.",
     "label_destination_input": "Destination {{ destination }}",
@@ -400,7 +401,6 @@
     "progress_current_state": "Waiting for transaction <1>{{ current }}</1> of <3>{{ total }}</3> to process...",
     "progress_done": "All transactions completed successfully. The scheduler will stop soon.",
     "error_loading_schedule_failed": "Loading schedule progress failed.",
-    "error_address_reuse": "Reusing addresses is prohibited. Make sure to use unique and unused addresses.",
     "precondition": {
       "hint_missing_utxos": "To run the scheduler you need at least one UTXO with <2>{{ minConfirmations }}</2> confirmations in Jar #0. Fund your wallet and wait for <6>{{ minConfirmations }}</6> blocks.",
       "hint_missing_confirmations": "The scheduler requires one of your UTXOs in Jar #0 to have <2>{{ minConfirmations }}</2> or more confirmations. Wait for <6>{{ amountOfMissingConfirmations }}</6> more block(s).",


### PR DESCRIPTION
Add a similar check for reused addresses on the Jam page as it already exists on the Send page.

Before this PR, only duplicate address entries in the form inputs have been checked.
After this PR is applied, address validation is extended to all addresses already known to Jam.

#####  :camera_flash: New, but duplicate address provided
<img src="https://user-images.githubusercontent.com/3358649/181744335-5316e995-741a-4d0c-8e93-f20f19fb1019.png" width=300 />

##### :camera_flash: Already reused address provided
<img src="https://user-images.githubusercontent.com/3358649/181744184-d8f8720b-306d-4cd0-8a94-3e23ed1211b8.png" width=300 />
