### PR TITLE
ui: remove column 'fee' from Earn Report

### DIFF
--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -17,13 +17,12 @@ const SORT_KEYS = {
   cjTotalAmountInSats: 'CJ_TOTAL_AMOUNT_IN_SATS',
   inputCount: 'INPUT_COUNT',
   inputAmountInSats: 'INPUT_AMOUNT_IN_SATS',
-  feeInSats: 'FEE_IN_SATS',
   earnedAmountInSats: 'EARNED_AMOUNT_IN_SATS',
 }
 
 const TABLE_THEME = {
   Table: `
-    --data-table-library_grid-template-columns: 2fr 2fr 2fr 1fr 2fr 2fr 2fr;
+    --data-table-library_grid-template-columns: 2fr 2fr 2fr 1fr 2fr 2fr;
     font-size: 0.9rem;
   `,
   BaseCell: `
@@ -43,10 +42,6 @@ const TABLE_THEME = {
       display: flex;
       justify-content: end;
     }
-    &:nth-of-type(6) button {
-      display: flex;
-      justify-content: end;
-    }
   `,
   Cell: `
     &:nth-of-type(2) {
@@ -59,9 +54,6 @@ const TABLE_THEME = {
       text-align: right;
     }
     &:nth-of-type(5) {
-      text-align: right;
-    }
-    &:nth-of-type(6) {
       text-align: right;
     }
   `,
@@ -156,7 +148,6 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
         [SORT_KEYS.cjTotalAmountInSats]: (array) => array.sort((a, b) => +a.cjTotalAmount - +b.cjTotalAmount),
         [SORT_KEYS.inputCount]: (array) => array.sort((a, b) => +a.inputCount - +b.inputCount),
         [SORT_KEYS.inputAmountInSats]: (array) => array.sort((a, b) => +a.inputAmount - +b.inputAmount),
-        [SORT_KEYS.feeInSats]: (array) => array.sort((a, b) => +a.fee - +b.fee),
       },
     }
   )
@@ -179,7 +170,6 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
                 <HeaderCellSort sortKey={SORT_KEYS.inputAmountInSats}>
                   {t('earn.report.heading_input_value')}
                 </HeaderCellSort>
-                <HeaderCellSort sortKey={SORT_KEYS.feeInSats}>{t('earn.report.heading_cj_fee')}</HeaderCellSort>
                 <HeaderCell>{t('earn.report.heading_notes')}</HeaderCell>
               </HeaderRow>
             </Header>
@@ -207,13 +197,6 @@ const EarnReportTable = ({ tableData }: EarnReportTableProps) => {
                     <Cell>
                       <Balance
                         valueString={entry.inputAmount?.toString() || ''}
-                        convertToUnit={settings.unit}
-                        showBalance={true}
-                      />
-                    </Cell>
-                    <Cell>
-                      <Balance
-                        valueString={entry.fee?.toString() || ''}
                         convertToUnit={settings.unit}
                         showBalance={true}
                       />
@@ -252,10 +235,8 @@ export function EarnReport({ entries, refresh }: EarnReportProps) {
               entry.cjTotalAmount?.toString().includes(searchVal) ||
               entry.inputCount?.toString().includes(searchVal) ||
               entry.inputAmount?.toString().includes(searchVal) ||
-              entry.fee?.toString().includes(searchVal) ||
               entry.earnedAmount?.toString().includes(searchVal) ||
               entry.inputCount?.toString().includes(searchVal) ||
-              entry.confirmationDuration?.toString().includes(searchVal) ||
               entry.notes?.toLowerCase().includes(searchVal)
             )
           })

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -259,7 +259,6 @@
       "heading_cj_amount": "Transaction Amount",
       "heading_input_count": "My Inputs",
       "heading_input_value": "My Input Amount",
-      "heading_cj_fee": "CoinJoin Fee",
       "heading_earned": "Earned",
       "heading_notes": "Notes"
     },


### PR DESCRIPTION
As suggested by @openoms in the [Community Call #21](https://bitcointv.com/w/tcebpxai765AnALer87fsU?start=17m16s) (at 17m16s), this commit removes the "Fee" column from the Earnings Report.

Since the Miner Fee Contribution is always zero, this value (`fee`) is the same as "earned" (`earnedAmount`). 

### :camera_flash: Before/After
<img src="https://user-images.githubusercontent.com/3358649/183930046-6a7988ac-3ac4-4e88-8351-afc337be099f.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/183931858-764cb8e2-e4ad-4b5b-9eff-0d6ad8d2fda2.png" width=400 />
