### PR TITLE
feat: rename "Joining" to "Jamming"

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -16,7 +16,7 @@
     "tab_send": "Send",
     "tab_receive": "Receive",
     "tab_earn": "Earn",
-    "joining_in_progress": "Joining",
+    "joining_in_progress": "Jamming",
     "menu_mobile": "Menu",
     "menu_mobile_settings": "Settings"
   },

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -5,7 +5,7 @@
     "tab_send": "Envoyer",
     "tab_receive": "Recevoir",
     "tab_earn": "Générer",
-    "joining_in_progress": "Joindre",
+    "joining_in_progress": "Brouillage",
     "menu_mobile": "Menu",
     "menu_mobile_settings": "Réglages"
   },


### PR DESCRIPTION
Always wanted to rename this, and now is the time! 😁 

Thanks to #474 it will only be visible on mobile anyway.

![Screenshot 2022-08-18 at 13-34-07 Jam for JoinMarket](https://user-images.githubusercontent.com/109058/185385641-af457f7d-ca7a-4212-b818-43bf2582a3c4.png)

![Screenshot 2022-08-18 at 13-36-00 define jam at DuckDuckGo](https://user-images.githubusercontent.com/109058/185385677-58edab0b-6089-437c-9f52-b1b573c7de55.png)

See also https://jamdocs.org/about/#about-the-name

<img width="471" alt="Screenshot 2022-08-18 at 13 37 45" src="https://user-images.githubusercontent.com/109058/185385834-701a48d3-6909-4a1a-bc56-e7fe41622a98.png">
