### PR TITLE
fix(navbar): send before earn

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -53,21 +53,6 @@ const CenterNav = ({ makerRunning, schedulerRunning, singleCollaborativeTransact
       <div className="d-none d-md-flex align-items-center center-nav-link-divider">»</div>
       <rb.Nav.Item className="d-flex align-items-stretch">
         <NavLink
-          to={routes.earn}
-          onClick={onClick}
-          className={({ isActive }) =>
-            'center-nav-link nav-link d-flex align-items-center justify-content-center' + (isActive ? ' active' : '')
-          }
-        >
-          <div className="d-flex align-items-start">
-            {t('navbar.tab_earn')}
-            <TabActivityIndicator isOn={makerRunning} />
-          </div>
-        </NavLink>
-      </rb.Nav.Item>
-      <div className="d-none d-md-flex align-items-center center-nav-link-divider">»</div>
-      <rb.Nav.Item className="d-flex align-items-stretch">
-        <NavLink
           to={routes.send}
           onClick={onClick}
           className={({ isActive }) =>
@@ -77,6 +62,21 @@ const CenterNav = ({ makerRunning, schedulerRunning, singleCollaborativeTransact
           <div className="d-flex align-items-start">
             {t('navbar.tab_send')}
             <TabActivityIndicator isOn={singleCollaborativeTransactionRunning} className="ms-1" />
+          </div>
+        </NavLink>
+      </rb.Nav.Item>
+      <div className="d-none d-md-flex align-items-center center-nav-link-divider">»</div>
+      <rb.Nav.Item className="d-flex align-items-stretch">
+        <NavLink
+          to={routes.earn}
+          onClick={onClick}
+          className={({ isActive }) =>
+            'center-nav-link nav-link d-flex align-items-center justify-content-center' + (isActive ? ' active' : '')
+          }
+        >
+          <div className="d-flex align-items-start">
+            {t('navbar.tab_earn')}
+            <TabActivityIndicator isOn={makerRunning} />
           </div>
         </NavLink>
       </rb.Nav.Item>


### PR DESCRIPTION
I don't know how I got this wrong, but the order I did in #496 has earn before send:

```
Receive  »  Earn  »  Send  |  Sweep
``` 

Because of the new flow it should be **send before earn**, to get `cj-out` for FB:

```
Receive  »  Send  »  Earn  |  Sweep
```

I got it right in [the docs](http://localhost:8000/interface/00-cheatsheet/) and in the cheatsheet (#496) - but I messed it up in the previous PR (#490).

---

### Before 📸

<img width="639" alt="Screenshot 2022-09-09 at 13 52 32" src="https://user-images.githubusercontent.com/109058/189344045-b8b6cec2-5212-442c-9066-ca019e28d7be.png">

### After 📸

![Screenshot 2022-09-20 at 19 55 54](https://user-images.githubusercontent.com/109058/191330027-171d5534-616b-4fe7-ac9f-c9bde86d6603.png)
