### PR TITLE
refactor: leverage session request for polling schedule

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -421,7 +421,6 @@
     "progress_description": "This estimate is the minimum waiting time. Additional delays due to network communication or transaction confirmation are not considered.",
     "progress_current_state": "Waiting for transaction <1>{{ current }}</1> of <3>{{ total }}</3> to process...",
     "progress_done": "All transactions completed successfully. The scheduler will stop soon.",
-    "error_loading_schedule_failed": "Loading schedule progress failed.",
     "precondition": {
       "hint_missing_utxos": "To run the scheduler you need at least one UTXO with <2>{{ minConfirmations }}</2> confirmations in Jar #0. Fund your wallet and wait for <6>{{ minConfirmations }}</6> blocks.",
       "hint_missing_confirmations": "The scheduler requires one of your UTXOs in Jar #0 to have <2>{{ minConfirmations }}</2> or more confirmations. Wait for <6>{{ amountOfMissingConfirmations }}</6> more block(s).",


### PR DESCRIPTION
Resolves #468.

Uses new `schedule` property of the `serviceInfo` object to display the scheduler progress instead of polling the `/schedule` endpoint. 