### PR TITLE
dev: install gpg in regtest containers

### DIFF
--- a/docker/regtest/dockerfile-deps/joinmarket/directory_node/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/directory_node/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9.7-slim-bullseye
 
 RUN apt-get update \
-    && apt-get install -qq --no-install-recommends tini procps vim git iproute2 supervisor \
+    && apt-get install -qq --no-install-recommends gnupg tini procps vim git iproute2 supervisor \
        # joinmarket dependencies
        curl build-essential automake pkg-config libtool python3-dev python3-pip python3-setuptools libltdl-dev \
        # tor dependencies

--- a/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9.7-slim-bullseye
 
 RUN apt-get update \
-    && apt-get install -qq --no-install-recommends tini procps vim git iproute2 supervisor \
+    && apt-get install -qq --no-install-recommends gnupg tini procps vim git iproute2 supervisor \
        # joinmarket dependencies
        curl build-essential automake pkg-config libtool python3-dev python3-pip python3-setuptools libltdl-dev \
        tor \


### PR DESCRIPTION
Current state of `master` in the backend repo does signature verification of lobsodium and tor (https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1323). gpg has always been installed in Jam's official docker images (during the install phase), but not in the development environment which leads to failing builds when building from the current `master` branch.


<img src="https://user-images.githubusercontent.com/3358649/184113939-e9ddddef-1c2f-48e6-bae5-0d88b00461e3.png" width=400 />
