### PR TITLE
fix: color of light-button in dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -529,7 +529,7 @@ h2 {
   border-color: var(--bs-gray-800) !important;
 }
 
-:root[data-theme='dark'] .btn {
+:root[data-theme='dark'] .btn:not(.btn-light) {
   --bs-btn-color: var(--bs-white);
 }
 


### PR DESCRIPTION
Again a slip on my side.. :disappointed: 
This fixes the button color of "light" buttons in dark mode after a bootstrap update. 
Really hope this is the last one.