### PR TITLE
feat: show sum of selected utxos

### DIFF
--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -76,12 +76,13 @@
 .overlayContainer .tabContainer {
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 0.5rem;
   background-color: var(--bs-body-bg);
 }
 
 @media only screen and (min-width: 992px) {
   .overlayContainer .tabContainer {
+    gap: 1.5rem;
     padding: 2rem;
     border-radius: 0.5rem;
   }

--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -1,38 +1,3 @@
-.utxoDetailModalBackdrop {
-  z-index: 1300 !important;
-}
-
-.utxoDetailModal {
-  z-index: 1400 !important;
-}
-
-.modalHeader {
-  display: flex !important;
-  justify-content: flex-start !important;
-  background-color: transparent !important;
-  padding: 1.25rem !important;
-}
-
-.modalTitle {
-  width: 100%;
-  font-size: 1rem !important;
-  font-weight: 400 !important;
-  color: var(--bs-body-color) !important;
-}
-
-.modalTitle > div:first-child {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.modalTitle .cancelButton {
-  padding: 0 0 0 1rem;
-  color: var(--bs-body-color);
-  background-color: transparent !important;
-  border: none;
-}
-
 .overlayContainer .accountStepperTitle {
   display: inline-flex;
   justify-content: center;

--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -53,7 +53,7 @@
   }
 }
 
-.overlayContainer .tabContainer > .utxoListTitleBar {
+.overlayContainer .tabContainer .utxoListTitleBar {
   min-height: 3.6rem;
   display: flex;
   justify-content: space-between;
@@ -65,25 +65,39 @@
 }
 
 @media only screen and (min-width: 992px) {
-  .overlayContainer .tabContainer > .utxoListTitleBar {
-    flex-direction: row;
-    align-items: center;
+  .overlayContainer .tabContainer .utxoListTitleBar {
     padding: 0.8rem 1rem;
     border-radius: 0.6rem;
   }
 }
 
-:root[data-theme='dark'] .overlayContainer .tabContainer > .utxoListTitleBar {
+:root[data-theme='dark'] .overlayContainer .tabContainer .utxoListTitleBar {
   background-color: var(--bs-gray-800);
 }
 
-.overlayContainer .tabContainer > .utxoListTitleBar .freezeUnfreezeButtonsContainer {
+.overlayContainer .tabContainer .utxoListTitleBar .operationsContainer {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+@media only screen and (min-width: 576px) {
+  .overlayContainer .tabContainer .utxoListTitleBar .operationsContainer {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.overlayContainer .tabContainer .utxoListTitleBar .freezeUnfreezeButtonsContainer {
   display: flex;
   flex-direction: row;
   gap: 0.5rem;
 }
 
-.overlayContainer .tabContainer > .utxoListTitleBar .freezeUnfreezeButtonsContainer > button {
+.overlayContainer .tabContainer .utxoListTitleBar .freezeUnfreezeButtonsContainer > button {
   width: 8rem;
   font-size: 0.6rem;
   padding: 0.3rem 0.5rem;
@@ -91,25 +105,25 @@
   justify-content: center;
   align-items: center;
   gap: 0.3rem;
-  background-color: white;
+  background-color: var(--bs-white);
   border: 1px solid var(--bs-gray-200);
   color: var(--bs-body-color);
   border-radius: 0.35rem;
 }
 
-.overlayContainer .tabContainer > .utxoListTitleBar .freezeUnfreezeButtonsContainer > button:hover {
+.overlayContainer .tabContainer .utxoListTitleBar .freezeUnfreezeButtonsContainer > button:hover {
   background-color: var(--bs-btn-hover-bg);
   border-color: var(--bs-btn-hover-border-color);
 }
 
 @media only screen and (min-width: 768px) {
-  .overlayContainer .tabContainer > .utxoListTitleBar .freezeUnfreezeButtonsContainer > button {
+  .overlayContainer .tabContainer .utxoListTitleBar .freezeUnfreezeButtonsContainer > button {
     width: 10rem;
     font-size: 0.8rem;
   }
 }
 
-:root[data-theme='dark'] .overlayContainer .tabContainer > .utxoListTitleBar .freezeUnfreezeButtonsContainer > button {
+:root[data-theme='dark'] .overlayContainer .tabContainer .utxoListTitleBar .freezeUnfreezeButtonsContainer > button {
   background-color: var(--bs-gray-600) !important;
   border-color: var(--bs-gray-600);
 }
@@ -117,14 +131,14 @@
 :root[data-theme='dark']
   .overlayContainer
   .tabContainer
-  > .utxoListTitleBar
+  .utxoListTitleBar
   .freezeUnfreezeButtonsContainer
   > button:hover {
   background-color: var(--bs-gray-700) !important;
   border-color: var(--bs-gray-700);
 }
 
-.overlayContainer .tabContainer > .utxoListTitleBar .refreshButton {
+.overlayContainer .tabContainer .utxoListTitleBar .refreshButton {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -89,6 +89,13 @@
     flex-direction: row;
     align-items: center;
   }
+
+  .selectedUtxosSumContainer {
+    order: 2;
+  }
+  .freezeUnfreezeButtonsContainer {
+    order: 1;
+  }
 }
 
 .overlayContainer .tabContainer .utxoListTitleBar .freezeUnfreezeButtonsContainer {

--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -84,17 +84,14 @@
   gap: 0.5rem;
 }
 
+.selectedUtxosSumContainer {
+  align-self: end;
+}
+
 @media only screen and (min-width: 576px) {
   .overlayContainer .tabContainer .utxoListTitleBar .operationsContainer {
     flex-direction: row;
     align-items: center;
-  }
-
-  .selectedUtxosSumContainer {
-    order: 2;
-  }
-  .freezeUnfreezeButtonsContainer {
-    order: 1;
   }
 }
 

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -374,7 +374,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
         </rb.Container>
       </rb.Offcanvas.Header>
       <rb.Offcanvas.Body>
-        <rb.Container fluid="lg" className="py-4 py-md-5">
+        <rb.Container fluid="lg" className="py-3">
           {alert && (
             <rb.Row>
               <rb.Col>

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -202,6 +202,11 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
   const [detailUtxo, setDetailUtxo] = useState<Utxo | null>(null)
 
   const account = useMemo(() => props.accounts[accountIndex], [props.accounts, accountIndex])
+  const utxos = useMemo(() => props.utxosByAccount[accountIndex] || [], [props.utxosByAccount, accountIndex])
+  const selectedUtxos = useMemo(
+    () => utxos.filter((utxo: Utxo) => selectedUtxoIds.includes(utxo.utxo)),
+    [utxos, selectedUtxoIds]
+  )
 
   const nextAccount = useCallback(
     () => setAccountIndex((current) => (current + 1 >= props.accounts.length ? 0 : current + 1)),
@@ -265,11 +270,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
   const changeSelectedUtxoFreeze = async (freeze: boolean) => {
     if (isLoadingFreeze || isLoadingUnfreeze || isLoadingRefresh || isTakerOrMakerRunning) return
 
-    if (selectedUtxoIds.length <= 0) return
-
-    const selectedUtxos = (props.utxosByAccount[accountIndex] || []).filter((utxo: Utxo) =>
-      selectedUtxoIds.includes(utxo.utxo)
-    )
+    if (selectedUtxos.length <= 0) return
 
     setAlert(null)
     freeze ? setIsLoadingFreeze(true) : setIsLoadingUnfreeze(true)
@@ -300,7 +301,6 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
   }
 
   const utxoListTitle = () => {
-    const utxos = props.utxosByAccount[accountIndex] || []
     return t('jar_details.utxo_list.title', { count: utxos.length, jar: jarInitial(accountIndex) })
   }
 
@@ -405,17 +405,17 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                         {refreshButton()}
                         {utxoListTitle()}
                       </div>
-                      {(props.utxosByAccount[accountIndex] || []).length > 0 && (
+                      {utxos.length > 0 && (
                         <div className={styles.freezeUnfreezeButtonsContainer}>
                           {freezeUnfreezeButton({ freeze: true })}
                           {freezeUnfreezeButton({ freeze: false })}
                         </div>
                       )}
                     </div>
-                    {(props.utxosByAccount[accountIndex] || []).length > 0 && (
+                    {utxos.length > 0 && (
                       <div className="px-md-3 pb-2">
                         <UtxoList
-                          utxos={props.utxosByAccount[accountIndex] || []}
+                          utxos={utxos}
                           walletInfo={props.walletInfo}
                           selectState={{ ids: selectedUtxoIds }}
                           setSelectedUtxoIds={setSelectedUtxoIds}

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -7,9 +7,9 @@ import { Account, Utxo, WalletInfo, CurrentWallet, useReloadCurrentWalletInfo } 
 import { useServiceInfo } from '../../context/ServiceInfoContext'
 import * as fb from '../fb/utils'
 import Alert from '../Alert'
-import Balance from '../Balance'
 import Sprite from '../Sprite'
 import SegmentedTabs from '../SegmentedTabs'
+import UtxoDetailModal from './UtxoDetailModule'
 import { UtxoList } from './UtxoList'
 import { DisplayBranchHeader, DisplayBranchBody } from './DisplayBranch'
 import { jarInitial } from '../jars/Jar'
@@ -29,13 +29,6 @@ interface HeaderProps {
   setTab: (tab: string) => void
   onHide: () => void
   initialTab: string
-}
-
-interface UtxoDetailModalProps {
-  utxo: Utxo
-  status: string | null
-  isShown: boolean
-  close: () => void
 }
 
 interface JarDetailsOverlayProps {
@@ -90,99 +83,6 @@ const Header = ({ account, nextAccount, previousAccount, setTab, onHide, initial
         </div>
       </div>
     </>
-  )
-}
-
-const UtxoDetailModal = ({ utxo, status, isShown, close }: UtxoDetailModalProps) => {
-  const { t } = useTranslation()
-  const settings = useSettings()
-
-  return (
-    <rb.Modal
-      show={isShown}
-      keyboard={true}
-      onEscapeKeyDown={close}
-      onHide={close}
-      centered={true}
-      animation={true}
-      className={styles.utxoDetailModal}
-      backdropClassName={styles.utxoDetailModalBackdrop}
-    >
-      <rb.Modal.Header className={styles.modalHeader}>
-        <rb.Modal.Title className={styles.modalTitle}>
-          <div>
-            <div>
-              <Balance
-                valueString={utxo.value.toString()}
-                convertToUnit={settings.unit}
-                showBalance={settings.showBalance}
-              />
-            </div>
-            <rb.Button onClick={close} className={styles.cancelButton}>
-              <Sprite symbol="cancel" width="26" height="26" />
-            </rb.Button>
-          </div>
-        </rb.Modal.Title>
-      </rb.Modal.Header>
-      <rb.Modal.Body>
-        <div className="d-flex flex-column gap-3">
-          <div>
-            <strong>{t('jar_details.utxo_list.utxo_detail_label_id')}</strong>: <code>{utxo.utxo}</code>
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_address')}</strong>: <code>{utxo.address}</code>
-            </div>
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_path')}</strong>: <code>{utxo.path}</code>
-            </div>
-            {utxo.label && (
-              <div>
-                <strong>{t('jar_details.utxo_list.utxo_detail_label_label')}</strong>: {utxo.label}
-              </div>
-            )}
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_value')}</strong>:{' '}
-              <Balance
-                valueString={utxo.value.toString()}
-                convertToUnit={settings.unit}
-                showBalance={settings.showBalance}
-              />
-            </div>
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_tries')}</strong>: {utxo.tries}
-            </div>
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_tries_remaining')}</strong>: {utxo.tries_remaining}
-            </div>
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_is_external')}</strong>:{' '}
-              {utxo.external ? 'Yes' : 'No'}
-            </div>
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_jar')}</strong>: {utxo.mixdepth}
-            </div>
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_confirmations')}</strong>: {utxo.confirmations}
-            </div>
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_is_frozen')}</strong>: {utxo.frozen ? 'Yes' : 'No'}
-            </div>
-            {utxo.locktime && (
-              <div>
-                <strong>{t('jar_details.utxo_list.utxo_detail_label_locktime')}</strong>: {utxo.locktime}
-              </div>
-            )}
-            <div>
-              <strong>{t('jar_details.utxo_list.utxo_detail_label_status')}</strong>: {status}
-            </div>
-          </div>
-        </div>
-      </rb.Modal.Body>
-      <rb.Modal.Footer className="d-flex justify-content-center">
-        <rb.Button variant="light" onClick={close} className="w-25 d-flex justify-content-center align-items-center">
-          <span>{t('global.close')}</span>
-        </rb.Button>
-      </rb.Modal.Footer>
-    </rb.Modal>
   )
 }
 

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import * as Api from '../../libs/JmWalletApi'
@@ -12,8 +12,8 @@ import Sprite from '../Sprite'
 import SegmentedTabs from '../SegmentedTabs'
 import { UtxoList } from './UtxoList'
 import { DisplayBranchHeader, DisplayBranchBody } from './DisplayBranch'
-import styles from './JarDetailsOverlay.module.css'
 import { jarInitial } from '../jars/Jar'
+import styles from './JarDetailsOverlay.module.css'
 
 const TABS = {
   UTXOS: 'UTXOS',
@@ -213,6 +213,10 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
   )
 
   useEffect(() => setAccountIndex(props.initialAccountIndex), [props.initialAccountIndex])
+  useEffect(() => {
+    // reset selected utxos when switching jars
+    setSelectedUtxoIds([])
+  }, [accountIndex])
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -413,6 +417,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                         <UtxoList
                           utxos={props.utxosByAccount[accountIndex] || []}
                           walletInfo={props.walletInfo}
+                          selectState={{ ids: selectedUtxoIds }}
                           setSelectedUtxoIds={setSelectedUtxoIds}
                           setDetailUtxo={setDetailUtxo}
                         />

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -312,14 +312,8 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                         {utxoListTitle()}
                       </div>
                       <div className={styles.operationsContainer}>
-                        {utxos.length > 0 && (
-                          <div className={styles.freezeUnfreezeButtonsContainer}>
-                            {freezeUnfreezeButton({ freeze: true })}
-                            {freezeUnfreezeButton({ freeze: false })}
-                          </div>
-                        )}
                         {selectedUtxosBalance > 0 && (
-                          <div>
+                          <div className={styles.selectedUtxosSumContainer}>
                             <Trans i18nKey="jar_details.utxo_list.text_balance_sum_selected">
                               <Balance
                                 valueString={String(selectedUtxosBalance)}
@@ -327,6 +321,12 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                                 showBalance={settings.showBalance}
                               />
                             </Trans>
+                          </div>
+                        )}
+                        {utxos.length > 0 && (
+                          <div className={styles.freezeUnfreezeButtonsContainer}>
+                            {freezeUnfreezeButton({ freeze: true })}
+                            {freezeUnfreezeButton({ freeze: false })}
                           </div>
                         )}
                       </div>

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -312,6 +312,12 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                         {utxoListTitle()}
                       </div>
                       <div className={styles.operationsContainer}>
+                        {utxos.length > 0 && (
+                          <div className={styles.freezeUnfreezeButtonsContainer}>
+                            {freezeUnfreezeButton({ freeze: true })}
+                            {freezeUnfreezeButton({ freeze: false })}
+                          </div>
+                        )}
                         {selectedUtxosBalance > 0 && (
                           <div className={styles.selectedUtxosSumContainer}>
                             <Trans i18nKey="jar_details.utxo_list.text_balance_sum_selected">
@@ -321,12 +327,6 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                                 showBalance={settings.showBalance}
                               />
                             </Trans>
-                          </div>
-                        )}
-                        {utxos.length > 0 && (
-                          <div className={styles.freezeUnfreezeButtonsContainer}>
-                            {freezeUnfreezeButton({ freeze: true })}
-                            {freezeUnfreezeButton({ freeze: false })}
                           </div>
                         )}
                       </div>

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -229,7 +229,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
     return () => document.removeEventListener('keydown', onKeyDown)
   }, [props.isShown, onKeyDown])
 
-  const isTakerOrMakerRunning = useCallback(
+  const isTakerOrMakerRunning = useMemo(
     () => serviceInfo && (serviceInfo.makerRunning || serviceInfo.coinjoinInProgress),
     [serviceInfo]
   )
@@ -259,7 +259,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
   }
 
   const changeSelectedUtxoFreeze = async (freeze: boolean) => {
-    if (isLoadingFreeze || isLoadingUnfreeze || isLoadingRefresh || isTakerOrMakerRunning()) return
+    if (isLoadingFreeze || isLoadingUnfreeze || isLoadingRefresh || isTakerOrMakerRunning) return
 
     if (selectedUtxoIds.length <= 0) return
 
@@ -304,7 +304,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
     return (
       <rb.Button
         className={styles.refreshButton}
-        disabled={isLoadingUnfreeze || isLoadingFreeze}
+        disabled={isLoadingRefresh || isLoadingUnfreeze || isLoadingFreeze}
         variant={settings.theme}
         onClick={() => {
           refreshUtxos()
@@ -324,7 +324,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
 
     return (
       <rb.Button
-        disabled={isTakerOrMakerRunning() || isLoadingRefresh || (freeze ? isLoadingUnfreeze : isLoadingFreeze)}
+        disabled={isTakerOrMakerRunning || isLoadingRefresh || (freeze ? isLoadingUnfreeze : isLoadingFreeze)}
         variant="light"
         onClick={() => {
           changeSelectedUtxoFreeze(freeze)
@@ -353,9 +353,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
     <rb.Offcanvas
       className={`offcanvas-fullscreen ${styles.overlayContainer}`}
       show={props.isShown}
-      onHide={() => {
-        props.onHide()
-      }}
+      onHide={props.onHide}
       keyboard={false}
       placement="bottom"
     >

--- a/src/components/jar_details/UtxoDetailModule.module.css
+++ b/src/components/jar_details/UtxoDetailModule.module.css
@@ -1,0 +1,34 @@
+.utxoDetailModalBackdrop {
+  z-index: 1300 !important;
+}
+
+.utxoDetailModal {
+  z-index: 1400 !important;
+}
+
+.modalHeader {
+  display: flex !important;
+  justify-content: flex-start !important;
+  background-color: transparent !important;
+  padding: 1.25rem !important;
+}
+
+.modalTitle {
+  width: 100%;
+  font-size: 1rem !important;
+  font-weight: 400 !important;
+  color: var(--bs-body-color) !important;
+}
+
+.modalTitle > div:first-child {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modalTitle .cancelButton {
+  padding: 0 0 0 1rem;
+  color: var(--bs-body-color);
+  background-color: transparent !important;
+  border: none;
+}

--- a/src/components/jar_details/UtxoDetailModule.tsx
+++ b/src/components/jar_details/UtxoDetailModule.tsx
@@ -1,0 +1,109 @@
+import * as rb from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
+import { useSettings } from '../../context/SettingsContext'
+import { Utxo } from '../../context/WalletContext'
+import Balance from '../Balance'
+import Sprite from '../Sprite'
+import styles from './UtxoDetailModule.module.css'
+
+interface UtxoDetailModalProps {
+  utxo: Utxo
+  status: string | null
+  isShown: boolean
+  close: () => void
+}
+
+const UtxoDetailModal = ({ utxo, status, isShown, close }: UtxoDetailModalProps) => {
+  const { t } = useTranslation()
+  const settings = useSettings()
+
+  return (
+    <rb.Modal
+      show={isShown}
+      keyboard={true}
+      onEscapeKeyDown={close}
+      onHide={close}
+      centered={true}
+      animation={true}
+      className={styles.utxoDetailModal}
+      backdropClassName={styles.utxoDetailModalBackdrop}
+    >
+      <rb.Modal.Header className={styles.modalHeader}>
+        <rb.Modal.Title className={styles.modalTitle}>
+          <div>
+            <div>
+              <Balance
+                valueString={utxo.value.toString()}
+                convertToUnit={settings.unit}
+                showBalance={settings.showBalance}
+              />
+            </div>
+            <rb.Button onClick={close} className={styles.cancelButton}>
+              <Sprite symbol="cancel" width="26" height="26" />
+            </rb.Button>
+          </div>
+        </rb.Modal.Title>
+      </rb.Modal.Header>
+      <rb.Modal.Body>
+        <div className="d-flex flex-column gap-3">
+          <div>
+            <strong>{t('jar_details.utxo_list.utxo_detail_label_id')}</strong>: <code>{utxo.utxo}</code>
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_address')}</strong>: <code>{utxo.address}</code>
+            </div>
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_path')}</strong>: <code>{utxo.path}</code>
+            </div>
+            {utxo.label && (
+              <div>
+                <strong>{t('jar_details.utxo_list.utxo_detail_label_label')}</strong>: {utxo.label}
+              </div>
+            )}
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_value')}</strong>:{' '}
+              <Balance
+                valueString={utxo.value.toString()}
+                convertToUnit={settings.unit}
+                showBalance={settings.showBalance}
+              />
+            </div>
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_tries')}</strong>: {utxo.tries}
+            </div>
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_tries_remaining')}</strong>: {utxo.tries_remaining}
+            </div>
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_is_external')}</strong>:{' '}
+              {utxo.external ? 'Yes' : 'No'}
+            </div>
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_jar')}</strong>: {utxo.mixdepth}
+            </div>
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_confirmations')}</strong>: {utxo.confirmations}
+            </div>
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_is_frozen')}</strong>: {utxo.frozen ? 'Yes' : 'No'}
+            </div>
+            {utxo.locktime && (
+              <div>
+                <strong>{t('jar_details.utxo_list.utxo_detail_label_locktime')}</strong>: {utxo.locktime}
+              </div>
+            )}
+            <div>
+              <strong>{t('jar_details.utxo_list.utxo_detail_label_status')}</strong>: {status}
+            </div>
+          </div>
+        </div>
+      </rb.Modal.Body>
+      <rb.Modal.Footer className="d-flex justify-content-center">
+        <rb.Button variant="light" onClick={close} className="w-25 d-flex justify-content-center align-items-center">
+          <span>{t('global.close')}</span>
+        </rb.Button>
+      </rb.Modal.Footer>
+    </rb.Modal>
+  )
+}
+
+export default UtxoDetailModal

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -287,7 +287,7 @@ const UtxoList = ({ utxos, walletInfo, selectState, setSelectedUtxoIds, setDetai
           </>
         )}
       </Table>
-      <div className="mt-4 mb-4 mb-md-0">
+      <div className="mt-4 mb-4 mb-lg-0">
         <TablePagination data={tableData} pagination={pagination} />
       </div>
     </div>

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import * as rb from 'react-bootstrap'
 import classnames from 'classnames'
 import { useTranslation } from 'react-i18next'
@@ -7,6 +7,7 @@ import { usePagination } from '@table-library/react-table-library/pagination'
 import { useRowSelect, HeaderCellSelect, CellSelect, SelectTypes } from '@table-library/react-table-library/select'
 import { useSort, HeaderCellSort, SortToggleType } from '@table-library/react-table-library/sort'
 import * as TableTypes from '@table-library/react-table-library/types/table'
+import { State } from '@table-library/react-table-library/types/common'
 import { useTheme } from '@table-library/react-table-library/theme'
 import { useSettings } from '../../context/SettingsContext'
 import { Utxo, WalletInfo } from '../../context/WalletContext'
@@ -73,11 +74,12 @@ const TABLE_THEME = {
 interface UtxoListProps {
   utxos: Array<Utxo>
   walletInfo: WalletInfo
+  selectState: State
   setSelectedUtxoIds: (selectedUtxoIds: Array<string>) => void
   setDetailUtxo: (utxo: Utxo) => void
 }
 
-const UtxoList = ({ utxos, walletInfo, setSelectedUtxoIds, setDetailUtxo }: UtxoListProps) => {
+const UtxoList = ({ utxos, walletInfo, selectState, setSelectedUtxoIds, setDetailUtxo }: UtxoListProps) => {
   const { t } = useTranslation()
   const settings = useSettings()
 
@@ -131,13 +133,14 @@ const UtxoList = ({ utxos, walletInfo, setSelectedUtxoIds, setDetailUtxo }: Utxo
     },
   })
 
-  const onTableSelectChange = (action: any, state: any) => {
+  const onTableSelectChange = (action: any, state: State) => {
     setSelectedUtxoIds(state.ids)
   }
 
   const tableSelect = useRowSelect(
     tableData,
     {
+      state: selectState,
       onChange: onTableSelectChange,
     },
     {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -487,7 +487,7 @@
       "title_zero": "No UTXOs in Jar {{ jar }}",
       "title_one": "{{ count }} UTXO in Jar {{ jar }}",
       "title_other": "{{ count }} UTXOs in Jar {{ jar }}",
-      "text_balance_sum_selected": "<0></0> totally selected",
+      "text_balance_sum_selected": "<0></0> selected",
       "button_freeze": "Freeze",
       "button_unfreeze": "Unfreeze",
       "button_freeze_loading": "Freezing...",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -482,13 +482,14 @@
   },
   "jar_details": {
     "title_tab_utxos": "UTXOs",
-    "title_tab_account": "Jar Details",
+    "title_tab_account": "Details",
     "utxo_list": {
       "title_zero": "No UTXOs in Jar {{ jar }}",
       "title_one": "{{ count }} UTXO in Jar {{ jar }}",
       "title_other": "{{ count }} UTXOs in Jar {{ jar }}",
-      "button_freeze": "Freeze selected",
-      "button_unfreeze": "Unfreeze selected",
+      "text_balance_sum_selected": "<0></0> totally selected",
+      "button_freeze": "Freeze",
+      "button_unfreeze": "Unfreeze",
       "button_freeze_loading": "Freezing...",
       "button_unfreeze_loading": "Unfreezing...",
       "utxo_tag_frozen": "frozen",


### PR DESCRIPTION
Resolves #440.

Changes:
- show sum of selected utxos
- adapt margins/paddings to better match figma screens
- wording according to figma:
  - "Jar Details" -> "Details"
  - "Freeze/unfreeze selected" -> "Freeze/unfreeze"
 
<img src="https://user-images.githubusercontent.com/3358649/191792783-64b09736-74ef-44ad-9dfe-f4213179e120.png" height=300 /><img src="https://user-images.githubusercontent.com/3358649/191795894-d80bc07a-9093-4711-a6ca-ca37460f1bc0.png" height=300 />
