### PR TITLE
fix: serialize values of `/maker/start` request body as strings

### DIFF
--- a/docker/regtest/init-setup.sh
+++ b/docker/regtest/init-setup.sh
@@ -63,7 +63,7 @@ else
     ## 200 OK
     ## {}
     msg "Starting maker service for wallet $wallet_name.."  
-    start_maker_request_payload="{\"txfee\":0,\"cjfee_a\":250,\"cjfee_r\":0.0003,\"ordertype\":\"sw0absoffer\",\"minsize\":10000}"
+    start_maker_request_payload="{\"txfee\":\"0\",\"cjfee_a\":\"250\",\"cjfee_r\":\"0.0003\",\"ordertype\":\"sw0absoffer\",\"minsize\":\"1\"}"
 
     start_maker_result=$(curl "$base_url/api/v1/wallet/$wallet_name/maker/start" --silent --show-error --insecure -H "$auth_header" --data "$start_maker_request_payload" | jq ".")
 

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -224,7 +224,7 @@ const postMakerStart = async ({ token, signal, walletName }: WalletRequestContex
     headers: { ...Authorization(token) },
     body: JSON.stringify({
       ...req,
-      // we enforce type-safety for the following properties, but their values must actually passed as string!
+      // We enforce type-safety for the following properties, but their values must actually be passed as string!
       cjfee_a: String(req.cjfee_a),
       cjfee_r: String(req.cjfee_r),
       minsize: String(req.minsize),

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -222,7 +222,14 @@ const postMakerStart = async ({ token, signal, walletName }: WalletRequestContex
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletName)}/maker/start`, {
     method: 'POST',
     headers: { ...Authorization(token) },
-    body: JSON.stringify({ ...req, txfee: '0' }),
+    body: JSON.stringify({
+      ...req,
+      // we enforce type-safety for the following properties, but their values must actually passed as string!
+      cjfee_a: String(req.cjfee_a),
+      cjfee_r: String(req.cjfee_r),
+      minsize: String(req.minsize),
+      txfee: String(0),
+    }),
     signal,
   })
 }


### PR DESCRIPTION
Before this commit, values of `POST /maker/start` have been passed as int/decimal types.
After this commit, they well be passed [according to the api docs](https://joinmarket-org.github.io/joinmarket-clientserver/api/#operation/startmaker) as strings.

This prevents an exception on the backend `builtins.TypeError: a bytes-like object is required, not 'float'`. It seemed to still have worked fine before (at least for absolute offers).