### PR TITLE
regtest: start additional maker service

### DIFF
--- a/docker/regtest/docker-compose-common.yml
+++ b/docker/regtest/docker-compose-common.yml
@@ -1,0 +1,45 @@
+version: "3"
+
+services:
+
+  joinmarket_native:
+    build:
+      context: ./dockerfile-deps/joinmarket/latest
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      READY_FILE: /root/.regtest-initializer/btc_fully_synched
+      ENSURE_WALLET: "true"
+      REMOVE_LOCK_FILES: "true"
+      jm_blockchain_source: regtest
+      jm_network: testnet
+      jm_rpc_host: bitcoind
+      jm_rpc_port: 43782
+      jm_directory_nodes: ${JM_DIRECTORY_NODES:?You must set the onion address generated in prepare step to your .env file}
+      jm_minimum_makers: 1 # necessary to do coinjoins with this regtest setup; default is 4
+      jm_taker_utxo_age: 1 # faster testing of scheduler runs; default is 5
+      jm_maker_timeout_sec: 30 # easier testing of maker timeouts on regtest (and "Stall Monitor" retries); default is 60
+    expose:
+      - 62601 # obwatch
+      - 28183 # jmwalletd api
+      - 28283 # jmwalletd websocket
+
+  joinmarket_jam_standalone:
+    build:
+      context: ./dockerfile-deps/joinmarket/webui-standalone
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      READY_FILE: /root/.regtest-initializer/btc_fully_synched
+      ENSURE_WALLET: "true"
+      REMOVE_LOCK_FILES: "true"
+      jm_blockchain_source: regtest
+      jm_network: testnet
+      jm_rpc_host: bitcoind
+      jm_rpc_port: 43782
+      jm_directory_nodes: ${JM_DIRECTORY_NODES:?You must set the onion address generated in prepare step to your .env file}
+      jm_minimum_makers: 1 # necessary to do coinjoins with this regtest setup; default is 4
+      jm_taker_utxo_age: 1 # faster testing of scheduler runs; default is 5
+    expose:
+      - 80    # nginx
+      - 28183 # jmwalletd api

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -4,29 +4,13 @@ services:
 
   joinmarket:
     container_name: jm_regtest_joinmarket
-    build:
-      context: ./dockerfile-deps/joinmarket/latest
-      dockerfile: Dockerfile
-    restart: unless-stopped
+    extends:
+      file: docker-compose-common.yml
+      service: joinmarket_native
     environment:
-      READY_FILE: /root/.regtest-initializer/btc_fully_synched
-      ENSURE_WALLET: "true"
-      REMOVE_LOCK_FILES: "true"
       jm_rpc_wallet_file: jm_primary
-      jm_blockchain_source: regtest
-      jm_network: testnet
-      jm_rpc_host: bitcoind
-      jm_rpc_port: 43782
       jm_rpc_user: joinmarket
       jm_rpc_password: joinmarket
-      jm_directory_nodes: ${JM_DIRECTORY_NODES:?You must set the onion address generated in prepare step to your .env file}
-      jm_minimum_makers: 1 # necessary to do coinjoins with this regtest setup; default is 4
-      jm_taker_utxo_age: 1 # faster testing of scheduler runs; default is 5
-      jm_maker_timeout_sec: 30 # easier testing of maker timeouts on regtest (and "Stall Monitor" retries); default is 60
-    expose:
-      - 62601 # obwatch
-      - 28183 # jmwalletd api
-      - 28283 # jmwalletd websocket
     ports:
       - "62601:62601"
       - "28183:28183"
@@ -41,34 +25,40 @@ services:
 
   joinmarket2:
     container_name: jm_regtest_joinmarket2
-    build:
-      context: ./dockerfile-deps/joinmarket/webui-standalone
-      dockerfile: Dockerfile
-    restart: unless-stopped
+    extends:
+      file: docker-compose-common.yml
+      service: joinmarket_jam_standalone
     environment:
-      READY_FILE: /root/.regtest-initializer/btc_fully_synched
-      ENSURE_WALLET: "true"
-      REMOVE_LOCK_FILES: "true"
       APP_USER: joinmarket
       APP_PASSWORD: joinmarket
       jm_rpc_wallet_file: jm_secondary
-      jm_blockchain_source: regtest
-      jm_network: testnet
-      jm_rpc_host: bitcoind
-      jm_rpc_port: 43782
       jm_rpc_user: joinmarket2
       jm_rpc_password: joinmarket2
-      jm_directory_nodes: ${JM_DIRECTORY_NODES:?You must set the onion address generated in prepare step to your .env file}
-      jm_minimum_makers: 1 # necessary to do coinjoins with this regtest setup; default is 4
-      jm_taker_utxo_age: 1 # faster testing of scheduler runs; default is 5
-    expose:
-      - 80    # nginx
-      - 28183 # jmwalletd api
     ports:
       - "29080:80"
       - "29183:28183" # exposed for "init setup" routine
     volumes:
       - "joinmarket2_datadir:/root/.joinmarket"
+      - "initializer_datadir:/root/.regtest-initializer"
+    depends_on:
+      - bitcoind
+      - bitcoind_regtest_initializer
+      - irc
+
+  joinmarket3:
+    container_name: jm_regtest_joinmarket3
+    extends:
+      file: docker-compose-common.yml
+      service: joinmarket_jam_standalone
+    environment:
+      jm_rpc_wallet_file: jm_tertiary
+      jm_rpc_user: joinmarket2
+      jm_rpc_password: joinmarket2
+    ports:
+      - "30080:80"
+      - "30183:28183" # exposed for "init setup" routine
+    volumes:
+      - "joinmarket3_datadir:/root/.joinmarket"
       - "initializer_datadir:/root/.regtest-initializer"
     depends_on:
       - bitcoind
@@ -175,5 +165,6 @@ volumes:
   initializer_datadir:
   joinmarket_datadir:
   joinmarket2_datadir:
+  joinmarket3_datadir:
   joinmarket_directory_node_datadir:
   irc_datadir:

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -13,8 +13,6 @@ services:
       ENSURE_WALLET: "true"
       REMOVE_LOCK_FILES: "true"
       jm_rpc_wallet_file: jm_primary
-      jm_minimum_makers: 1
-      jm_tx_broadcast: self
       jm_blockchain_source: regtest
       jm_network: testnet
       jm_rpc_host: bitcoind
@@ -22,10 +20,11 @@ services:
       jm_rpc_user: joinmarket
       jm_rpc_password: joinmarket
       jm_directory_nodes: ${JM_DIRECTORY_NODES:?You must set the onion address generated in prepare step to your .env file}
-      jm_socks5: "false" # will _not_ connect to local irc over tor
+      jm_minimum_makers: 1 # necessary to do coinjoins with this regtest setup; default is 4
+      jm_taker_utxo_age: 1 # faster testing of scheduler runs; default is 5
+      jm_maker_timeout_sec: 30 # easier testing of maker timeouts on regtest (and "Stall Monitor" retries); default is 60
     expose:
       - 62601 # obwatch
-      - 27183 # joinmarketd
       - 28183 # jmwalletd api
       - 28283 # jmwalletd websocket
     ports:
@@ -53,8 +52,6 @@ services:
       APP_USER: joinmarket
       APP_PASSWORD: joinmarket
       jm_rpc_wallet_file: jm_secondary
-      jm_minimum_makers: 1
-      jm_tx_broadcast: self
       jm_blockchain_source: regtest
       jm_network: testnet
       jm_rpc_host: bitcoind
@@ -62,19 +59,14 @@ services:
       jm_rpc_user: joinmarket2
       jm_rpc_password: joinmarket2
       jm_directory_nodes: ${JM_DIRECTORY_NODES:?You must set the onion address generated in prepare step to your .env file}
-      jm_socks5: "false" # will _not_ connect to local irc over tor
-      jm_taker_utxo_retries: 1 # easier testing of commitment failures on regtest; default is 3
-      maker_timeout_sec: 10 # easier testing of maker timeouts on regtest (and "Stall Monitor" retries); default is 60
+      jm_minimum_makers: 1 # necessary to do coinjoins with this regtest setup; default is 4
+      jm_taker_utxo_age: 1 # faster testing of scheduler runs; default is 5
     expose:
       - 80    # nginx
-      - 62601 # obwatch
-      - 27183 # joinmarketd
       - 28183 # jmwalletd api
-      - 28283 # jmwalletd websocket
     ports:
-      - "29183:28183"
-      - "29283:28283"
       - "29080:80"
+      - "29183:28183" # exposed for "init setup" routine
     volumes:
       - "joinmarket2_datadir:/root/.joinmarket"
       - "initializer_datadir:/root/.regtest-initializer"

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       service: joinmarket_jam_standalone
     environment:
       jm_rpc_wallet_file: jm_tertiary
-      jm_rpc_user: joinmarket2
-      jm_rpc_password: joinmarket2
+      jm_rpc_user: joinmarket3
+      jm_rpc_password: joinmarket3
     ports:
       - "30080:80"
       - "30183:28183" # exposed for "init setup" routine
@@ -122,6 +122,8 @@ services:
         rpcauth=joinmarket:260b4c5b1fbd09d75a4aabf90226282f$$76e170af088d43a588992cdd5e7bae2242b03c33aa672cccfd1fb75f9281299e
         # rpcauth (user=joinmarket2; password=joinmarket2)
         rpcauth=joinmarket2:521bf9f4468529d49c0a41f9c9f8fdbf$$63ae94a73d2aa45e7ee756945d9b1e469f9873ce026b815d676a748f777e0b8d
+        # rpcauth (user=joinmarket3; password=joinmarket3)
+        rpcauth=joinmarket3:85d4beaa74540c3b08f4fef50d74a59e$$3033c779ea4bfd02a1f3403bc4d012f3e6d19b355f74c5e8de1d3439979d5e4b
     expose:
       - 43782 # RPC
       - 39388 # P2P

--- a/docker/regtest/fund-wallet.sh
+++ b/docker/regtest/fund-wallet.sh
@@ -103,11 +103,13 @@ parse_params() {
   [ "$blocks" -ge 1 ] || die "Invalid parameter: 'blocks' must be a positve integer"
 
   [ "$container" == "jm_regtest_joinmarket" ] || 
-  [ "$container" == "jm_regtest_joinmarket2" ] || 
+  [ "$container" == "jm_regtest_joinmarket2" ] ||
+  [ "$container" == "jm_regtest_joinmarket3" ] || 
   die "Invalid parameter: 'container' must be a known container name"
 
   [ "$container" == "jm_regtest_joinmarket" ] && base_url='https://localhost:28183'
   [ "$container" == "jm_regtest_joinmarket2" ] && base_url='https://localhost:29183'
+  [ "$container" == "jm_regtest_joinmarket3" ] && base_url='https://localhost:30183'
 
   return 0
 }

--- a/docker/regtest/init-setup.sh
+++ b/docker/regtest/init-setup.sh
@@ -6,8 +6,8 @@
 # Its main goal is to make CoinJoin transactions possible in the regtest environment.
 #
 # It has two responsibilities:
-# - funding wallets in both containers with some coins
-# - starting the maker service in the secondary container
+# - funding wallets in all containers with some coins
+# - starting the maker service in the secondary and tertiary container
 #
 ###
 
@@ -18,62 +18,60 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 # fund wallet in primary JoinMarket container
 . "$script_dir/fund-wallet.sh" --container jm_regtest_joinmarket --unmatured --blocks 3
 
-# fund wallet in secondary JoinMarket container.
-# this will get more coins than the primary one in order to have enough liquidity
+# fund wallet in secondary and tertiary JoinMarket container.
+# these will get more coins than the primary one in order to have enough liquidity
 # to run the scheduler (scheduled sweep) successfully multiple times.
 . "$script_dir/fund-wallet.sh" --container jm_regtest_joinmarket2 --unmatured --blocks 50
+. "$script_dir/fund-wallet.sh" --container jm_regtest_joinmarket3 --unmatured --blocks 50
 
 # make block rewards spendable: 100 + 5 (default of `taker_utxo_age`) + 1 = 106
 . "$script_dir/mine-block.sh" 106 &>/dev/null
 
+start_maker() {
+    local base_url; base_url=${1:-}
+    local wallet_name; wallet_name=${2:-}
+    local wallet_password; wallet_password=${3:-}
+    
+    # Check if maker service is not yet running
+    verify_no_open_session_or_throw "$base_url"
 
-base_url='https://localhost:29183'
-wallet_name='Satoshi.jmdat'
-wallet_password='test'
+    local maker_running; maker_running=$(is_maker_running "$base_url")
+
+    if [ "$maker_running" != false ]; then
+      msg_success "Maker is already running"
+    else
+        # Unlock wallet
+        local unlock_result; unlock_result=$(unlock_wallet "$base_url" "$wallet_name" "$wallet_password")
+
+        local auth_token; auth_token=$(jq -r '.token' <<< "$unlock_result")
+        local auth_header; auth_header="Authorization: Bearer $auth_token"
+
+        # --------------------------
+        # Start maker
+        # --------------------------
+        ## API: POST /api/v1/wallet/$wallet_name/maker/start
+        ## 
+        ## Response: 
+        ## 200 OK
+        ## {}
+        msg "Starting maker service for wallet $wallet_name.."  
+        local start_maker_request_payload; start_maker_request_payload="{\"txfee\":\"0\",\"cjfee_a\":\"250\",\"cjfee_r\":\"0.0003\",\"ordertype\":\"sw0absoffer\",\"minsize\":\"1\"}"
+
+        local start_maker_result; start_maker_result=$(curl "$base_url/api/v1/wallet/$wallet_name/maker/start" --silent --show-error --insecure -H "$auth_header" --data "$start_maker_request_payload" | jq ".")
+
+        if [ "$start_maker_result" != "{}" ]; then
+            msg_warn "There has been a problem starting the maker service: $start_maker_result"
+        else
+            msg_success "Successfully started maker for wallet $wallet_name."
+        fi
+        
+        # do not lock the wallet as this will terminate the maker service
+        msg_warn "Wallet $wallet_name remains unlocked!"
+    fi
+}
 
 msg "Attempt to start maker service for wallet $wallet_name in secondary container.."
+start_maker "https://localhost:29183" "Satoshi.jmdat" "test"
 
-# --------------------------
-# Check if maker service is not yet running
-# --------------------------
-if session_result=$(curl "$base_url/api/v1/session" --silent --show-error --insecure | jq "."); then
-  msg_success "Successfully established connection to jmwalletd"
-else rc=$?
-  die "Could not connect to jmwalletd. Please make sure it is running inside container."
-fi
-
-maker_running=$(jq -r '.maker_running' <<< "$session_result")
-
-if [ "$maker_running" != false ]; then
-  msg_success "Maker is already running"
-else
-    # --------------------------
-    # Unlock wallet
-    # --------------------------
-    unlock_result=$(unlock_wallet "$base_url" "$wallet_name" "$wallet_password")
-
-    auth_token=$(jq -r '.token' <<< "$unlock_result")
-    auth_header="Authorization: Bearer $auth_token"
-
-    # --------------------------
-    # Start maker
-    # --------------------------
-    ## API: POST /api/v1/wallet/$wallet_name/maker/start
-    ## 
-    ## Response: 
-    ## 200 OK
-    ## {}
-    msg "Starting maker service for wallet $wallet_name.."  
-    start_maker_request_payload="{\"txfee\":\"0\",\"cjfee_a\":\"250\",\"cjfee_r\":\"0.0003\",\"ordertype\":\"sw0absoffer\",\"minsize\":\"1\"}"
-
-    start_maker_result=$(curl "$base_url/api/v1/wallet/$wallet_name/maker/start" --silent --show-error --insecure -H "$auth_header" --data "$start_maker_request_payload" | jq ".")
-
-    if [ "$start_maker_result" != "{}" ]; then
-        msg_warn "There has been a problem starting the maker service: $start_maker_result"
-    else
-        msg_success "Successfully started maker for wallet $wallet_name in secondary container."
-    fi
-    
-    # do not lock the wallet as this will terminate the maker service
-    msg_warn "Wallet $wallet_name in secondary container remains unlocked!"
-fi
+msg "Attempt to start maker service for wallet $wallet_name in tertiary container.."
+start_maker "https://localhost:30183" "Satoshi.jmdat" "test"

--- a/docker/regtest/init-setup.sh
+++ b/docker/regtest/init-setup.sh
@@ -2,7 +2,7 @@
 
 ###
 #
-# This script helps initializing the joinmarket docker containers.
+# This script helps initializing the JoinMarket docker containers.
 # Its main goal is to make CoinJoin transactions possible in the regtest environment.
 #
 # It has two responsibilities:
@@ -15,11 +15,12 @@ set -Eeuo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
-# fund wallet in primary joinmarket container
+# fund wallet in primary JoinMarket container
 . "$script_dir/fund-wallet.sh" --container jm_regtest_joinmarket --unmatured --blocks 3
 
-# fund wallet in secondary joinmarket container
-# this will get more coins than the primary one in order to successfully run the tumbler.py script
+# fund wallet in secondary JoinMarket container.
+# this will get more coins than the primary one in order to have enough liquidity
+# to run the scheduler (scheduled sweep) successfully multiple times.
 . "$script_dir/fund-wallet.sh" --container jm_regtest_joinmarket2 --unmatured --blocks 50
 
 # make block rewards spendable: 100 + 5 (default of `taker_utxo_age`) + 1 = 106
@@ -38,7 +39,7 @@ msg "Attempt to start maker service for wallet $wallet_name in secondary contain
 if session_result=$(curl "$base_url/api/v1/session" --silent --show-error --insecure | jq "."); then
   msg_success "Successfully established connection to jmwalletd"
 else rc=$?
-  die "Could not connect to joinmarket. Please make sure jmwalletd is running inside container."
+  die "Could not connect to jmwalletd. Please make sure it is running inside container."
 fi
 
 maker_running=$(jq -r '.maker_running' <<< "$session_result")

--- a/docker/regtest/readme.md
+++ b/docker/regtest/readme.md
@@ -4,7 +4,7 @@ This setup will help you set up a regtest environment quickly.
 It starts multiple JoinMarket containers, hence not only API calls but also actual CoinJoin transactions can be tested.
 Communication between these containers is done via Tor (if internet connection is available) and IRC (locally running container).
 
-Both containers will have a wallet named `Satoshi.jmdat` with password `test`.
+All containers will have a wallet named `Satoshi.jmdat` with password `test`.
 The second container has basic auth enabled (username `joinmarket` and password `joinmarket`).
 
 ## Common flow
@@ -15,7 +15,7 @@ npm run regtest:rebuild
 # start the regtest environment
 npm run regtest:up
 
-# fund wallets and start maker in secondary container
+# fund wallets and start maker in secondary and tertiary container
 npm run regtest:init
 
 # mine blocks in regtest periodically
@@ -42,7 +42,7 @@ Start the regtest environment with:
 ```sh
 npm run regtest:up
 
-# (optional) fund wallets and start maker in secondary container
+# (optional) fund wallets and start maker in secondary and tertiary containers
 npm run regtest:init
 ```
 
@@ -80,9 +80,10 @@ Keep in mind: Building from `master` is not always reliable. This tradeoff is ma
 
 The second JoinMarket container is based on `joinmarket-webui/jam-dev-standalone:master` which exposes an UI on port `29080`
 (username `joinmarket` and pass `joinmarket` for Basic Authentication).
+The third container is a copy of the second one exposed on port `30080` without authentication.
 This is useful if you want to perform regression tests.
 
-The third JoinMarket container acts as [Directory Node](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/onion-message-channels.md#directory) and exists solely to enable communication between peers.
+One additional JoinMarket container acts as [Directory Node](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/onion-message-channels.md#directory) and exists solely to enable communication between peers.
 
 ### Build
 ```sh
@@ -118,13 +119,13 @@ Some helper scripts are included to make recurring tasks and interaction with th
 
 ### `init-setup.sh`
 
-This script helps in providing both JoinMarket containers a wallet with spendable coins and starting the Maker Service in the secondary container.
+This script helps in providing JoinMarket containers a wallet with spendable coins and starting the Maker Service in the secondary and tertiary containers.
 Its main goal is to make CoinJoin transactions possible in the regtest environment.
 It should be run immediately after the Docker setup is successfully started so you can start developing right away.
 A wallet named `Satoshi.jmdat` with password `test` will be created if it does not exist.
 
 ```sh
-# fund wallets and start maker service in secondary container
+# fund wallets and start maker service in secondary and tertiary containers
 [user@home regtest]$ ./init-setup.sh
 ```
 
@@ -132,8 +133,11 @@ A wallet named `Satoshi.jmdat` with password `test` will be created if it does n
 [...]
 Attempt to start maker for wallet 'Satoshi.jmdat' in secondary container ..
 [...]
-Starting maker service for wallet 'Satoshi.jmdat'
-Successfully started maker for wallet 'Satoshi.jmdat' in secondary container.
+Successfully started maker for wallet 'Satoshi.jmdat'.
+[...]
+Attempt to start maker for wallet 'Satoshi.jmdat' in tertiary container ..
+[...]
+Successfully started maker for wallet 'Satoshi.jmdat'.
 [...]
 ```
 


### PR DESCRIPTION
This PR adds a third JM regtest instance and starts an additional maker service during initialization with `npm run regtest:init`.
It is an attempt to make the development setup more resilient to maker timeouts. Setup script takes slightly longer and cpu usage during development will increase a bit.

Also adapted some regtest settings for faster/easier testing:
- actually set `maker_timeout_sec` on primary instance -> was `maker_timeout_sec` instead of `jm_maker_timeout_sec`
- set `taker_utxo_age` from 5 to 1 on primary instance (this revealed that coinjoin precondition warning message must be parameterized)
- do not set `tx_broadcast` - was `self` (use default value `random-peer`); you'll see more "tx already in chain" warnings, which is expected behaviour.

#### How to test
Start and initialize your dev environment as usual and try to send a collaborative transaction with 2 collaborators.