### PR TITLE
fix: redirect to home if no wallet is active on route `/wallet`

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -82,6 +82,7 @@ export default function App() {
                 />
                 {currentWallet && (
                   <>
+                    <Route path={routes.wallet} element={<MainWalletView />} />
                     <Route path={routes.jam} element={<Jam />} />
                     <Route path={routes.send} element={<Send />} />
                     <Route path={routes.earn} element={<Earn />} />
@@ -89,9 +90,6 @@ export default function App() {
                     <Route path={routes.settings} element={<Settings stopWallet={stopWallet} />} />
                   </>
                 )}
-              </Route>
-              <Route element={<Layout />}>
-                <Route path={routes.wallet} element={<MainWalletView />} />
               </Route>
               <Route path="*" element={<Navigate to={routes.home} replace={true} />} />
             </>

--- a/src/components/Wallet.jsx
+++ b/src/components/Wallet.jsx
@@ -120,9 +120,13 @@ export default function Wallet({
               <rb.Card.Title>
                 {isActive ? (
                   <span style={{ position: 'relative' }}>
-                    <Link className="wallet-name" to={routes.wallet}>
-                      {walletDisplayName(name)}
-                    </Link>
+                    {lockWallet ? (
+                      <Link className="wallet-name" to={routes.wallet}>
+                        {walletDisplayName(name)}
+                      </Link>
+                    ) : (
+                      <>{walletDisplayName(name)}</>
+                    )}
                     {makerRunning && <TabActivityIndicator isOn={true} />}
                     {coinjoinInProgress && <JoiningIndicator isOn={true} className="text-success" />}
                   </span>


### PR DESCRIPTION
Before this commit, a user that logs into an active wallet from a second tab/browser, had the first tab/browser not redirect to the unlock wallet page if route `/wallet` was active.
After this commit, the will redirect to the "unlock wallet" page (like all other routes, e.g. `/jam`, `/send`, etc.).

This has really only been the case for route `/wallet`.

It can be tested by navigating to `/wallet` and unlocking the wallet from a second browser/tab.
It should then redirect properly. The secondary instance can be used as a regression test - it still has this bug included.

Additional fix coming out of this: Wallet name on unlock page should only be a link to `/wallet` if the wallet is active **and** unlocked by the current user.