### PR TITLE
fix: remove jar source from scheduler options

### DIFF
--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -211,7 +211,6 @@ export default function Jam() {
         stage1_timelambda_increase: 1.0,
         liquiditywait: 10,
         waittime: 1.0,
-        mixdepthsrc: 0,
       }
     }
 

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -102,7 +102,6 @@ interface StartSchedulerRequest {
 }
 
 interface TumblerOptions {
-  mixdepthsrc?: number
   restart?: boolean
   schedulefile?: string
   addrcount?: number


### PR DESCRIPTION
In https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1324 the scheduler option `mixdepthsource` has been removed as the scheduler will automatically start from the first funded account and hence this param does not make much sense anymore.

This commit removes this value from the API request.
~~It can only be merged once https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1324 has been applied.~~ Applied! Rebuild your development environment with the latest changes from master.