### PR TITLE
fix: do not disable submit button on warnings on Send page

### DIFF
--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -240,7 +240,6 @@ export default function Send() {
 
   const [waitForUtxosToBeSpent, setWaitForUtxosToBeSpent] = useState([])
   const [paymentSuccessfulInfoAlert, setPaymentSuccessfulInfoAlert] = useState(null)
-  const [takerStartedInfoAlert, setTakerStartedInfoAlert] = useState(null)
 
   const isOperationDisabled = useMemo(
     () => isCoinjoinInProgress || isMakerRunning || waitForUtxosToBeSpent.length > 0,
@@ -251,10 +250,6 @@ export default function Send() {
     () => isInitializing || waitForUtxosToBeSpent.length > 0,
     [isInitializing, waitForUtxosToBeSpent]
   )
-
-  useEffect(() => {
-    setTakerStartedInfoAlert((current) => (isCoinjoinInProgress ? current : null))
-  }, [isCoinjoinInProgress])
 
   const [destination, setDestination] = useState(INITIAL_DESTINATION)
   const [account, setAccount] = useState(parseInt(location.state?.account, 10) || INITIAL_ACCOUNT)
@@ -477,10 +472,6 @@ export default function Send() {
       if (res.ok) {
         const data = await res.json()
         console.log(data)
-        setTakerStartedInfoAlert({
-          variant: 'success',
-          message: t('send.alert_coinjoin_started'),
-        })
         success = true
       } else {
         const message = await Api.Helper.extractErrorMessage(res)
@@ -709,9 +700,6 @@ export default function Send() {
 
         {paymentSuccessfulInfoAlert && (
           <rb.Alert variant={paymentSuccessfulInfoAlert.variant}>{paymentSuccessfulInfoAlert.message}</rb.Alert>
-        )}
-        {takerStartedInfoAlert && (
-          <rb.Alert variant={takerStartedInfoAlert.variant}>{takerStartedInfoAlert.message}</rb.Alert>
         )}
 
         {!isLoading && !isOperationDisabled && isCoinjoin && !coinjoinPreconditionSummary.isFulfilled && (

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -252,10 +252,6 @@ export default function Send() {
     [isInitializing, waitForUtxosToBeSpent]
   )
 
-  const [showConfirmAbortModal, setShowConfirmAbortModal] = useState(false)
-  const [showConfirmSendModal, setShowConfirmSendModal] = useState(false)
-  const submitButtonRef = useRef(null)
-
   useEffect(() => {
     setTakerStartedInfoAlert((current) => (isCoinjoinInProgress ? current : null))
   }, [isCoinjoinInProgress])
@@ -282,6 +278,16 @@ export default function Send() {
     () => buildCoinjoinRequirementSummary(sourceJarUtxos || []),
     [sourceJarUtxos]
   )
+
+  const [showConfirmAbortModal, setShowConfirmAbortModal] = useState(false)
+  const [showConfirmSendModal, setShowConfirmSendModal] = useState(false)
+  const submitButtonRef = useRef(null)
+  const submitButtonVariant = useMemo(() => {
+    if (isInitializing) return 'dark'
+    if (!isCoinjoin) return 'danger'
+    if (!coinjoinPreconditionSummary.isFulfilled) return 'warning'
+    return 'dark'
+  }, [isInitializing, isCoinjoin, coinjoinPreconditionSummary])
 
   useEffect(() => {
     if (
@@ -912,7 +918,7 @@ export default function Send() {
         )}
         <rb.Button
           ref={submitButtonRef}
-          variant={isCoinjoin ? 'dark' : 'danger'}
+          variant={submitButtonVariant}
           type="submit"
           disabled={isOperationDisabled || isLoading || isSending || !formIsValid}
           className={`${styles['button']} ${styles['send-button']} mt-4`}

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -918,7 +918,11 @@ export default function Send() {
               {t('send.text_sending')}
             </div>
           ) : isCoinjoin ? (
-            t('send.button_send')
+            !coinjoinPreconditionSummary.isFulfilled ? (
+              t('send.button_send_despite_warning')
+            ) : (
+              t('send.button_send')
+            )
           ) : (
             t('send.button_send_without_improved_privacy')
           )}

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -289,8 +289,7 @@ export default function Send() {
       !destinationIsReusedAddress &&
       isValidAccount(account) &&
       isValidAmount(amount, isSweep) &&
-      (isCoinjoin ? isValidNumCollaborators(numCollaborators, minNumCollaborators) : true) &&
-      (isCoinjoin ? coinjoinPreconditionSummary.isFulfilled : true)
+      (isCoinjoin ? isValidNumCollaborators(numCollaborators, minNumCollaborators) : true)
     ) {
       setFormIsValid(true)
     } else {
@@ -304,7 +303,6 @@ export default function Send() {
     minNumCollaborators,
     isCoinjoin,
     isSweep,
-    coinjoinPreconditionSummary,
     destinationIsReusedAddress,
   ])
 

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -187,7 +187,6 @@
     "error_loading_wallet_failed": "Loading wallet failed.",
     "error_loading_min_makers_failed": "Loading config value 'minimum_makers' failed.",
     "alert_payment_successful": "Payment successful: Sent {{ amount }} sats to {{ address }}.",
-    "alert_coinjoin_started": "Collaborative transaction started",
     "text_maker_running": "Earn is active. Stop the service in order to send collaborative transactions.",
     "text_coinjoin_already_running": "A collaborative transaction is currently in progress.",
     "label_recipient": "Recipient",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -199,6 +199,7 @@
     "toggle_coinjoin": "Send as collaborative transaction",
     "toggle_coinjoin_subtitle": "Collaborative transactions improve the privacy of yourself and others.",
     "button_send": "Send",
+    "button_send_despite_warning": "Ignore warning & send",
     "button_send_without_improved_privacy": "Send without privacy improvement",
     "text_sending": "Sending",
     "button_sweep": "Sweep",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -161,7 +161,6 @@
     "error_loading_wallet_failed": "Le chargement du portefeuille a échoué.",
     "error_loading_min_makers_failed": "Le chargement de la valeur de configuration 'minimum_makers' a échoué.",
     "alert_payment_successful": "Paiement réussi : Envoyé {{ amount }} sats à {{ address }}.",
-    "alert_coinjoin_started": "Transaction collaborative démarrée",
     "text_maker_running": "Générer est actif. Arrêtez le service afin d'envoyer des transactions collaboratives.",
     "text_coinjoin_already_running": "Une transaction collaborative est actuellement en cours.",
     "label_recipient": "Destinataire",


### PR DESCRIPTION
Before this PR, the submit button on the Send page has been disabled, if the requirements for collaborative transactions were not met.
After this PR, the warnings are still displayed, but the button is enabled and a payment can be attempted.

Why this change? The functionality has been disabled, as single collaborative transactions have no retry mechanism in place (unlike the scheduled sweep) and users had no real hint on how to recover, in case a transaction gets "stuck". With #497 resolved, users can now abort/cancel single collaborative transactions, hence the button can safely be enabled.

<img src="https://user-images.githubusercontent.com/3358649/190604272-462bcf1a-b036-4b7a-9cac-0510be46b479.png" width=300 />

However, if preconditions are not fulfilled, the transaction will likely either get "stuck" (e.g. when a utxo with <5 confs is used) or will be aborted by the server (20% rule, no retries left) - there is no good way of communicating this to the user other than the current warnings.

Additional Change:
- "Collaborative transaction started" toast has been removed, as per this comment https://github.com/joinmarket-webui/jam/pull/497#issuecomment-1249059814

Question: The warning texts have not been changed. Do you think they should be adapted and need rephrasing?