### PR TITLE
ui: use 'zoom-in' cursor when hovering over jars on main page

### DIFF
--- a/src/components/jars/Jar.module.css
+++ b/src/components/jars/Jar.module.css
@@ -84,5 +84,5 @@
 }
 
 .tooltipJarContainer {
-  cursor: pointer;
+  cursor: zoom-in;
 }


### PR DESCRIPTION
This PR changes the cursor when hovering over Jars to open the detailed view from 'pointer' to 'zoom-in'.

Saw it on Figma and thought it was easy to do.

## :camera_flash: Before/After
<img src="https://user-images.githubusercontent.com/3358649/189980051-41caa81d-8b92-4cef-8ea9-850054966775.png" width=300 /> <img src="https://user-images.githubusercontent.com/3358649/189979958-fed6fcf3-cb44-4f75-a087-77a5ee7fb462.png" width=300 />


If you don't think this is a good idea, please feel free to just close the PR.