### PR TITLE
i18n(orderbook): order -> offer

### DIFF
--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -421,10 +421,10 @@
   },
   "orderbook": {
     "title": "Orderbook",
-    "text_orderbook_summary_one": "{{ count }} order by {{ counterpartyCount }} conterparty",
-    "text_orderbook_summary_other": "{{ count }} orders by {{ counterpartyCount }} conterparties",
-    "text_orderbook_summary_filtered_one": "found {{ count }} order by {{ counterpartyCount }} conterparty",
-    "text_orderbook_summary_filtered_other": "found {{ count }} orders by {{ counterpartyCount }} conterparties",
+    "text_orderbook_summary_one": "{{ count }} offer by {{ counterpartyCount }} conterparty",
+    "text_orderbook_summary_other": "{{ count }} offers by {{ counterpartyCount }} conterparties",
+    "text_orderbook_summary_filtered_one": "found {{ count }} offer by {{ counterpartyCount }} conterparty",
+    "text_orderbook_summary_filtered_other": "found {{ count }} offers by {{ counterpartyCount }} conterparties",
     "alert_empty_orderbook": "Orderbook is empty",
     "error_loading_orderbook_failed": "Error while loading the orderbook. Your current local setup might not support fetching the orderbook. Reason: {{ reason }}",
     "text_offer_type_absolute": "absolute",
@@ -432,7 +432,7 @@
     "label_search": "Search",
     "placeholder_search": "Search",
     "text_orderbook_filter_count": "{{ filterCount }} entries match given search criteria",
-    "label_highlight_own_orders": "Highlight my orders",
+    "label_highlight_own_orders": "Highlight my offers",
     "table": {
       "heading_type": "Type",
       "heading_counterparty": "Counterparty",


### PR DESCRIPTION
Change phrasing in orderbook summary: "order" -> "offer".
The "orderbook" does not consist of "orders" but of "offers". A taker is someone that makes an "order" based on "offers".

e.g.
-  "42 orders by 21 counterparties" -> "42 offers by 21 counterparties"
- "Highlight my orders" -> "Highlight my offers"

