### PR TITLE
feat: display fee settings on Send page

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react'
+import { ReactNode, PropsWithChildren } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import styles from './Modal.module.css'
@@ -6,7 +6,7 @@ import Sprite from './Sprite'
 
 interface ConfirmModalProps {
   isShown: boolean
-  title: React.ReactNode | string
+  title: ReactNode | string
   onCancel: () => void
   onConfirm: () => void
 }

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -355,12 +355,12 @@ function PaymentConfirmModal({
             </rb.Col>
             <rb.Col xs={8} md={9} className="d-inline-flex align-items-center text-start">
               <div>
+                &le;
                 <Balance
                   valueString={`${estimatedMaxCollaboratorFee}`}
                   convertToUnit={settings.unit}
                   showBalance={true}
                 />
-
                 <rb.OverlayTrigger
                   placement="right"
                   overlay={

--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -3,11 +3,12 @@ import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { Formik, FormikErrors } from 'formik'
 import classNames from 'classnames'
-import { useRefreshConfigValues, useUpdateConfigValues } from '../../context/ServiceConfigContext'
+import { FEE_CONFIG_KEYS, FeeValues, useLoadFeeConfigValues } from '../../hooks/Fees'
+import { useUpdateConfigValues } from '../../context/ServiceConfigContext'
 import { factorToPercentage, percentageToFactor } from '../../utils'
 import Sprite from '../Sprite'
-import styles from './FeeConfigModal.module.css'
 import SegmentedTabs from '../SegmentedTabs'
+import styles from './FeeConfigModal.module.css'
 
 type SatsPerKiloVByte = number
 
@@ -17,7 +18,6 @@ const TX_FEES_SATSPERKILOVBYTE_MIN: SatsPerKiloVByte = 1_000 // 1 sat/vbyte
 // 350 sats/vbyte - no enforcement by JM - this should be a "sane" max value (taken default value of "absurd_fee_per_kb")
 const TX_FEES_SATSPERKILOVBYTE_MAX: SatsPerKiloVByte = 350_000
 const TX_FEES_SATSPERKILOVBYTE_ADJUSTED_MIN = 1_001 // actual min of `tx_fees` if unit is sats/kilo-vbyte
-const TX_FEES_FACTOR_DEFAULT_VAL = 0.2 // 20%
 const TX_FEES_FACTOR_MIN = 0 // 0%
 const TX_FEES_FACTOR_MAX = 1 // 100%
 const CJ_FEE_ABS_MIN = 1
@@ -27,26 +27,12 @@ const CJ_FEE_REL_MAX = 0.05 // 5% - no enforcement by JM - this should be a "san
 
 const isValidNumber = (val: number | undefined) => typeof val === 'number' && !isNaN(val)
 
-const FEE_KEYS = {
-  tx_fees: { section: 'POLICY', field: 'tx_fees' },
-  tx_fees_factor: { section: 'POLICY', field: 'tx_fees_factor' },
-  max_cj_fee_abs: { section: 'POLICY', field: 'max_cj_fee_abs' },
-  max_cj_fee_rel: { section: 'POLICY', field: 'max_cj_fee_rel' },
-}
-
 interface FeeConfigModalProps {
   show: boolean
   onHide: () => void
 }
 
 type TxFeeValueUnit = 'blocks' | 'sats/kilo-vbyte'
-
-interface FeeValues {
-  tx_fees?: number
-  tx_fees_factor?: number
-  max_cj_fee_abs?: number
-  max_cj_fee_rel?: number
-}
 
 interface FeeConfigFormProps {
   initialValues: FeeValues
@@ -312,8 +298,8 @@ const FeeConfigForm = forwardRef(
 
 export default function FeeConfigModal({ show, onHide }: FeeConfigModalProps) {
   const { t } = useTranslation()
-  const refreshConfigValues = useRefreshConfigValues()
   const updateConfigValues = useUpdateConfigValues()
+  const loadFeeConfigValues = useLoadFeeConfigValues()
   const [isLoading, setIsLoading] = useState(true)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [loadError, setLoadError] = useState(false)
@@ -322,47 +308,31 @@ export default function FeeConfigModal({ show, onHide }: FeeConfigModalProps) {
   const formRef = useRef<HTMLFormElement>(null)
 
   useEffect(() => {
-    const loadFeeValues = async (signal: AbortSignal) => {
-      setLoadError(false)
-      setIsLoading(true)
-
-      try {
-        const serviceConfig = await refreshConfigValues({
-          signal,
-          keys: Object.values(FEE_KEYS),
-        })
-
-        setIsLoading(false)
-
-        const policy = serviceConfig['POLICY'] || {}
-
-        const feeValues: FeeValues = {
-          tx_fees: parseInt(policy.tx_fees || '', 10) || undefined,
-          tx_fees_factor: parseFloat(policy.tx_fees_factor || `${TX_FEES_FACTOR_DEFAULT_VAL}`),
-          max_cj_fee_abs: parseInt(policy.max_cj_fee_abs || '', 10) || undefined,
-          max_cj_fee_rel: parseFloat(policy.max_cj_fee_rel || '') || undefined,
-        }
-        setFeeConfigValues(feeValues)
-      } catch (e) {
-        if (!signal.aborted) {
-          setIsLoading(false)
-          setLoadError(true)
-        }
-      }
-    }
+    setLoadError(false)
 
     const abortCtrl = new AbortController()
     if (show) {
-      loadFeeValues(abortCtrl.signal)
+      setIsLoading(true)
+
+      loadFeeConfigValues(abortCtrl.signal)
+        .then((val) => {
+          if (abortCtrl.signal.aborted) return
+          setIsLoading(false)
+          setFeeConfigValues(val)
+        })
+        .catch((e) => {
+          if (abortCtrl.signal.aborted) return
+          setIsLoading(false)
+          setLoadError(true)
+        })
     } else {
-      setLoadError(false)
       setSaveErrorMessage(undefined)
     }
 
     return () => {
       abortCtrl.abort()
     }
-  }, [show, refreshConfigValues])
+  }, [show, loadFeeConfigValues])
 
   const submit = async (feeValues: FeeValues, txFeesUnit: TxFeeValueUnit) => {
     const allValuesPresent = Object.values(feeValues).every((it) => it !== undefined)
@@ -380,19 +350,19 @@ export default function FeeConfigModal({ show, onHide }: FeeConfigModalProps) {
 
     const updates = [
       {
-        key: FEE_KEYS.tx_fees,
+        key: FEE_CONFIG_KEYS.tx_fees,
         value: String(adjustedTxFees),
       },
       {
-        key: FEE_KEYS.tx_fees_factor,
+        key: FEE_CONFIG_KEYS.tx_fees_factor,
         value: String(feeValues.tx_fees_factor),
       },
       {
-        key: FEE_KEYS.max_cj_fee_abs,
+        key: FEE_CONFIG_KEYS.max_cj_fee_abs,
         value: String(feeValues.max_cj_fee_abs),
       },
       {
-        key: FEE_KEYS.max_cj_fee_rel,
+        key: FEE_CONFIG_KEYS.max_cj_fee_rel,
         value: String(feeValues.max_cj_fee_rel),
       },
     ]

--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -5,7 +5,7 @@ import { Formik, FormikErrors } from 'formik'
 import classNames from 'classnames'
 import { FEE_CONFIG_KEYS, FeeValues, useLoadFeeConfigValues } from '../../hooks/Fees'
 import { useUpdateConfigValues } from '../../context/ServiceConfigContext'
-import { factorToPercentage, percentageToFactor } from '../../utils'
+import { isValidNumber, factorToPercentage, percentageToFactor } from '../../utils'
 import Sprite from '../Sprite'
 import SegmentedTabs from '../SegmentedTabs'
 import styles from './FeeConfigModal.module.css'
@@ -24,8 +24,6 @@ const CJ_FEE_ABS_MIN = 1
 const CJ_FEE_ABS_MAX = 1_000_000 // 0.01 BTC - no enforcement by JM - this should be a "sane" max value
 const CJ_FEE_REL_MIN = 0.000001 // 0.0001%
 const CJ_FEE_REL_MAX = 0.05 // 5% - no enforcement by JM - this should be a "sane" max value
-
-const isValidNumber = (val: number | undefined) => typeof val === 'number' && !isNaN(val)
 
 interface FeeConfigModalProps {
   show: boolean

--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -3,7 +3,7 @@ import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { Formik, FormikErrors } from 'formik'
 import classNames from 'classnames'
-import { FEE_CONFIG_KEYS, FeeValues, useLoadFeeConfigValues } from '../../hooks/Fees'
+import { FEE_CONFIG_KEYS, TxFeeValueUnit, toTxFeeValueUnit, FeeValues, useLoadFeeConfigValues } from '../../hooks/Fees'
 import { useUpdateConfigValues } from '../../context/ServiceConfigContext'
 import { isValidNumber, factorToPercentage, percentageToFactor } from '../../utils'
 import Sprite from '../Sprite'
@@ -30,8 +30,6 @@ interface FeeConfigModalProps {
   onHide: () => void
 }
 
-type TxFeeValueUnit = 'blocks' | 'sats/kilo-vbyte'
-
 interface FeeConfigFormProps {
   initialValues: FeeValues
   validate: (values: FeeValues, txFeesUnit: TxFeeValueUnit) => FormikErrors<FeeValues>
@@ -42,9 +40,7 @@ const FeeConfigForm = forwardRef(
   ({ onSubmit, validate, initialValues }: FeeConfigFormProps, ref: React.Ref<HTMLFormElement>) => {
     const { t, i18n } = useTranslation()
 
-    const [txFeesUnit, setTxFeesUnit] = useState<TxFeeValueUnit>(
-      initialValues.tx_fees && initialValues.tx_fees > 1_000 ? 'sats/kilo-vbyte' : 'blocks'
-    )
+    const [txFeesUnit, setTxFeesUnit] = useState<TxFeeValueUnit>(toTxFeeValueUnit(initialValues.tx_fees) || 'blocks')
 
     return (
       <Formik

--- a/src/hooks/Fees.test.ts
+++ b/src/hooks/Fees.test.ts
@@ -1,4 +1,23 @@
-import { estimateMaxCollaboratorFee } from './Fees'
+import { toTxFeeValueUnit, estimateMaxCollaboratorFee } from './Fees'
+
+describe('toTxFeeValueUnit', () => {
+  it('should return correct unit', () => {
+    expect(toTxFeeValueUnit(undefined)).toBe(undefined)
+    expect(toTxFeeValueUnit(NaN)).toBe(undefined)
+    expect(toTxFeeValueUnit(-1)).toBe(undefined)
+    expect(toTxFeeValueUnit(0)).toBe(undefined)
+    expect(toTxFeeValueUnit(1.1)).toBe(undefined)
+    expect(toTxFeeValueUnit(1_001.1)).toBe(undefined)
+
+    expect(toTxFeeValueUnit(1)).toBe('blocks')
+    expect(toTxFeeValueUnit(999)).toBe('blocks')
+    expect(toTxFeeValueUnit(1_000)).toBe('blocks')
+
+    expect(toTxFeeValueUnit(1_001)).toBe('sats/kilo-vbyte')
+    expect(toTxFeeValueUnit(1001 + Math.round(Math.random() * 1_000_000))).toBe('sats/kilo-vbyte')
+    expect(toTxFeeValueUnit(Number.MAX_SAFE_INTEGER)).toBe('sats/kilo-vbyte')
+  })
+})
 
 describe('estimateMaxCollaboratorFee', () => {
   it('should return estimate based on max fee', () => {

--- a/src/hooks/Fees.test.ts
+++ b/src/hooks/Fees.test.ts
@@ -1,0 +1,50 @@
+import { estimateMaxCollaboratorFee } from './Fees'
+
+describe('estimateMaxCollaboratorFee', () => {
+  it('should return estimate based on max fee', () => {
+    const data = {
+      amount: 100_000_000, // 1 btc
+      maxFeeAbs: 21_000,
+      maxFeeRel: 0.0002, // 0.02% = (20k sats)
+    }
+
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: -1 })).toBe(0)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 0 })).toBe(0)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 1 })).toBe(21_000)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 2 })).toBe(42_000)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 3 })).toBe(63_000)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 10 })).toBe(210_000)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 21_000 })).toBe(data.amount)
+  })
+
+  it('should return estimate based on rel fee', () => {
+    const data = {
+      amount: 100_000_000, // 1 btc
+      maxFeeAbs: 9_001,
+      maxFeeRel: 0.0001, // 0.01% = (10k sats)
+    }
+
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: -1 })).toBe(0)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 0 })).toBe(0)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 1 })).toBe(10_000)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 2 })).toBe(20_000)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 3 })).toBe(30_000)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 10 })).toBe(100_000)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 21_000 })).toBe(data.amount)
+  })
+
+  it('should return amount if max. fees are higher than amount', () => {
+    const data = {
+      amount: 21, // 21 sats
+      maxFeeAbs: 22,
+      maxFeeRel: 1, // 100%
+    }
+
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: -1 })).toBe(0)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 0 })).toBe(0)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 1 })).toBe(data.amount)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 2 })).toBe(data.amount)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 10 })).toBe(data.amount)
+    expect(estimateMaxCollaboratorFee({ ...data, collaborators: 21_000 })).toBe(data.amount)
+  })
+})

--- a/src/hooks/Fees.ts
+++ b/src/hooks/Fees.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react'
+import { useRefreshConfigValues } from '../context/ServiceConfigContext'
+
+export const FEE_CONFIG_KEYS = {
+  tx_fees: { section: 'POLICY', field: 'tx_fees' },
+  tx_fees_factor: { section: 'POLICY', field: 'tx_fees_factor' },
+  max_cj_fee_abs: { section: 'POLICY', field: 'max_cj_fee_abs' },
+  max_cj_fee_rel: { section: 'POLICY', field: 'max_cj_fee_rel' },
+}
+
+export interface FeeValues {
+  tx_fees?: number
+  tx_fees_factor?: number
+  max_cj_fee_abs?: number
+  max_cj_fee_rel?: number
+}
+
+export const useLoadFeeConfigValues = () => {
+  const refreshConfigValues = useRefreshConfigValues()
+
+  return useCallback(
+    async (signal?: AbortSignal) => {
+      const serviceConfig = await refreshConfigValues({
+        signal,
+        keys: Object.values(FEE_CONFIG_KEYS),
+      })
+
+      const policy = serviceConfig['POLICY'] || {}
+
+      const feeValues: FeeValues = {
+        tx_fees: parseInt(policy.tx_fees || '', 10) || undefined,
+        tx_fees_factor: parseFloat(policy.tx_fees_factor || '') || undefined,
+        max_cj_fee_abs: parseInt(policy.max_cj_fee_abs || '', 10) || undefined,
+        max_cj_fee_rel: parseFloat(policy.max_cj_fee_rel || '') || undefined,
+      }
+      return feeValues
+    },
+    [refreshConfigValues]
+  )
+}

--- a/src/hooks/Fees.ts
+++ b/src/hooks/Fees.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { useRefreshConfigValues } from '../context/ServiceConfigContext'
 import { AmountSats } from '../libs/JmWalletApi'
+import { isValidNumber } from '../utils'
 
 export type TxFeeValueUnit = 'blocks' | 'sats/kilo-vbyte'
 
@@ -35,11 +36,16 @@ export const useLoadFeeConfigValues = () => {
 
       const policy = serviceConfig['POLICY'] || {}
 
+      const parsedTxFees = parseInt(policy.tx_fees || '', 10)
+      const parsedTxFeesFactor = parseFloat(policy.tx_fees_factor || '')
+      const parsedMaxFeeAbs = parseInt(policy.max_cj_fee_abs || '', 10)
+      const parsedMaxFeeRel = parseFloat(policy.max_cj_fee_rel || '')
+
       const feeValues: FeeValues = {
-        tx_fees: parseInt(policy.tx_fees || '', 10) || undefined,
-        tx_fees_factor: parseFloat(policy.tx_fees_factor || '') || undefined,
-        max_cj_fee_abs: parseInt(policy.max_cj_fee_abs || '', 10) || undefined,
-        max_cj_fee_rel: parseFloat(policy.max_cj_fee_rel || '') || undefined,
+        tx_fees: isValidNumber(parsedTxFees) ? parsedTxFees : undefined,
+        tx_fees_factor: isValidNumber(parsedTxFeesFactor) ? parsedTxFeesFactor : undefined,
+        max_cj_fee_abs: isValidNumber(parsedMaxFeeAbs) ? parsedMaxFeeAbs : undefined,
+        max_cj_fee_rel: isValidNumber(parsedMaxFeeRel) ? parsedMaxFeeRel : undefined,
       }
       return feeValues
     },

--- a/src/hooks/Fees.ts
+++ b/src/hooks/Fees.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { useRefreshConfigValues } from '../context/ServiceConfigContext'
+import { AmountSats } from '../libs/JmWalletApi'
 
 export const FEE_CONFIG_KEYS = {
   tx_fees: { section: 'POLICY', field: 'tx_fees' },
@@ -37,4 +38,21 @@ export const useLoadFeeConfigValues = () => {
     },
     [refreshConfigValues]
   )
+}
+
+interface EstimatMaxCollaboratorFeeProps {
+  amount: AmountSats
+  collaborators: number
+  maxFeeAbs: AmountSats
+  maxFeeRel: number // e.g. 0.001 for 0.1%
+}
+
+export const estimateMaxCollaboratorFee = ({
+  amount,
+  collaborators,
+  maxFeeAbs,
+  maxFeeRel,
+}: EstimatMaxCollaboratorFeeProps) => {
+  const maxFeePerCollaborator = Math.max(Math.ceil(amount * maxFeeRel), maxFeeAbs)
+  return collaborators > 0 ? Math.min(maxFeePerCollaborator * collaborators, amount) : 0
 }

--- a/src/hooks/Fees.ts
+++ b/src/hooks/Fees.ts
@@ -2,6 +2,13 @@ import { useCallback } from 'react'
 import { useRefreshConfigValues } from '../context/ServiceConfigContext'
 import { AmountSats } from '../libs/JmWalletApi'
 
+export type TxFeeValueUnit = 'blocks' | 'sats/kilo-vbyte'
+
+export const toTxFeeValueUnit = (val?: number): TxFeeValueUnit | undefined => {
+  if (val === undefined || !Number.isInteger(val) || val < 1) return undefined
+  return val <= 1_000 ? 'blocks' : 'sats/kilo-vbyte'
+}
+
 export const FEE_CONFIG_KEYS = {
   tx_fees: { section: 'POLICY', field: 'tx_fees' },
   tx_fees_factor: { section: 'POLICY', field: 'tx_fees_factor' },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -249,13 +249,13 @@
       "label_num_collaborators": "Collaborators",
       "text_collaborative_tx_enabled": "Payment with privacy improvement",
       "text_collaborative_tx_disabled": "Payment without privacy improvement",
-      "label_estimated_max_collaborator_fee": "Estimated Max. Collaborator Fee",
+      "label_estimated_max_collaborator_fee": "Collaborator Fee",
       "text_estimated_max_collaborator_fee_info_popover": "This value represents a maximum upper limit. The actual fee is likely to be much lower.",
       "label_miner_fee": "Mining fee",
       "text_miner_fee_in_satspervbyte_exact": "{{ value }} sats/vByte",
       "text_miner_fee_in_satspervbyte_randomized": "{{ min }} - {{ max }} sats/vByte",
-      "text_miner_fee_in_targeted_blocks_one": "Next block",
-      "text_miner_fee_in_targeted_blocks_other": "In {{ count }} blocks"
+      "text_miner_fee_in_targeted_blocks_one": "High priority (next block)",
+      "text_miner_fee_in_targeted_blocks_other": "To be included in {{ count }} blocks or earlier"
     },
     "confirm_abort_modal": {
       "title": "Abort payment",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -251,7 +251,7 @@
       "text_collaborative_tx_disabled": "Payment without privacy improvement",
       "label_estimated_max_collaborator_fee": "Estimated Max. Collaborator Fee",
       "text_estimated_max_collaborator_fee_info_popover": "This value represents a maximum upper limit. The actual fee is likely to be much lower.",
-      "label_miner_fee": "Mining fee target",
+      "label_miner_fee": "Mining fee",
       "text_miner_fee_in_satspervbyte_exact": "{{ value }} sats/vByte",
       "text_miner_fee_in_satspervbyte_randomized": "{{ min }} - {{ max }} sats/vByte",
       "text_miner_fee_in_targeted_blocks_one": "Next block",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -248,7 +248,9 @@
       "text_source_jar": "Jar {{ jarId }}",
       "label_num_collaborators": "Collaborators",
       "text_collaborative_tx_enabled": "Payment with privacy improvement",
-      "text_collaborative_tx_disabled": "Payment without privacy improvement"
+      "text_collaborative_tx_disabled": "Payment without privacy improvement",
+      "label_estimated_max_collaborator_fee": "Estimated Max. Collaborator Fee",
+      "text_estimated_max_collaborator_fee_info_popover": "This value represents a maximum upper limit. The actual fee is likely to be much lower."
     },
     "confirm_abort_modal": {
       "title": "Abort payment",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -249,7 +249,7 @@
       "label_num_collaborators": "Collaborators",
       "text_collaborative_tx_enabled": "Payment with privacy improvement",
       "text_collaborative_tx_disabled": "Payment without privacy improvement",
-      "label_estimated_max_collaborator_fee": "Collaborator Fee",
+      "label_estimated_max_collaborator_fee": "Collaborator fee",
       "text_estimated_max_collaborator_fee_info_popover": "This value represents a maximum upper limit. The actual fee is likely to be much lower.",
       "label_miner_fee": "Mining fee",
       "text_miner_fee_in_satspervbyte_exact": "{{ value }} sats/vByte",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -254,8 +254,8 @@
       "label_miner_fee": "Mining fee target",
       "text_miner_fee_in_satspervbyte_exact": "{{ value }} sats/vByte",
       "text_miner_fee_in_satspervbyte_randomized": "{{ min }} - {{ max }} sats/vByte",
-      "text_miner_fee_in_targeted_blocks_one": "next block",
-      "text_miner_fee_in_targeted_blocks_other": "in {{ count }} blocks"
+      "text_miner_fee_in_targeted_blocks_one": "Next block",
+      "text_miner_fee_in_targeted_blocks_other": "In {{ count }} blocks"
     },
     "confirm_abort_modal": {
       "title": "Abort payment",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -250,7 +250,12 @@
       "text_collaborative_tx_enabled": "Payment with privacy improvement",
       "text_collaborative_tx_disabled": "Payment without privacy improvement",
       "label_estimated_max_collaborator_fee": "Estimated Max. Collaborator Fee",
-      "text_estimated_max_collaborator_fee_info_popover": "This value represents a maximum upper limit. The actual fee is likely to be much lower."
+      "text_estimated_max_collaborator_fee_info_popover": "This value represents a maximum upper limit. The actual fee is likely to be much lower.",
+      "label_miner_fee": "Mining fee target",
+      "text_miner_fee_in_satspervbyte_exact": "{{ value }} sats/vByte",
+      "text_miner_fee_in_satspervbyte_randomized": "{{ min }} - {{ max }} sats/vByte",
+      "text_miner_fee_in_targeted_blocks_one": "next block",
+      "text_miner_fee_in_targeted_blocks_other": "in {{ count }} blocks"
     },
     "confirm_abort_modal": {
       "title": "Abort payment",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -254,8 +254,8 @@
       "label_miner_fee": "Mining fee",
       "text_miner_fee_in_satspervbyte_exact": "{{ value }} sats/vByte",
       "text_miner_fee_in_satspervbyte_randomized": "{{ min }} - {{ max }} sats/vByte",
-      "text_miner_fee_in_targeted_blocks_one": "High priority (next block)",
-      "text_miner_fee_in_targeted_blocks_other": "To be included in {{ count }} blocks or earlier"
+      "text_miner_fee_in_targeted_blocks_one": "High priority estimate (next block)",
+      "text_miner_fee_in_targeted_blocks_other": "Using estimate for inclusion in next {{ count }} blocks"
     },
     "confirm_abort_modal": {
       "title": "Abort payment",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,3 +60,5 @@ export const factorToPercentage = (val: number, precision = 6) => {
   // but: ✓ Number((0.000027 * 100).toFixed(6)) = 0.0027
   return Number((val * 100).toFixed(precision))
 }
+
+export const isValidNumber = (val: number | undefined) => typeof val === 'number' && !isNaN(val)


### PR DESCRIPTION
Partly addresses #518.
Display values based on fee settings in the confirmation modal of the Send page.

"Mining fee target" will be displayed either as "targeted blocks" or "sats/vByte" (randomized or exact):
e.g.
- "Next block" (`tx_fees := 1`)
- "In 6 blocks" (`tx_fees := 6`)
- "In 1,000 blocks" (`tx_fees := 1000`)
- "1.001 sats/vByte" (`tx_fees := 1001`, `tx_fees_factor := 0`)
- "9.1 - 10.9 sats/vByte" (`tx_fees := 10000`, `tx_fees_factor := 0.9`)

"Estimated Max. Collaborator Fee" will be displayed for collaborative transactions.
Calculation can be found here: https://github.com/joinmarket-webui/jam/blob/feat/display-fee-settings-in-send/src/hooks/Fees.ts#L69-L70 (Tests: https://github.com/joinmarket-webui/jam/blob/feat/display-fee-settings-in-send/src/hooks/Fees.test.ts#L22-L69)

## :camera_flash: 
#### sats/vByte with randomization
<img src="https://user-images.githubusercontent.com/3358649/193833076-21253f65-3953-4af7-9211-8c3f86c3160f.png" width=400 />

#### sats/vByte exact
<img src="https://user-images.githubusercontent.com/3358649/193834820-3f7362c1-e2a7-44bb-a88b-5b2e4a5402fe.png" width=400 />

#### Targeted blocks
<img src="https://user-images.githubusercontent.com/3358649/193835046-5189ca24-db84-445e-b111-52a91573cfee.png" width=400 />
<img src="https://user-images.githubusercontent.com/3358649/193835379-6c09b888-2106-4a42-9603-406894ca7351.png" width=400 />

#### Collaborative transaction

<img src="https://user-images.githubusercontent.com/3358649/193836523-2f4c51dc-3f4b-4765-90d5-767f8517e943.png" width=400 />


