### PR TITLE
feat: highlight own orders in orderbook

### DIFF
--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -521,7 +521,11 @@ export default function Earn() {
       </rb.Row>
       <rb.Row className="mt-5 mb-3">
         <rb.Col className="d-flex justify-content-center">
-          <OrderbookOverlay show={isShowOrderbook} onHide={() => setIsShowOrderbook(false)} />
+          <OrderbookOverlay
+            show={isShowOrderbook}
+            onHide={() => setIsShowOrderbook(false)}
+            nickname={serviceInfo?.nickname}
+          />
           <rb.Button
             variant="outline-dark"
             className="border-0 mb-2 d-inline-flex align-items-center"

--- a/src/components/Orderbook.module.css
+++ b/src/components/Orderbook.module.css
@@ -55,3 +55,7 @@
   padding: 0.1rem;
   border: none;
 }
+
+.highlighted td {
+  background-color: rgba(var(--bs-success-rgb), 0.33) !important;
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -388,6 +388,7 @@
     "label_search": "Search",
     "placeholder_search": "Search",
     "text_orderbook_filter_count": "{{ filterCount }} entries match given search criteria",
+    "label_highlight_own_orders": "Highlight my orders",
     "table": {
       "heading_type": "Type",
       "heading_counterparty": "Counterparty",


### PR DESCRIPTION
Closes #413.

This does not actually display the nickname (counterparty ID), but lets the user highlight his own orders, as the nickname is already shown on the Earn page (see #461).

First attempt was to just filter the orderbook for the users orders by using the nickname as search value.
However, opted for highlighting the row instead, as this provides the functionality to sort the data and provide more insights and better hints about the positions of your own orders within the orderbook. Let me know what you think.

## :camera_flash: 
<img src="https://user-images.githubusercontent.com/3358649/184675685-00ff0d6a-651c-4663-9cad-ad027867dba1.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/184675820-e21ca185-ba9a-4b3a-95f7-95bf38c751d1.png" width=400 />
