### PR TITLE
ui: improve layout of JarDetailsOverlay on small screens

### DIFF
--- a/src/components/TablePagination.tsx
+++ b/src/components/TablePagination.tsx
@@ -25,8 +25,8 @@ export default function TablePagination({
   const { t } = useTranslation()
 
   return (
-    <div className="d-flex justify-content-between flex-column flex-md-row">
-      <div className="mt-3 mt-md-0 ms-3 ms-md-0 d-flex justify-content-center align-items-center order-2 order-md-1 gap-2">
+    <div className="d-flex justify-content-between flex-column flex-sm-row">
+      <div className="mt-3 mt-md-0 mx-3 mx-md-0 d-flex justify-content-center align-items-center order-2 order-md-1 gap-2">
         <div className="flex-shrink-0">{t('global.table.pagination.items_per_page.label')}</div>
         <rb.Form.Select
           aria-label={t('global.table.pagination.items_per_page.label')}
@@ -49,7 +49,7 @@ export default function TablePagination({
         </rb.Form.Select>
       </div>
 
-      <div className="mt-3 mt-md-0 ms-3 ms-md-0 d-flex justify-content-center align-items-center order-1 order-md-2 gap-1">
+      <div className="mt-3 mt-md-0 mx-3 mx-md-0 d-flex justify-content-center align-items-center order-1 order-md-2 gap-1">
         <rb.Button
           aria-label={t('global.table.pagination.page_selector.label_first')}
           variant={'outline-dark'}

--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -80,7 +80,7 @@
   background-color: var(--bs-body-bg);
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 992px) {
   .overlayContainer .tabContainer {
     padding: 2rem;
     border-radius: 0.5rem;
@@ -94,21 +94,16 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 0.5rem;
-  padding: 0 0 0.8rem 0;
+  padding: 0 0.5rem 0.8rem 0.5rem;
   background-color: var(--bs-gray-100);
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 992px) {
   .overlayContainer .tabContainer > .utxoListTitleBar {
+    flex-direction: row;
     align-items: center;
     padding: 0.8rem 1rem;
     border-radius: 0.6rem;
-  }
-}
-
-@media only screen and (min-width: 768px) {
-  .overlayContainer .tabContainer > .utxoListTitleBar {
-    flex-direction: row;
   }
 }
 

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -84,7 +84,7 @@ const Header = ({ account, nextAccount, previousAccount, setTab, onHide, initial
           />
         </div>
         <div className="d-flex flex-1">
-          <rb.Button variant="link" className="unstyled pe-0 ms-auto me-auto me-md-0" onClick={onHide}>
+          <rb.Button variant="link" className="unstyled px-0 ms-auto me-auto me-md-0" onClick={onHide}>
             <Sprite symbol="cancel" width="32" height="32" />
           </rb.Button>
         </div>
@@ -360,7 +360,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
       placement="bottom"
     >
       <rb.Offcanvas.Header>
-        <rb.Container>
+        <rb.Container fluid="lg">
           <Header
             account={account}
             nextAccount={nextAccount}
@@ -372,7 +372,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
         </rb.Container>
       </rb.Offcanvas.Header>
       <rb.Offcanvas.Body>
-        <rb.Container fluid="md" className="py-4 py-sm-5">
+        <rb.Container fluid="lg" className="py-4 py-md-5">
           {alert && (
             <rb.Row>
               <rb.Col>
@@ -394,35 +394,35 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
             />
           )}
           <rb.Row className="justify-content-center">
-            <rb.Col>
-              {selectedTab === TABS.UTXOS ? (
-                <div className={styles.tabContainer}>
-                  <div className={styles.utxoListTitleBar}>
-                    <div className="d-flex justify-content-center align-items-center gap-2">
-                      {refreshButton()}
-                      {utxoListTitle()}
+            <rb.Col className="px-0">
+              <div className={styles.tabContainer}>
+                {selectedTab === TABS.UTXOS ? (
+                  <>
+                    <div className={styles.utxoListTitleBar}>
+                      <div className="d-flex justify-content-center align-items-center gap-2">
+                        {refreshButton()}
+                        {utxoListTitle()}
+                      </div>
+                      {(props.utxosByAccount[accountIndex] || []).length > 0 && (
+                        <div className={styles.freezeUnfreezeButtonsContainer}>
+                          {freezeUnfreezeButton({ freeze: true })}
+                          {freezeUnfreezeButton({ freeze: false })}
+                        </div>
+                      )}
                     </div>
                     {(props.utxosByAccount[accountIndex] || []).length > 0 && (
-                      <div className={styles.freezeUnfreezeButtonsContainer}>
-                        {freezeUnfreezeButton({ freeze: true })}
-                        {freezeUnfreezeButton({ freeze: false })}
+                      <div className="px-md-3 pb-2">
+                        <UtxoList
+                          utxos={props.utxosByAccount[accountIndex] || []}
+                          walletInfo={props.walletInfo}
+                          setSelectedUtxoIds={setSelectedUtxoIds}
+                          setDetailUtxo={setDetailUtxo}
+                        />
                       </div>
                     )}
-                  </div>
-                  {(props.utxosByAccount[accountIndex] || []).length > 0 && (
-                    <div className="px-md-3 pb-2">
-                      <UtxoList
-                        utxos={props.utxosByAccount[accountIndex] || []}
-                        walletInfo={props.walletInfo}
-                        setSelectedUtxoIds={setSelectedUtxoIds}
-                        setDetailUtxo={setDetailUtxo}
-                      />
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div className={styles.tabContainer}>
-                  <rb.Accordion flush>
+                  </>
+                ) : (
+                  <rb.Accordion flush className="p-3 p-lg-0">
                     {account.branches.map((branch, index) => (
                       <rb.Accordion.Item className={styles.accountItem} key={branch.branch} eventKey={`${index}`}>
                         <rb.Accordion.Header>
@@ -434,8 +434,8 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                       </rb.Accordion.Item>
                     ))}
                   </rb.Accordion>
-                </div>
-              )}
+                )}
+              </div>
             </rb.Col>
           </rb.Row>
         </rb.Container>


### PR DESCRIPTION
UI improvements on small screens.
This is a step towards the new Figma layouts.

## :camera_flash: 
### xs (Before/After)
<img src="https://user-images.githubusercontent.com/3358649/190015531-e1cae9d9-f7d0-4365-8731-7144f415e459.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/190015489-25275cb5-5fed-4c9b-84d8-7debb45081d8.png" width=400 />

### sm (Before/After)
<img src="https://user-images.githubusercontent.com/3358649/190017174-26e262db-a6e8-416c-b731-76d7dfc2684b.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/190017049-5ac9342e-8c3d-41dd-ab82-991cd4afd865.png" width=400 />

### md (Before/After)
<img src="https://user-images.githubusercontent.com/3358649/190016077-673c3ffb-d5c1-4f31-a741-e5f1529b4101.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/190016032-587e3a51-0917-4aa5-b862-fdb02189cfcc.png" width=400 />

### lg (Before/After) - no changes
<img src="https://user-images.githubusercontent.com/3358649/190017650-909f1b12-c566-43de-858a-a9dd30c95347.png" width=400 /> <img src="https://user-images.githubusercontent.com/3358649/190017614-d4ba69a8-caa1-4649-baad-98c930d57005.png" width=400 />