### PR TITLE
chore(i18n): add missing translations for fidelity bonds form

### DIFF
--- a/src/components/fb/CreateFidelityBond.jsx
+++ b/src/components/fb/CreateFidelityBond.jsx
@@ -265,7 +265,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, accountBalances, totalBal
         }
 
         if (timelockedAddress === null) {
-          return <div>{t('earn.fidelity_bond.error.loading_address')}</div>
+          return <div>{t('earn.fidelity_bond.error_loading_address')}</div>
         }
 
         return (

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -339,6 +339,7 @@
       "review_inputs": {
         "text_primary_button": "Create fidelity bond",
         "text_primary_button_unsafe": "Create fidelity bond with potentially less private UTXOs",
+        "text_primary_button_error": "Try again",
         "text_secondary_button": "Cancel",
         "description": "You configured the fidelity bond as follows:",
         "label_lock_date": "Locked until",


### PR DESCRIPTION
Small i18n fixes:
- add missing translation for key `earn.fidelity_bond.review_inputs.text_primary_button_error`
- fix typo in key `.error.loading_address` -> `.error_loading_address`

This has come up when trying to create a fidelity bond with a wallet that does not support fidelity bonds. Jam, by default, will always generate fb-enabled wallets. If we want to prevent users with unsupported wallets from even seeing the form, Jam would have to make an additional http call prior to that - so it might not be worth it.
Question is: Should we append the phrase "Your wallet might not support fidelity bonds" or "Please make sure your wallet supports fidelity bonds", or something like that?