### PR TITLE
regtest: speed up scheduled sweep for testing

### DIFF
--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { Formik, useFormikContext } from 'formik'
@@ -17,8 +17,8 @@ import ScheduleProgress from './ScheduleProgress'
 
 import styles from './Jam.module.css'
 
-const DEST_ADDRESS_PROD = 3
-const DEST_ADDRESS_TEST = 1
+const DEST_ADDRESS_COUNT_PROD = 3
+const DEST_ADDRESS_COUNT_TEST = 1
 
 const addressValueKeys = (addressCount) =>
   Array(addressCount)
@@ -87,7 +87,7 @@ export default function Jam() {
 
   const [useInsecureTestingSettings, setUseInsecureTestingSettings] = useState(false)
   const addressCount = useMemo(
-    () => (useInsecureTestingSettings ? DEST_ADDRESS_TEST : DEST_ADDRESS_PROD),
+    () => (useInsecureTestingSettings ? DEST_ADDRESS_COUNT_TEST : DEST_ADDRESS_COUNT_PROD),
     [useInsecureTestingSettings]
   )
 
@@ -185,7 +185,7 @@ export default function Jam() {
         addrcount: addressCount,
         minmakercount: 1,
         makercountrange: [1, 0],
-        mixdepthcount: 2,
+        mixdepthcount: addressCount,
         mintxcount: 1,
         txcountparams: [1, 0],
         timelambda: 0.025, // 0.025 minutes := 1.5 seconds
@@ -359,19 +359,19 @@ export default function Jam() {
                                 setUseInsecureTestingSettings(isToggled)
                                 if (isToggled) {
                                   try {
-                                    const newAddresses = getNewAddresses(DEST_ADDRESS_TEST)
+                                    const newAddresses = getNewAddresses(DEST_ADDRESS_COUNT_TEST)
                                     newAddresses.forEach((newAddress, index) => {
                                       setFieldValue(`dest${index + 1}`, newAddress, true)
                                     })
                                   } catch (e) {
                                     console.error('Could not get internal addresses.', e)
 
-                                    addressValueKeys(DEST_ADDRESS_TEST).forEach((key) => {
+                                    addressValueKeys(DEST_ADDRESS_COUNT_TEST).forEach((key) => {
                                       setFieldValue(key, '', true)
                                     })
                                   }
                                 } else {
-                                  addressValueKeys(DEST_ADDRESS_PROD).forEach((key) => {
+                                  addressValueKeys(DEST_ADDRESS_COUNT_PROD).forEach((key) => {
                                     setFieldValue(key, '', false)
                                   })
                                 }

--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -17,19 +17,25 @@ import ScheduleProgress from './ScheduleProgress'
 
 import styles from './Jam.module.css'
 
-// When running the scheduler with internal destination addresses, the funds
-// will end up on those 3 mixdepths (one UTXO each).
-// Length of this array must be 3 for now.
-const INTERNAL_DEST_ACCOUNTS = [0, 1, 2]
+const DEST_ADDRESS_PROD = 3
+const DEST_ADDRESS_TEST = 1
 
-const ValuesListener = ({ handler }) => {
+const addressValueKeys = (addressCount) =>
+  Array(addressCount)
+    .fill('')
+    .map((_, index) => `dest${index + 1}`)
+
+const ValuesListener = ({ handler, addressCount }) => {
   const { values } = useFormikContext()
 
   useEffect(() => {
-    if (values.dest1 !== '' && values.dest2 !== '' && values.dest3 !== '') {
+    const allValuesPresent = addressValueKeys(addressCount)
+      .map((key) => values[key])
+      .every((val) => val !== '')
+    if (allValuesPresent) {
       handler()
     }
-  }, [values, handler])
+  }, [values, handler, addressCount])
 
   return null
 }
@@ -58,41 +64,38 @@ export default function Jam() {
   )
 
   // Returns one fresh address for each requested mixdepth.
-  const getNewAddressesForAccounts = useCallback(
-    (mixdepths) => {
-      if (mixdepths.length !== 3) {
-        throw new Error('Can only handle 3 destination addresses for now.')
-      }
+  const getNewAddresses = useCallback(
+    (count, mixdepth = 0) => {
       if (!walletInfo) {
         throw new Error('Wallet info is not available.')
       }
-      return mixdepths.map((mixdepth) => {
-        const externalBranch = walletInfo.data.display.walletinfo.accounts[mixdepth].branches.find((branch) => {
-          return branch.branch.split('\t')[0] === 'external addresses'
-        })
-
-        const newEntry = externalBranch.entries.find((entry) => entry.status === 'new')
-
-        if (!newEntry) {
-          throw new Error(`Cannot find a fresh address in mixdepth ${mixdepth}`)
-        }
-
-        return newEntry.address
+      const externalBranch = walletInfo.data.display.walletinfo.accounts[mixdepth].branches.find((branch) => {
+        return branch.branch.split('\t')[0] === 'external addresses'
       })
+
+      const newEntries = externalBranch.entries.filter((entry) => entry.status === 'new').slice(0, count)
+
+      if (newEntries.length !== count) {
+        throw new Error(`Cannot find enough fresh addresses in mixdepth ${mixdepth}`)
+      }
+
+      return newEntries.map((it) => it.address)
     },
     [walletInfo]
   )
 
   const [useInsecureTestingSettings, setUseInsecureTestingSettings] = useState(false)
+  const addressCount = useMemo(
+    () => (useInsecureTestingSettings ? DEST_ADDRESS_TEST : DEST_ADDRESS_PROD),
+    [useInsecureTestingSettings]
+  )
 
   const initialFormValues = useMemo(() => {
-    const addressCount = 3
-
     let destinationAddresses = Array(addressCount).fill('')
     if (useInsecureTestingSettings) {
       try {
         // prefill with addresses marked as "new"
-        destinationAddresses = getNewAddressesForAccounts(INTERNAL_DEST_ACCOUNTS)
+        destinationAddresses = getNewAddresses(addressCount)
       } catch (e) {
         // on error initialize with empty addresses - form validation will do the rest
         destinationAddresses = Array(addressCount).fill('')
@@ -100,7 +103,7 @@ export default function Jam() {
     }
 
     return destinationAddresses.reduce((obj, addr, index) => ({ ...obj, [`dest${index + 1}`]: addr }), {})
-  }, [useInsecureTestingSettings, getNewAddressesForAccounts])
+  }, [addressCount, useInsecureTestingSettings, getNewAddresses])
 
   useEffect(() => {
     const abortCtrl = new AbortController()
@@ -143,23 +146,25 @@ export default function Jam() {
     setIsLoading(true)
     setIsWaitingSchedulerStart(true)
 
-    const destinations = [values.dest1, values.dest2, values.dest3]
+    const destinations = addressValueKeys(addressCount).map((key) => values[key])
 
     const body = { destination_addresses: destinations }
 
     // Make sure schedule testing is really only used in dev mode.
     if (isDebugFeatureEnabled('insecureScheduleTesting') && useInsecureTestingSettings) {
+      // for a proper description of all parameters see
+      // https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.9.8/jmclient/jmclient/cli_options.py#L268
       body.tumbler_options = {
-        addrcount: 3,
+        addrcount: addressCount,
         minmakercount: 1,
         makercountrange: [1, 0],
-        mixdepthcount: 3,
-        mintxcount: 2,
-        txcountparams: [1, 1],
-        timelambda: 0.1,
+        mixdepthcount: 2,
+        mintxcount: 1,
+        txcountparams: [1, 0],
+        timelambda: 0.000001, // zero not allowed, set as low as possible
         stage1_timelambda_increase: 1.0,
         liquiditywait: 10,
-        waittime: 1.0,
+        waittime: 0.0,
       }
     }
 
@@ -286,15 +291,12 @@ export default function Jam() {
                   return alreadyUsed || duplicateEntry
                 }
 
-                const addressDict = Array(3)
-                  .fill('')
-                  .map((_, index) => {
-                    const key = `dest${index + 1}`
-                    return {
-                      key,
-                      address: values[key],
-                    }
-                  })
+                const addressDict = addressValueKeys(addressCount).map((key) => {
+                  return {
+                    key,
+                    address: values[key],
+                  }
+                })
                 const addresses = addressDict.map((it) => it.address)
 
                 addressDict.forEach((addressEntry) => {
@@ -329,7 +331,7 @@ export default function Jam() {
                 errors,
               }) => (
                 <>
-                  <ValuesListener handler={validateForm} />
+                  <ValuesListener handler={validateForm} addressCount={addressCount} />
                   <rb.Form onSubmit={handleSubmit} noValidate>
                     {!collaborativeOperationRunning && (
                       <>
@@ -345,20 +347,24 @@ export default function Jam() {
                                 setUseInsecureTestingSettings(isToggled)
                                 if (isToggled) {
                                   try {
-                                    const newAddresses = getNewAddressesForAccounts(INTERNAL_DEST_ACCOUNTS)
-                                    setFieldValue('dest1', newAddresses[0], true)
-                                    setFieldValue('dest2', newAddresses[1], true)
-                                    setFieldValue('dest3', newAddresses[2], true)
+                                    const newAddresses = getNewAddresses(DEST_ADDRESS_TEST)
+                                    newAddresses.forEach((newAddress, index) => {
+                                      setFieldValue(`dest${index + 1}`, newAddress, true)
+                                    })
                                   } catch (e) {
                                     console.error('Could not get internal addresses.', e)
-                                    setFieldValue('dest1', '', true)
-                                    setFieldValue('dest2', '', true)
-                                    setFieldValue('dest3', '', true)
+                                    Array(DEST_ADDRESS_TEST)
+                                      .fill('')
+                                      .forEach((blank, index) => {
+                                        setFieldValue(`dest${index + 1}`, blank, true)
+                                      })
                                   }
                                 } else {
-                                  setFieldValue('dest1', '', false)
-                                  setFieldValue('dest2', '', false)
-                                  setFieldValue('dest3', '', false)
+                                  Array(DEST_ADDRESS_PROD)
+                                    .fill('')
+                                    .forEach((blank, index) => {
+                                      setFieldValue(`dest${index + 1}`, blank, false)
+                                    })
                                 }
                               }}
                               disabled={isSubmitting}
@@ -368,20 +374,22 @@ export default function Jam() {
                       </>
                     )}
                     {!collaborativeOperationRunning &&
-                      [1, 2, 3].map((i) => {
+                      addressValueKeys(addressCount).map((key, index) => {
                         return (
-                          <rb.Form.Group className="mb-4" key={i} controlId={`dest${i}`}>
-                            <rb.Form.Label>{t('scheduler.label_destination_input', { destination: i })}</rb.Form.Label>
+                          <rb.Form.Group className="mb-4" key={key} controlId={key}>
+                            <rb.Form.Label>
+                              {t('scheduler.label_destination_input', { destination: index + 1 })}
+                            </rb.Form.Label>
                             <rb.Form.Control
-                              name={`dest${i}`}
-                              value={values[`dest${i}`]}
+                              name={key}
+                              value={values[key]}
                               placeholder={t('scheduler.placeholder_destination_input')}
                               onChange={handleChange}
                               onBlur={handleBlur}
-                              isInvalid={touched[`dest${i}`] && !!errors[`dest${i}`]}
+                              isInvalid={touched[key] && !!errors[key]}
                               className={`${styles.input} slashed-zeroes`}
                             />
-                            <rb.Form.Control.Feedback type="invalid">{errors[`dest${i}`]}</rb.Form.Control.Feedback>
+                            <rb.Form.Control.Feedback type="invalid">{errors[key]}</rb.Form.Control.Feedback>
                           </rb.Form.Group>
                         )
                       })}

--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -188,7 +188,7 @@ export default function Jam() {
         mixdepthcount: 2,
         mintxcount: 1,
         txcountparams: [1, 0],
-        timelambda: 0.000001, // zero not allowed, set as low as possible
+        timelambda: 0.025, // 0.025 minutes := 1.5 seconds
         stage1_timelambda_increase: 1.0,
         liquiditywait: 10,
         waittime: 0.0,
@@ -365,18 +365,15 @@ export default function Jam() {
                                     })
                                   } catch (e) {
                                     console.error('Could not get internal addresses.', e)
-                                    Array(DEST_ADDRESS_TEST)
-                                      .fill('')
-                                      .forEach((blank, index) => {
-                                        setFieldValue(`dest${index + 1}`, blank, true)
-                                      })
+
+                                    addressValueKeys(DEST_ADDRESS_TEST).forEach((key) => {
+                                      setFieldValue(key, '', true)
+                                    })
                                   }
                                 } else {
-                                  Array(DEST_ADDRESS_PROD)
-                                    .fill('')
-                                    .forEach((blank, index) => {
-                                      setFieldValue(`dest${index + 1}`, blank, false)
-                                    })
+                                  addressValueKeys(DEST_ADDRESS_PROD).forEach((key) => {
+                                    setFieldValue(key, '', false)
+                                  })
                                 }
                               }}
                               disabled={isSubmitting}


### PR DESCRIPTION
Was able to reduce the time from >=10min to ~3min for scheduled sweeps.
This is achieved by adapting the "test mode" settings:
- reducing destination addresses from 3 to 1
- reducing the time between transactions
- reducing minimum transaction count per Jar from 2 to 1

```
2022-10-04 07:54:30,991 [DEBUG]  connection was made, starting client.
[...]
2022-10-04 07:57:58,889 [INFO]  Coinjoin completed correctly
```


Example schedule:
```
[
  [0, 0, 1, "INTERNAL", 0.05, 16, 0], 
  [1, 0, 1, "bcrt1qc8s0d5cnhkqyp4fae7epj4up36sjz8gtvp7ru6", 0.03, 16, 0]
]
```

Destination address count can be adapted by changing the `DEST_ADDRESS_COUNT_TEST` constant.

### How to test
Invoke a sweep and verify that ~2 transactions (instead of ~6) are scheduled in quick succession.
If everything works correctly, the operation should take no longer than 5mins.
Pro top: Mine 5 blocks at once with `npm run regtest:mine 5`  while sweeping.