### PR TITLE
fix: consistent button text during screen initialization

### DIFF
--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -277,12 +277,25 @@ export default function Send() {
   const [showConfirmAbortModal, setShowConfirmAbortModal] = useState(false)
   const [showConfirmSendModal, setShowConfirmSendModal] = useState(false)
   const submitButtonRef = useRef(null)
-  const submitButtonVariant = useMemo(() => {
-    if (isInitializing) return 'dark'
-    if (!isCoinjoin) return 'danger'
-    if (!coinjoinPreconditionSummary.isFulfilled) return 'warning'
-    return 'dark'
-  }, [isInitializing, isCoinjoin, coinjoinPreconditionSummary])
+  const submitButtonOptions = useMemo(() => {
+    if (!isInitializing) {
+      if (!isCoinjoin)
+        return {
+          variant: 'danger',
+          text: t('send.button_send_without_improved_privacy'),
+        }
+      if (!coinjoinPreconditionSummary.isFulfilled)
+        return {
+          variant: 'warning',
+          text: t('send.button_send_despite_warning'),
+        }
+    }
+
+    return {
+      variant: 'dark',
+      text: t('send.button_send'),
+    }
+  }, [isInitializing, isCoinjoin, coinjoinPreconditionSummary, t])
 
   useEffect(() => {
     if (
@@ -906,7 +919,7 @@ export default function Send() {
         )}
         <rb.Button
           ref={submitButtonRef}
-          variant={submitButtonVariant}
+          variant={submitButtonOptions.variant}
           type="submit"
           disabled={isOperationDisabled || isLoading || isSending || !formIsValid}
           className={`${styles['button']} ${styles['send-button']} mt-4`}
@@ -917,14 +930,8 @@ export default function Send() {
               <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
               {t('send.text_sending')}
             </div>
-          ) : isCoinjoin ? (
-            !coinjoinPreconditionSummary.isFulfilled ? (
-              t('send.button_send_despite_warning')
-            ) : (
-              t('send.button_send')
-            )
           ) : (
-            t('send.button_send_without_improved_privacy')
+            <>{submitButtonOptions.text}</>
           )}
         </rb.Button>
 

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -199,7 +199,7 @@
     "toggle_coinjoin": "Send as collaborative transaction",
     "toggle_coinjoin_subtitle": "Collaborative transactions improve the privacy of yourself and others.",
     "button_send": "Send",
-    "button_send_despite_warning": "Ignore warning & send",
+    "button_send_despite_warning": "Ignore warning & try send",
     "button_send_without_improved_privacy": "Send without privacy improvement",
     "text_sending": "Sending",
     "button_sweep": "Sweep",


### PR DESCRIPTION
Consistent button labeling on Send page.

Additionally, change text from  "Ignore warning & send" to "Ignore warning & try send".