### PR TITLE
fix: pass mixdepth prop as number in request body

### DIFF
--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -243,8 +243,7 @@ const postDirectSend = async ({ token, signal, walletName }: WalletRequestContex
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletName)}/taker/direct-send`, {
     method: 'POST',
     headers: { ...Authorization(token) },
-    // docs say "integer", but "midxdepth" must serialize as string!
-    body: JSON.stringify({ ...req, mixdepth: String(req.mixdepth) }),
+    body: JSON.stringify(req),
     signal,
   })
 }
@@ -253,8 +252,7 @@ const postCoinjoin = async ({ token, signal, walletName }: WalletRequestContext,
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletName)}/taker/coinjoin`, {
     method: 'POST',
     headers: { ...Authorization(token) },
-    // docs say "integer", but "midxdepth" must serialize as string!
-    body: JSON.stringify({ ...req, mixdepth: String(req.mixdepth) }),
+    body: JSON.stringify(req),
     signal,
   })
 }


### PR DESCRIPTION
It seems passing it as string was needed before but is not needed anymore.
To stay in line with the [API  documentation ](https://joinmarket-org.github.io/joinmarket-clientserver/api/#operation/directsend) the `mixdepth` property when sending a payment (direct-send as well as initiating a collaborative transaction) is now serialized as `integer` instead of `string`.
Know that this does not change any functionality and worked without issues before, it just removes a possible "surprise" for any dev glancing over the code.