### PR TITLE
feat: add sorting and filtering to earn report

### DIFF
--- a/src/components/EarnReport.module.css
+++ b/src/components/EarnReport.module.css
@@ -4,12 +4,54 @@
 }
 
 .overlayContainer .earnReportContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
   background-color: var(--bs-body-bg);
 }
 
 @media only screen and (min-width: 768px) {
   .overlayContainer .earnReportContainer {
-    border-radius: 0.5rem;
     padding: 2rem;
+    border-radius: 0.5rem;
   }
+}
+
+.overlayContainer .earnReportContainer > .titleBar {
+  min-height: 3.6rem;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0 0 0.8rem 0;
+  background-color: var(--bs-gray-100);
+}
+
+@media only screen and (min-width: 768px) {
+  .overlayContainer .earnReportContainer > .titleBar {
+    align-items: center;
+    padding: 0.8rem 1rem;
+    border-radius: 0.6rem;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .overlayContainer .earnReportContainer > .titleBar {
+    flex-direction: row;
+  }
+}
+
+:root[data-theme='dark'] .overlayContainer .earnReportContainer > .titleBar {
+  background-color: var(--bs-gray-800);
+}
+
+.overlayContainer .earnReportContainer > .titleBar .refreshButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0.1rem;
+  border: none;
 }

--- a/src/components/EarnReport.test.tsx
+++ b/src/components/EarnReport.test.tsx
@@ -1,5 +1,8 @@
 import { yieldgenReportToEarnReportEntries } from './EarnReport'
 
+const EXPECTED_HEADER_LINE =
+  'timestamp,cj amount/satoshi,my input count,my input value/satoshi,cjfee/satoshi,earned/satoshi,confirm time/min,notes\n'
+
 describe('Earn Report', () => {
   it('should parse empty data correctly', () => {
     const entries = yieldgenReportToEarnReportEntries([])
@@ -7,20 +10,16 @@ describe('Earn Report', () => {
   })
 
   it('should parse data only containing headers correctly', () => {
-    const onlyHeaders = [
-      'timestamp,cj amount/satoshi,my input count,my input value/satoshi,cjfee/satoshi,earned/satoshi,confirm time/min,notes\n',
-    ]
-
-    const entries = yieldgenReportToEarnReportEntries(onlyHeaders)
+    const entries = yieldgenReportToEarnReportEntries([EXPECTED_HEADER_LINE])
 
     expect(entries.length).toBe(0)
   })
 
   it('should parse expected data structure correctly', () => {
     const exampleData = [
-      'timestamp,cj amount/satoshi,my input count,my input value/satoshi,cjfee/satoshi,earned/satoshi,confirm time/min,notes\n',
-      '2009/01/03 02:54:42,,,,,,,Connected\n',
-      '2009/01/03 03:02:12,14999989490,4,20000005630,250,250,0.42,\n',
+      EXPECTED_HEADER_LINE,
+      '2008/10/31 02:42:54,,,,,,,Connected\n',
+      '2009/01/03 02:54:42,14999989490,4,20000005630,250,250,0.42,\n',
       '2009/01/03 03:03:32,10000000000,3,15000016390,250,250,0.8,\n',
       '2009/01/03 03:04:47,4999981140,1,5000016640,250,250,0,\n',
       '2009/01/03 03:06:07,1132600000,1,2500000000,250,250,13.37,\n',
@@ -33,7 +32,7 @@ describe('Earn Report', () => {
     expect(entries.length).toBe(7)
 
     const firstEntry = entries[0]
-    expect(firstEntry.timestamp.toUTCString()).toBe('Sat, 03 Jan 2009 02:54:42 GMT')
+    expect(firstEntry.timestamp.toUTCString()).toBe('Fri, 31 Oct 2008 02:42:54 GMT')
     expect(firstEntry.cjTotalAmount).toBe(null)
     expect(firstEntry.inputCount).toBe(null)
     expect(firstEntry.inputAmount).toBe(null)
@@ -51,5 +50,40 @@ describe('Earn Report', () => {
     expect(lastEntry.earnedAmount).toBe(250)
     expect(lastEntry.confirmationDuration).toBe(0.17)
     expect(lastEntry.notes).toBe('\n')
+  })
+
+  it('should handle unexpected/malformed data in a sane way', () => {
+    const unexpectedHeader = EXPECTED_HEADER_LINE + ',foo,bar'
+    const emptyLine = '' // should be skipped
+    const onlyNewLine = '\n' // should be skipped
+    const shortLine = '2009/01/03 04:04:04,,,' // should be skipped
+    const longLine = '2009/01/03 05:05:05,,,,,,,,,,,,,,,,,,,,,,,' // should be parsed
+    const malformedLine = 'this,is,a,malformed,line,with,some,unexpected,data' // should be parsed
+
+    const exampleData = [unexpectedHeader, emptyLine, onlyNewLine, shortLine, longLine, malformedLine]
+
+    const entries = yieldgenReportToEarnReportEntries(exampleData)
+
+    expect(entries.length).toBe(2)
+
+    const firstEntry = entries[0]
+    expect(firstEntry.timestamp.toUTCString()).toBe('Sat, 03 Jan 2009 05:05:05 GMT')
+    expect(firstEntry.cjTotalAmount).toBe(null)
+    expect(firstEntry.inputCount).toBe(null)
+    expect(firstEntry.inputAmount).toBe(null)
+    expect(firstEntry.fee).toBe(null)
+    expect(firstEntry.earnedAmount).toBe(null)
+    expect(firstEntry.confirmationDuration).toBe(null)
+    expect(firstEntry.notes).toBe(null)
+
+    const secondEntry = entries[1]
+    expect(secondEntry.timestamp.toUTCString()).toBe('Invalid Date')
+    expect(secondEntry.cjTotalAmount).toBe(NaN)
+    expect(secondEntry.inputCount).toBe(NaN)
+    expect(secondEntry.inputAmount).toBe(NaN)
+    expect(secondEntry.fee).toBe(NaN)
+    expect(secondEntry.earnedAmount).toBe(NaN)
+    expect(secondEntry.confirmationDuration).toBe(NaN)
+    expect(secondEntry.notes).toBe('unexpected')
   })
 })

--- a/src/components/EarnReport.test.tsx
+++ b/src/components/EarnReport.test.tsx
@@ -1,0 +1,55 @@
+import { yieldgenReportToEarnReportEntries } from './EarnReport'
+
+describe('Earn Report', () => {
+  it('should parse empty data correctly', () => {
+    const entries = yieldgenReportToEarnReportEntries([])
+    expect(entries.length).toBe(0)
+  })
+
+  it('should parse data only containing headers correctly', () => {
+    const onlyHeaders = [
+      'timestamp,cj amount/satoshi,my input count,my input value/satoshi,cjfee/satoshi,earned/satoshi,confirm time/min,notes\n',
+    ]
+
+    const entries = yieldgenReportToEarnReportEntries(onlyHeaders)
+
+    expect(entries.length).toBe(0)
+  })
+
+  it('should parse expected data structure correctly', () => {
+    const exampleData = [
+      'timestamp,cj amount/satoshi,my input count,my input value/satoshi,cjfee/satoshi,earned/satoshi,confirm time/min,notes\n',
+      '2009/01/03 02:54:42,,,,,,,Connected\n',
+      '2009/01/03 03:02:12,14999989490,4,20000005630,250,250,0.42,\n',
+      '2009/01/03 03:03:32,10000000000,3,15000016390,250,250,0.8,\n',
+      '2009/01/03 03:04:47,4999981140,1,5000016640,250,250,0,\n',
+      '2009/01/03 03:06:07,1132600000,1,2500000000,250,250,13.37,\n',
+      '2009/01/03 03:07:27,8867393010,2,10000000000,250,250,42,\n',
+      '2009/01/03 03:08:52,1132595980,1,1367400250,250,250,0.17,\n',
+    ]
+
+    const entries = yieldgenReportToEarnReportEntries(exampleData)
+
+    expect(entries.length).toBe(7)
+
+    const firstEntry = entries[0]
+    expect(firstEntry.timestamp.toUTCString()).toBe('Sat, 03 Jan 2009 02:54:42 GMT')
+    expect(firstEntry.cjTotalAmount).toBe(null)
+    expect(firstEntry.inputCount).toBe(null)
+    expect(firstEntry.inputAmount).toBe(null)
+    expect(firstEntry.fee).toBe(null)
+    expect(firstEntry.earnedAmount).toBe(null)
+    expect(firstEntry.confirmationDuration).toBe(null)
+    expect(firstEntry.notes).toBe('Connected\n')
+
+    const lastEntry = entries[entries.length - 1]
+    expect(lastEntry.timestamp.toUTCString()).toBe('Sat, 03 Jan 2009 03:08:52 GMT')
+    expect(lastEntry.cjTotalAmount).toBe(1132595980)
+    expect(lastEntry.inputCount).toBe(1)
+    expect(lastEntry.inputAmount).toBe(1367400250)
+    expect(lastEntry.fee).toBe(250)
+    expect(lastEntry.earnedAmount).toBe(250)
+    expect(lastEntry.confirmationDuration).toBe(0.17)
+    expect(lastEntry.notes).toBe('\n')
+  })
+})

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -19,12 +19,11 @@ const SORT_KEYS = {
   inputAmountInSats: 'INPUT_AMOUNT_IN_SATS',
   feeInSats: 'FEE_IN_SATS',
   earnedAmountInSats: 'EARNED_AMOUNT_IN_SATS',
-  confirmDurationInMinutes: 'CONF_DURATION_IN_MINUTES',
 }
 
 const TABLE_THEME = {
   Table: `
-    --data-table-library_grid-template-columns: 1fr 1fr 9rem 1fr 1fr 1fr 1fr 1fr;
+    --data-table-library_grid-template-columns: 1fr 1fr 9rem 1fr 1fr 1fr 1fr;
     font-size: 0.9rem;
   `,
   BaseCell: `
@@ -48,10 +47,6 @@ const TABLE_THEME = {
       display: flex;
       justify-content: end;
     }
-    &:nth-of-type(7) button {
-      display: flex;
-      justify-content: center;
-    }
   `,
   Cell: `
     &:nth-of-type(2) {
@@ -68,9 +63,6 @@ const TABLE_THEME = {
     }
     &:nth-of-type(6) {
       text-align: right;
-    }
-    &:nth-of-type(7) {
-      text-align: center;
     }
   `,
 }
@@ -164,8 +156,6 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
         [SORT_KEYS.inputAmountInSats]: (array) => array.sort((a, b) => +a.inputAmount - +b.inputAmount),
         [SORT_KEYS.feeInSats]: (array) => array.sort((a, b) => +a.fee - +b.fee),
         [SORT_KEYS.earnedAmountInSats]: (array) => array.sort((a, b) => +a.earnedAmount - +b.earnedAmount),
-        [SORT_KEYS.confirmDurationInMinutes]: (array) =>
-          array.sort((a, b) => +a.confirmationDuration - +b.confirmationDuration),
       },
     }
   )
@@ -186,9 +176,6 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
               </HeaderCellSort>
               <HeaderCellSort sortKey={SORT_KEYS.feeInSats}>{t('earn.report.heading_cj_fee')}</HeaderCellSort>
               <HeaderCellSort sortKey={SORT_KEYS.earnedAmountInSats}>{t('earn.report.heading_earned')}</HeaderCellSort>
-              <HeaderCellSort sortKey={SORT_KEYS.confirmDurationInMinutes}>
-                {t('earn.report.heading_confirm_time')}
-              </HeaderCellSort>
               <HeaderCell>{t('earn.report.heading_notes')}</HeaderCell>
             </HeaderRow>
           </Header>
@@ -227,7 +214,6 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
                       showBalance={true}
                     />
                   </Cell>
-                  <Cell>{entry.confirmationDuration}</Cell>
                   <Cell>{entry.notes}</Cell>
                 </Row>
               )

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -110,7 +110,8 @@ const yieldgenReportLineToEarnReportEntry = (line: string): EarnReportEntry | nu
 
 type YieldgenReportLinesWithHeader = string[]
 
-const yieldgenReportToEarnReportEntries = (lines: YieldgenReportLinesWithHeader) => {
+// exported for tests only
+export const yieldgenReportToEarnReportEntries = (lines: YieldgenReportLinesWithHeader) => {
   const empty = lines.length < 2 // report is "empty" if it just contains the header line
   const linesWithoutHeader = empty ? [] : lines.slice(1, lines.length)
 

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -23,7 +23,7 @@ const SORT_KEYS = {
 
 const TABLE_THEME = {
   Table: `
-    --data-table-library_grid-template-columns: 1fr 1fr 9rem 1fr 1fr 1fr 1fr;
+    --data-table-library_grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
     font-size: 0.9rem;
   `,
   BaseCell: `

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Table, Header, HeaderRow, HeaderCell, Body, Row, Cell } from '@table-library/react-table-library/table'
 import { useSort, HeaderCellSort, SortToggleType } from '@table-library/react-table-library/sort'
-import { usePagination, Pagination } from '@table-library/react-table-library/pagination'
 import * as TableTypes from '@table-library/react-table-library/types/table'
 import { useTheme } from '@table-library/react-table-library/theme'
 import * as rb from 'react-bootstrap'
@@ -68,8 +67,6 @@ const TABLE_THEME = {
   `,
 }
 
-const TABLE_PAGE_SIZES = [25, 50, 100]
-
 type Minutes = number
 
 interface EarnReportEntry {
@@ -126,95 +123,6 @@ const yieldgenReportToEarnReportEntries = (lines: YieldgenReportLinesWithHeader)
 // `TableNode` is known to have same properties as `EarnReportEntry`, hence prefer casting over object destructuring
 const toEarnReportEntry = (tableNode: TableTypes.TableNode) => tableNode as unknown as EarnReportEntry
 
-interface TablePaginationProps {
-  tableData: TableTypes.Data
-  pagination: Pagination
-  pageSizes: number[]
-  allowShowAll?: boolean
-}
-
-const TablePagination = ({ tableData, pagination, pageSizes, allowShowAll = true }: TablePaginationProps) => {
-  const { t } = useTranslation()
-
-  return (
-    <div className="mt-4 mb-4 mb-md-0 d-flex justify-content-between flex-column flex-md-row">
-      <div className="mt-3 mt-md-0 ms-3 ms-md-0 d-flex justify-content-center align-items-center order-2 order-md-1">
-        {t('earn.report.pagination.items_per_page.label')}
-        <rb.Form.Select
-          aria-label={t('earn.report.pagination.items_per_page.label')}
-          className="ms-2 d-inline-block w-auto"
-          defaultValue={pageSizes[0]}
-          onChange={(e) => {
-            const value = parseInt(e.target.value, 10)
-            const pageSize = value > 0 ? value : tableData.nodes.length
-            pagination.fns.onSetSize(pageSize)
-          }}
-        >
-          {pageSizes.map((size) => (
-            <option key={size} value={size}>
-              {size}
-            </option>
-          ))}
-          {allowShowAll && (
-            <option value={-1}>{t('earn.report.pagination.items_per_page.text_option_show_all')}</option>
-          )}
-        </rb.Form.Select>
-      </div>
-
-      <div className="mt-3 mt-md-0 ms-3 ms-md-0 d-flex justify-content-center align-items-center order-1 order-md-2">
-        <rb.Button
-          variant={'outline-dark'}
-          className="ms-1"
-          disabled={pagination.state.page === 0}
-          onClick={() => pagination.fns.onSetPage(0)}
-        >
-          {t('earn.report.pagination.page_selector.label_first')}
-        </rb.Button>
-        <rb.Button
-          variant="outline-dark"
-          className="ms-1"
-          disabled={pagination.state.page === 0}
-          onClick={() => pagination.fns.onSetPage(pagination.state.page - 1)}
-        >
-          {t('earn.report.pagination.page_selector.label_previous')}
-        </rb.Button>
-        <rb.Form.Select
-          aria-label={t('earn.report.pagination.page_selector.label')}
-          className="ms-1 d-inline-block w-auto h-auto"
-          value={pagination.state.page}
-          onChange={(e) => {
-            const value = parseInt(e.target.value, 10)
-            const page = value > 0 ? value : 0
-            pagination.fns.onSetPage(page)
-          }}
-        >
-          {pagination.state.getPages(tableData.nodes).map((_: any, index: number) => (
-            <option key={index} value={index}>
-              {index + 1}
-            </option>
-          ))}
-        </rb.Form.Select>
-        <rb.Button
-          variant="outline-dark"
-          className="ms-1"
-          disabled={pagination.state.page + 1 === pagination.state.getTotalPages(tableData.nodes)}
-          onClick={() => pagination.fns.onSetPage(pagination.state.page + 1)}
-        >
-          {t('earn.report.pagination.page_selector.label_next')}
-        </rb.Button>
-        <rb.Button
-          variant="outline-dark"
-          className="ms-1"
-          disabled={pagination.state.page + 1 === pagination.state.getTotalPages(tableData.nodes)}
-          onClick={() => pagination.fns.onSetPage(pagination.state.getTotalPages(tableData.nodes) - 1)}
-        >
-          {t('earn.report.pagination.page_selector.label_last')}
-        </rb.Button>
-      </div>
-    </div>
-  )
-}
-
 interface EarnReportTableProps {
   tableData: TableTypes.Data
 }
@@ -252,22 +160,9 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
     }
   )
 
-  const pagination = usePagination(tableData, {
-    state: {
-      page: 0,
-      size: TABLE_PAGE_SIZES[0],
-    },
-  })
-
   return (
     <>
-      <Table
-        data={tableData}
-        theme={tableTheme}
-        pagination={pagination}
-        sort={tableSort}
-        layout={{ custom: true, horizontalScroll: true }}
-      >
+      <Table data={tableData} theme={tableTheme} sort={tableSort} layout={{ custom: true, horizontalScroll: true }}>
         {(tableList) => (
           <>
             <Header>
@@ -330,7 +225,6 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
           </>
         )}
       </Table>
-      <TablePagination pagination={pagination} tableData={tableData} pageSizes={TABLE_PAGE_SIZES} />
     </>
   )
 }

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -23,7 +23,7 @@ const SORT_KEYS = {
 
 const TABLE_THEME = {
   Table: `
-    --data-table-library_grid-template-columns: 2fr 2fr 1fr 2fr 2fr 2fr 2fr;
+    --data-table-library_grid-template-columns: 2fr 2fr 2fr 1fr 2fr 2fr 2fr;
     font-size: 0.9rem;
   `,
   BaseCell: `
@@ -152,11 +152,11 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
       sortToggleType: SortToggleType.AlternateWithReset,
       sortFns: {
         [SORT_KEYS.timestamp]: (array) => array.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime()),
+        [SORT_KEYS.earnedAmountInSats]: (array) => array.sort((a, b) => +a.earnedAmount - +b.earnedAmount),
         [SORT_KEYS.cjTotalAmountInSats]: (array) => array.sort((a, b) => +a.cjTotalAmount - +b.cjTotalAmount),
         [SORT_KEYS.inputCount]: (array) => array.sort((a, b) => +a.inputCount - +b.inputCount),
         [SORT_KEYS.inputAmountInSats]: (array) => array.sort((a, b) => +a.inputAmount - +b.inputAmount),
         [SORT_KEYS.feeInSats]: (array) => array.sort((a, b) => +a.fee - +b.fee),
-        [SORT_KEYS.earnedAmountInSats]: (array) => array.sort((a, b) => +a.earnedAmount - +b.earnedAmount),
       },
     }
   )
@@ -169,6 +169,9 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
             <Header>
               <HeaderRow>
                 <HeaderCellSort sortKey={SORT_KEYS.timestamp}>{t('earn.report.heading_timestamp')}</HeaderCellSort>
+                <HeaderCellSort sortKey={SORT_KEYS.earnedAmountInSats}>
+                  {t('earn.report.heading_earned')}
+                </HeaderCellSort>
                 <HeaderCellSort sortKey={SORT_KEYS.cjTotalAmountInSats}>
                   {t('earn.report.heading_cj_amount')}
                 </HeaderCellSort>
@@ -177,9 +180,6 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
                   {t('earn.report.heading_input_value')}
                 </HeaderCellSort>
                 <HeaderCellSort sortKey={SORT_KEYS.feeInSats}>{t('earn.report.heading_cj_fee')}</HeaderCellSort>
-                <HeaderCellSort sortKey={SORT_KEYS.earnedAmountInSats}>
-                  {t('earn.report.heading_earned')}
-                </HeaderCellSort>
                 <HeaderCell>{t('earn.report.heading_notes')}</HeaderCell>
               </HeaderRow>
             </Header>
@@ -189,6 +189,13 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
                 return (
                   <Row key={item.id} item={item}>
                     <Cell>{entry.timestamp.toLocaleString()}</Cell>
+                    <Cell>
+                      <Balance
+                        valueString={entry.earnedAmount?.toString() || ''}
+                        convertToUnit={settings.unit}
+                        showBalance={true}
+                      />
+                    </Cell>
                     <Cell>
                       <Balance
                         valueString={entry.cjTotalAmount?.toString() || ''}
@@ -207,13 +214,6 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
                     <Cell>
                       <Balance
                         valueString={entry.fee?.toString() || ''}
-                        convertToUnit={settings.unit}
-                        showBalance={true}
-                      />
-                    </Cell>
-                    <Cell>
-                      <Balance
-                        valueString={entry.earnedAmount?.toString() || ''}
                         convertToUnit={settings.unit}
                         showBalance={true}
                       />

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -24,7 +24,7 @@ const SORT_KEYS = {
 
 const TABLE_THEME = {
   Table: `
-    --data-table-library_grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+    --data-table-library_grid-template-columns: 2fr 2fr 1fr 2fr 2fr 2fr 2fr;
     font-size: 0.9rem;
   `,
   BaseCell: `

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Table, Header, HeaderRow, HeaderCell, Body, Row, Cell } from '@table-library/react-table-library/table'
 import { useSort, HeaderCellSort, SortToggleType } from '@table-library/react-table-library/sort'
+import { usePagination, Pagination } from '@table-library/react-table-library/pagination'
 import * as TableTypes from '@table-library/react-table-library/types/table'
 import { useTheme } from '@table-library/react-table-library/theme'
 import * as rb from 'react-bootstrap'
@@ -123,6 +124,95 @@ const yieldgenReportToEarnReportEntries = (lines: YieldgenReportLinesWithHeader)
 // `TableNode` is known to have same properties as `EarnReportEntry`, hence prefer casting over object destructuring
 const toEarnReportEntry = (tableNode: TableTypes.TableNode) => tableNode as unknown as EarnReportEntry
 
+interface TablePaginationProps {
+  tableData: TableTypes.Data
+  pagination: Pagination
+  itemsPerPage: number[]
+  allowShowAll?: boolean
+}
+
+const TablePagination = ({ tableData, pagination, itemsPerPage, allowShowAll = true }: TablePaginationProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="mt-4 mb-4 mb-md-0 d-flex justify-content-between flex-column flex-md-row">
+      <div className="mt-3 mt-md-0 ms-3 ms-md-0 d-flex justify-content-center align-items-center order-2 order-md-1">
+        {t('earn.report.pagination.items_per_page.label')}
+        <rb.Form.Select
+          aria-label={t('earn.report.pagination.items_per_page.label')}
+          className="ms-2 d-inline-block w-auto"
+          defaultValue={itemsPerPage[0]}
+          onChange={(e) => {
+            const value = parseInt(e.target.value, 10)
+            const pageSize = value > 0 ? value : tableData.nodes.length
+            pagination.fns.onSetSize(pageSize)
+          }}
+        >
+          {itemsPerPage.map((size) => (
+            <option key={size} value={size}>
+              {size}
+            </option>
+          ))}
+          {allowShowAll && (
+            <option value={-1}>{t('earn.report.pagination.items_per_page.text_option_show_all')}</option>
+          )}
+        </rb.Form.Select>
+      </div>
+
+      <div className="mt-3 mt-md-0 ms-3 ms-md-0 d-flex justify-content-center align-items-center order-1 order-md-2">
+        <rb.Button
+          variant={'outline-dark'}
+          className="ms-1"
+          disabled={pagination.state.page === 0}
+          onClick={() => pagination.fns.onSetPage(0)}
+        >
+          {t('earn.report.pagination.page_selector.label_first')}
+        </rb.Button>
+        <rb.Button
+          variant="outline-dark"
+          className="ms-1"
+          disabled={pagination.state.page === 0}
+          onClick={() => pagination.fns.onSetPage(pagination.state.page - 1)}
+        >
+          {t('earn.report.pagination.page_selector.label_previous')}
+        </rb.Button>
+        <rb.Form.Select
+          aria-label={t('earn.report.pagination.page_selector.label')}
+          className="ms-1 d-inline-block w-auto h-auto"
+          value={pagination.state.page}
+          onChange={(e) => {
+            const value = parseInt(e.target.value, 10)
+            const page = value > 0 ? value : 0
+            pagination.fns.onSetPage(page)
+          }}
+        >
+          {pagination.state.getPages(tableData.nodes).map((_: any, index: number) => (
+            <option key={index} value={index}>
+              {index + 1}
+            </option>
+          ))}
+        </rb.Form.Select>
+        <rb.Button
+          variant="outline-dark"
+          className="ms-1"
+          disabled={pagination.state.page + 1 === pagination.state.getTotalPages(tableData.nodes)}
+          onClick={() => pagination.fns.onSetPage(pagination.state.page + 1)}
+        >
+          {t('earn.report.pagination.page_selector.label_next')}
+        </rb.Button>
+        <rb.Button
+          variant="outline-dark"
+          className="ms-1"
+          disabled={pagination.state.page + 1 === pagination.state.getTotalPages(tableData.nodes)}
+          onClick={() => pagination.fns.onSetPage(pagination.state.getTotalPages(tableData.nodes) - 1)}
+        >
+          {t('earn.report.pagination.page_selector.label_last')}
+        </rb.Button>
+      </div>
+    </div>
+  )
+}
+
 interface EarnReportTableProps {
   tableData: TableTypes.Data
 }
@@ -160,68 +250,87 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
     }
   )
 
+  const itemsPerPage = [25, 50, 100]
+  const pagination = usePagination(tableData, {
+    state: {
+      page: 0,
+      size: itemsPerPage[0],
+    },
+  })
+
   return (
-    <Table data={tableData} theme={tableTheme} sort={tableSort} layout={{ custom: true, horizontalScroll: true }}>
-      {(tableList) => (
-        <>
-          <Header>
-            <HeaderRow>
-              <HeaderCellSort sortKey={SORT_KEYS.timestamp}>{t('earn.report.heading_timestamp')}</HeaderCellSort>
-              <HeaderCellSort sortKey={SORT_KEYS.cjTotalAmountInSats}>
-                {t('earn.report.heading_cj_amount')}
-              </HeaderCellSort>
-              <HeaderCellSort sortKey={SORT_KEYS.inputCount}>{t('earn.report.heading_input_count')}</HeaderCellSort>
-              <HeaderCellSort sortKey={SORT_KEYS.inputAmountInSats}>
-                {t('earn.report.heading_input_value')}
-              </HeaderCellSort>
-              <HeaderCellSort sortKey={SORT_KEYS.feeInSats}>{t('earn.report.heading_cj_fee')}</HeaderCellSort>
-              <HeaderCellSort sortKey={SORT_KEYS.earnedAmountInSats}>{t('earn.report.heading_earned')}</HeaderCellSort>
-              <HeaderCell>{t('earn.report.heading_notes')}</HeaderCell>
-            </HeaderRow>
-          </Header>
-          <Body>
-            {tableList.map((item) => {
-              const entry = toEarnReportEntry(item)
-              return (
-                <Row key={item.id} item={item}>
-                  <Cell>{entry.timestamp.toLocaleString()}</Cell>
-                  <Cell>
-                    <Balance
-                      valueString={entry.cjTotalAmount?.toString() || ''}
-                      convertToUnit={settings.unit}
-                      showBalance={true}
-                    />
-                  </Cell>
-                  <Cell>{entry.inputCount}</Cell>
-                  <Cell>
-                    <Balance
-                      valueString={entry.inputAmount?.toString() || ''}
-                      convertToUnit={settings.unit}
-                      showBalance={true}
-                    />
-                  </Cell>
-                  <Cell>
-                    <Balance
-                      valueString={entry.fee?.toString() || ''}
-                      convertToUnit={settings.unit}
-                      showBalance={true}
-                    />
-                  </Cell>
-                  <Cell>
-                    <Balance
-                      valueString={entry.earnedAmount?.toString() || ''}
-                      convertToUnit={settings.unit}
-                      showBalance={true}
-                    />
-                  </Cell>
-                  <Cell>{entry.notes}</Cell>
-                </Row>
-              )
-            })}
-          </Body>
-        </>
-      )}
-    </Table>
+    <>
+      <Table
+        data={tableData}
+        theme={tableTheme}
+        pagination={pagination}
+        sort={tableSort}
+        layout={{ custom: true, horizontalScroll: true }}
+      >
+        {(tableList) => (
+          <>
+            <Header>
+              <HeaderRow>
+                <HeaderCellSort sortKey={SORT_KEYS.timestamp}>{t('earn.report.heading_timestamp')}</HeaderCellSort>
+                <HeaderCellSort sortKey={SORT_KEYS.cjTotalAmountInSats}>
+                  {t('earn.report.heading_cj_amount')}
+                </HeaderCellSort>
+                <HeaderCellSort sortKey={SORT_KEYS.inputCount}>{t('earn.report.heading_input_count')}</HeaderCellSort>
+                <HeaderCellSort sortKey={SORT_KEYS.inputAmountInSats}>
+                  {t('earn.report.heading_input_value')}
+                </HeaderCellSort>
+                <HeaderCellSort sortKey={SORT_KEYS.feeInSats}>{t('earn.report.heading_cj_fee')}</HeaderCellSort>
+                <HeaderCellSort sortKey={SORT_KEYS.earnedAmountInSats}>
+                  {t('earn.report.heading_earned')}
+                </HeaderCellSort>
+                <HeaderCell>{t('earn.report.heading_notes')}</HeaderCell>
+              </HeaderRow>
+            </Header>
+            <Body>
+              {tableList.map((item) => {
+                const entry = toEarnReportEntry(item)
+                return (
+                  <Row key={item.id} item={item}>
+                    <Cell>{entry.timestamp.toLocaleString()}</Cell>
+                    <Cell>
+                      <Balance
+                        valueString={entry.cjTotalAmount?.toString() || ''}
+                        convertToUnit={settings.unit}
+                        showBalance={true}
+                      />
+                    </Cell>
+                    <Cell>{entry.inputCount}</Cell>
+                    <Cell>
+                      <Balance
+                        valueString={entry.inputAmount?.toString() || ''}
+                        convertToUnit={settings.unit}
+                        showBalance={true}
+                      />
+                    </Cell>
+                    <Cell>
+                      <Balance
+                        valueString={entry.fee?.toString() || ''}
+                        convertToUnit={settings.unit}
+                        showBalance={true}
+                      />
+                    </Cell>
+                    <Cell>
+                      <Balance
+                        valueString={entry.earnedAmount?.toString() || ''}
+                        convertToUnit={settings.unit}
+                        showBalance={true}
+                      />
+                    </Cell>
+                    <Cell>{entry.notes}</Cell>
+                  </Row>
+                )
+              })}
+            </Body>
+          </>
+        )}
+      </Table>
+      <TablePagination pagination={pagination} tableData={tableData} itemsPerPage={itemsPerPage} />
+    </>
   )
 }
 

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -34,7 +34,7 @@ const TABLE_THEME = {
     }
     &:nth-of-type(3) button {
       display: flex;
-      justify-content: center;
+      justify-content: end;
     }
     &:nth-of-type(4) button {
       display: flex;
@@ -54,7 +54,7 @@ const TABLE_THEME = {
       text-align: right;
     }
     &:nth-of-type(3) {
-      text-align: center;
+      text-align: right;
     }
     &:nth-of-type(4) {
       text-align: right;

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -68,6 +68,8 @@ const TABLE_THEME = {
   `,
 }
 
+const TABLE_PAGE_SIZES = [25, 50, 100]
+
 type Minutes = number
 
 interface EarnReportEntry {
@@ -127,11 +129,11 @@ const toEarnReportEntry = (tableNode: TableTypes.TableNode) => tableNode as unkn
 interface TablePaginationProps {
   tableData: TableTypes.Data
   pagination: Pagination
-  itemsPerPage: number[]
+  pageSizes: number[]
   allowShowAll?: boolean
 }
 
-const TablePagination = ({ tableData, pagination, itemsPerPage, allowShowAll = true }: TablePaginationProps) => {
+const TablePagination = ({ tableData, pagination, pageSizes, allowShowAll = true }: TablePaginationProps) => {
   const { t } = useTranslation()
 
   return (
@@ -141,14 +143,14 @@ const TablePagination = ({ tableData, pagination, itemsPerPage, allowShowAll = t
         <rb.Form.Select
           aria-label={t('earn.report.pagination.items_per_page.label')}
           className="ms-2 d-inline-block w-auto"
-          defaultValue={itemsPerPage[0]}
+          defaultValue={pageSizes[0]}
           onChange={(e) => {
             const value = parseInt(e.target.value, 10)
             const pageSize = value > 0 ? value : tableData.nodes.length
             pagination.fns.onSetSize(pageSize)
           }}
         >
-          {itemsPerPage.map((size) => (
+          {pageSizes.map((size) => (
             <option key={size} value={size}>
               {size}
             </option>
@@ -250,11 +252,10 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
     }
   )
 
-  const itemsPerPage = [25, 50, 100]
   const pagination = usePagination(tableData, {
     state: {
       page: 0,
-      size: itemsPerPage[0],
+      size: TABLE_PAGE_SIZES[0],
     },
   })
 
@@ -329,7 +330,7 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
           </>
         )}
       </Table>
-      <TablePagination pagination={pagination} tableData={tableData} itemsPerPage={itemsPerPage} />
+      <TablePagination pagination={pagination} tableData={tableData} pageSizes={TABLE_PAGE_SIZES} />
     </>
   )
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -261,20 +261,7 @@
       "heading_input_value": "My Input Amount",
       "heading_cj_fee": "CoinJoin Fee",
       "heading_earned": "Earned",
-      "heading_notes": "Notes",
-      "pagination": {
-        "items_per_page": {
-          "label": "Items per page",
-          "text_option_show_all": "All"
-        },
-        "page_selector": {
-          "label": "Page",
-          "label_first": "First",
-          "label_previous": "Previous",
-          "label_next": "Next",
-          "label_last": "Last"
-        }
-      }
+      "heading_notes": "Notes"
     },
     "title_fidelity_bonds": "Create a Fidelity Bond",
     "title_fidelity_bond_exists": "Your Fidelity Bonds",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -257,7 +257,7 @@
       "placeholder_search": "Search",
       "heading_timestamp": "Timestamp",
       "heading_cj_amount": "Transaction Amount",
-      "heading_input_count": "No. of UTXOs input by me",
+      "heading_input_count": "No. of inputs by me",
       "heading_input_value": "Amount input by me",
       "heading_cj_fee": "CoinJoin Fee",
       "heading_earned": "Earned",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -257,11 +257,10 @@
       "placeholder_search": "Search",
       "heading_timestamp": "Timestamp",
       "heading_cj_amount": "Transaction Amount",
-      "heading_input_count": "Inputs by me",
-      "heading_input_value": "Amount input by me",
+      "heading_input_count": "My Inputs",
+      "heading_input_value": "My Input Amount",
       "heading_cj_fee": "CoinJoin Fee",
       "heading_earned": "Earned",
-      "heading_confirm_time": "Confirmation Time (mins)",
       "heading_notes": "Notes",
       "pagination": {
         "items_per_page": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -257,12 +257,25 @@
       "placeholder_search": "Search",
       "heading_timestamp": "Timestamp",
       "heading_cj_amount": "Transaction Amount",
-      "heading_input_count": "No. of inputs by me",
+      "heading_input_count": "Inputs by me",
       "heading_input_value": "Amount input by me",
       "heading_cj_fee": "CoinJoin Fee",
       "heading_earned": "Earned",
       "heading_confirm_time": "Confirmation Time (mins)",
-      "heading_notes": "Notes"
+      "heading_notes": "Notes",
+      "pagination": {
+        "items_per_page": {
+          "label": "Items per page",
+          "text_option_show_all": "All"
+        },
+        "page_selector": {
+          "label": "Page",
+          "label_first": "First",
+          "label_previous": "Previous",
+          "label_next": "Next",
+          "label_last": "Last"
+        }
+      }
     },
     "title_fidelity_bonds": "Create a Fidelity Bond",
     "title_fidelity_bond_exists": "Your Fidelity Bonds",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -249,6 +249,12 @@
     "button_show_orderbook": "Show orderbook",
     "report": {
       "title": "Earnings Report",
+      "text_report_summary_one": "{{ count }} entry",
+      "text_report_summary_other": "{{ count }} entries",
+      "text_report_summary_filtered_one": "found {{ count }} entry",
+      "text_report_summary_filtered_other": "found {{ count }} entries",
+      "label_search": "Search",
+      "placeholder_search": "Search",
       "heading_timestamp": "Timestamp",
       "heading_cj_amount": "Transaction Amount",
       "heading_input_count": "No. of UTXOs input by me",

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -259,6 +259,28 @@ const postCoinjoin = async ({ token, signal, walletName }: WalletRequestContext,
   })
 }
 
+/**
+ * Fetch the contents of JM's yigen-statement.csv file.
+ *
+ * @param signal AbortSignal
+ * @returns object with prop `yigen_data` representing contents of yigen-statement.csv as array of strings
+ *
+ * e.g.
+ * ```json
+ * {
+ *  "yigen_data": [
+ *    "timestamp,cj amount/satoshi,my input count,my input value/satoshi,cjfee/satoshi,earned/satoshi,confirm time/min,notes\n",
+ *    "2009/01/03 02:54:42,,,,,,,Connected\n",
+ *    "2009/01/09 02:55:13,14999992400,4,20000000000,250,250,60.17,\n",
+ *    "2009/01/09 03:02:48,11093696866,3,15000007850,250,250,12.17,\n",
+ *    "2009/02/01 17:31:03,3906287184,1,5000000000,250,250,30.08,\n",
+ *    "2009/02/04 16:22:18,9687053174,2,10000000000,250,250,0.0,\n",
+ *    "2009/02/12 22:01:57,1406636022,1,2500000000,250,250,4.08,\n",
+ *    "2009/03/07 09:38:12,9687049154,2,10000000000,250,250,0.0,\n"
+ *  ]
+ * }
+ * ```
+ */
 const getYieldgenReport = async ({ signal }: ApiRequestContext) => {
   return await fetch(`${basePath()}/v1/wallet/yieldgen/report`, {
     signal,


### PR DESCRIPTION
Adds ~~pagination,~~ sorting and filtering to Earnings Report overlay.

Was not quite sure how to best style the pagination. Not that happy with the result. Suggestions welcome!
Also, any ideas for improved wording of the table headings?

## :camera_flash: 
![image](https://user-images.githubusercontent.com/3358649/182963019-84f35684-e88a-4b39-a7ef-bf5d4f38c581.png)
