### PR TITLE
dev: bullseye as base image for regtest containers

### DIFF
--- a/docker/regtest/dockerfile-deps/joinmarket/directory_node/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/directory_node/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.7-slim-bullseye
+FROM debian:bullseye-20220801-slim
 
 RUN apt-get update \
     && apt-get install -qq --no-install-recommends gnupg tini procps vim git iproute2 supervisor \

--- a/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.7-slim-bullseye
+FROM debian:bullseye-20220801-slim
 
 RUN apt-get update \
     && apt-get install -qq --no-install-recommends gnupg tini procps vim git iproute2 supervisor \


### PR DESCRIPTION
Companion change of https://github.com/joinmarket-webui/jam-docker/pull/52 for the regtest environment.

The development environment should as closely as possible incorporate all changes of the prod image.
Neat side effect is, that the images get smaller, even if that is not a high priority objective for the dev setup.