### PR TITLE
fix: pass api token to session request

### DIFF
--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -14,13 +14,13 @@ interface JmSessionData {
   session: boolean
   maker_running: boolean
   coinjoin_in_process: boolean
-  wallet_name: string
+  wallet_name: Api.WalletName | 'None'
 }
 
 type SessionFlag = { sessionActive: boolean }
 type MakerRunningFlag = { makerRunning: boolean }
 type CoinjoinInProgressFlag = { coinjoinInProgress: boolean }
-type WalletName = { walletName: string | null }
+type WalletName = { walletName: Api.WalletName | null }
 
 type ServiceInfo = SessionFlag & MakerRunningFlag & CoinjoinInProgressFlag & WalletName
 type ServiceInfoUpdate = ServiceInfo | MakerRunningFlag | CoinjoinInProgressFlag
@@ -74,7 +74,7 @@ const ServiceInfoProvider = ({ children }: React.PropsWithChildren<{}>) => {
         }
       }
 
-      const fetch = Api.getSession({ signal })
+      const fetch = Api.getSession({ signal, token: currentWallet?.token })
         .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res)))
         .then((data: JmSessionData) => {
           const {

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -6,8 +6,8 @@ import * as Api from '../libs/JmWalletApi'
 import { WalletBalanceSummary, toBalanceSummary } from './BalanceSummary'
 
 export interface CurrentWallet {
-  name: string
-  token: string
+  name: Api.WalletName
+  token: Api.ApiToken
 }
 
 // TODO: move these interfaces to JmWalletApi, once distinct types are used as return value instead of plain "Response"

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -12,8 +12,8 @@
  */
 const basePath = () => `${window.JM.PUBLIC_PATH}/api`
 
-type ApiToken = string
-type WalletName = string
+export type ApiToken = string
+export type WalletName = `${string}.jmdat`
 
 type Mixdepth = number
 export type AmountSats = number // TODO: should be BigInt! Remove once every caller migrated to TypeScript.

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,8 +1,10 @@
+import { WalletName, ApiToken } from './libs/JmWalletApi'
+
 const SESSION_KEY = 'joinmarket'
 
 export interface SessionItem {
-  name: string
-  token: string
+  name: WalletName
+  token: ApiToken
 }
 
 export const setSession = (session: SessionItem) => sessionStorage.setItem(SESSION_KEY, JSON.stringify(session))


### PR DESCRIPTION
Must have been lost during a refactoring, as I am sure this has been supported before.
This readds the API token to the `/session` request.

This request will have additional data in the upcoming JM release, such as `offerlist`, `nickname` and `schedule`.
Also, as this requests checks the validity of the token, it will end the current session if a users logs in form another browser window.