### PR TITLE
fix: cheatsheet icon

### DIFF
--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -102,6 +102,10 @@
     <symbol id="file" fill="currentColor" viewBox="0 0 24 24">
         <path fill-rule="evenodd" d="M13 4H7.5A1.5 1.5 0 006 5.5v13A1.5 1.5 0 007.5 20h9a1.5 1.5 0 001.5-1.5V9h-.004L13 4zm-1 1.604V9.75c0 .138.112.25.25.25h4.146a.25.25 0 00.177-.427l-4.146-4.146a.25.25 0 00-.427.177z" clip-rule="evenodd"></path>
     </symbol>
+    <symbol id="file-outline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path d="M6.5 6A1.5 1.5 0 018 4.5h5.5l4 4V18a1.5 1.5 0 01-1.5 1.5H8A1.5 1.5 0 016.5 18V6z"></path>
+        <path stroke-linejoin="round" d="M13 4.5V9h4.5"></path>
+    </symbol>
     <symbol id="sweep" fill="none" viewBox="0 0 24 24">
         <path stroke="currentColor" d="M5.5 19.5L18.5 19.5L18.5 12.5C18.5 11.9696 18.2893 11.4609 17.9142 11.0858C17.5391 10.7107 17.0304 10.5 16.5 10.5L13.5 10.5L13.5 7C13.5 6.60217 13.342 6.22064 13.0607 5.93934C12.7794 5.65804 12.3978 5.5 12 5.5C11.6022 5.5 11.2206 5.65804 10.9393 5.93934C10.658 6.22064 10.5 6.60217 10.5 7L10.5 10.5L7.5 10.5C6.96957 10.5 6.46086 10.7107 6.08579 11.0858C5.71071 11.4609 5.5 11.9696 5.5 12.5L5.5 19.5Z"/>
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" d="M16 19L16 18M18 13.5L6 13.5L18 13.5ZM8 19L8 17L8 19ZM10.5 19L10.5 15.5L10.5 19Z"/>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -178,7 +178,7 @@ export default function App() {
                     onClick={() => setShowCheatsheet(true)}
                   >
                     <div className="d-flex justify-content-center align-items-center">
-                      <Sprite symbol="file" width="24" height="24" />
+                      <Sprite symbol="file-outline" width="24" height="24" />
                       <div className="ps-0">{t('footer.cheatsheet')}</div>
                     </div>
                   </rb.Button>


### PR DESCRIPTION
In https://github.com/joinmarket-webui/jam/pull/439 I swapped the "file" icon from an outlined version to a filled version because that looks better on the settings page. However, in the footer -- where we use the same icon for the cheatsheet -- the outlined version looks better. So I changed it back to be outlined for the cheatsheet and stay filled on the settings page.

## 📸 

**Before:**
<img width="1198" alt="Screenshot 2022-08-04 at 12 28 24" src="https://user-images.githubusercontent.com/10026790/182826151-9cfd76b4-aaca-4ca1-a7c4-383389653c1a.png">

**After:**
<img width="1201" alt="Screenshot 2022-08-04 at 12 28 04" src="https://user-images.githubusercontent.com/10026790/182826199-b4c06947-cb91-4611-80ea-c392499b8c4e.png">

