### PR TITLE
fix: refresh orderbook

### DIFF
--- a/src/components/Orderbook.tsx
+++ b/src/components/Orderbook.tsx
@@ -5,6 +5,7 @@ import * as TableTypes from '@table-library/react-table-library/types/table'
 import { useTheme } from '@table-library/react-table-library/theme'
 import * as rb from 'react-bootstrap'
 import { useTranslation, TFunction } from 'react-i18next'
+import { Helper as ApiHelper } from '../libs/JmWalletApi'
 import * as ObwatchApi from '../libs/JmObwatchApi'
 // @ts-ignore
 import { useSettings } from '../context/SettingsContext'
@@ -337,7 +338,15 @@ export function OrderbookOverlay({ show, onHide }: rb.OffcanvasProps) {
 
   const refresh = useCallback(
     (signal: AbortSignal) => {
-      return ObwatchApi.fetchOrderbook({ signal })
+      return ObwatchApi.refreshOrderbook({ signal })
+        .then((res) => {
+          if (!res.ok) {
+            // e.g. error is raised if ob-watcher is not running
+            return ApiHelper.throwError(res)
+          }
+
+          return ObwatchApi.fetchOrderbook({ signal })
+        })
         .then((orders) => {
           if (signal.aborted) return
 

--- a/src/components/Orderbook.tsx
+++ b/src/components/Orderbook.tsx
@@ -221,7 +221,7 @@ const OrderbookTable = ({ tableData }: OrderbookTableProps) => {
 
 interface OrderbookProps {
   orders: ObwatchApi.Order[]
-  refresh: (abortCtrl: AbortController) => Promise<void>
+  refresh: (signal: AbortSignal) => Promise<void>
 }
 
 export function Orderbook({ orders, refresh }: OrderbookProps) {
@@ -274,7 +274,7 @@ export function Orderbook({ orders, refresh }: OrderbookProps) {
               setIsLoadingRefresh(true)
 
               const abortCtrl = new AbortController()
-              refresh(abortCtrl).finally(() => {
+              refresh(abortCtrl.signal).finally(() => {
                 // as refreshing is fast most of the time, add a short delay to avoid flickering
                 setTimeout(() => setIsLoadingRefresh(false), 250)
               })
@@ -336,16 +336,16 @@ export function OrderbookOverlay({ show, onHide }: rb.OffcanvasProps) {
   const [orders, setOrders] = useState<ObwatchApi.Order[] | null>(null)
 
   const refresh = useCallback(
-    (abortCtrl: AbortController) => {
-      return ObwatchApi.fetchOrderbook({ signal: abortCtrl.signal })
+    (signal: AbortSignal) => {
+      return ObwatchApi.fetchOrderbook({ signal })
         .then((orders) => {
-          if (abortCtrl.signal.aborted) return
+          if (signal.aborted) return
 
           setOrders(orders)
           setAlert(null)
         })
         .catch((e) => {
-          if (abortCtrl.signal.aborted) return
+          if (signal.aborted) return
           const message = t('orderbook.error_loading_orderbook_failed', {
             reason: e.message || 'Unknown reason',
           })
@@ -361,7 +361,7 @@ export function OrderbookOverlay({ show, onHide }: rb.OffcanvasProps) {
     const abortCtrl = new AbortController()
 
     setIsLoading(true)
-    refresh(abortCtrl).finally(() => {
+    refresh(abortCtrl.signal).finally(() => {
       if (abortCtrl.signal.aborted) return
       setIsLoading(false)
       setIsInitialized(true)

--- a/src/libs/JmObwatchApi.ts
+++ b/src/libs/JmObwatchApi.ts
@@ -73,4 +73,11 @@ const fetchOrderbook = async ({ signal }: { signal: AbortSignal }) => {
   }).then((res) => parseOrderbook(res))
 }
 
-export { fetchOrderbook }
+const refreshOrderbook = async ({ signal }: { signal: AbortSignal }) => {
+  return await fetch(`${basePath()}/refreshorderbook`, {
+    method: 'POST',
+    signal,
+  })
+}
+
+export { fetchOrderbook, refreshOrderbook }


### PR DESCRIPTION
Resolves #455.

Before this PR, the orderbook was "refreshed" by just refetching the data.
After this PR a `POST` request to `/refreshorderbook` is made beforehand to check for timed-out counterparties.
