### PR TITLE
fix(fees): mitigate construction of non-forwardable transactions

### DIFF
--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useRef, useCallback, useEffect, useState } from 'react'
 import * as rb from 'react-bootstrap'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { Formik, FormikErrors } from 'formik'
 import classNames from 'classnames'
 import { FEE_CONFIG_KEYS, TxFeeValueUnit, toTxFeeValueUnit, FeeValues, useLoadFeeConfigValues } from '../../hooks/Fees'
@@ -482,7 +482,20 @@ export default function FeeConfigModal({ show, onHide }: FeeConfigModalProps) {
       </rb.Modal.Header>
       <rb.Modal.Body>
         <>
-          <div className="mb-4 small">{t('settings.fees.description')}</div>
+          <div className="mb-4 small">
+            <Trans i18nKey="settings.fees.description">
+              Fee description. See
+              <a
+                href="https://jamdocs.org/market/fees/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="link-dark"
+              >
+                this link
+              </a>
+              for more information.
+            </Trans>
+          </div>
           {loadError && (
             <rb.Alert variant="danger" className="w-100">
               {t('settings.fees.error_loading_fee_config_failed')}

--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -24,7 +24,7 @@ const TX_FEES_BLOCKS_MAX = 1_000
  * See https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1360#issuecomment-1262295463
  * Last checked on 2022-10-06.
  */
-const TX_FEES_SATSPERKILOVBYTE_MIN: SatsPerKiloVByte = 2_000 // 2 sat/vbyte
+const TX_FEES_SATSPERKILOVBYTE_MIN: SatsPerKiloVByte = 3_000 // 3 sat/vbyte
 // 350 sats/vbyte - no enforcement by JM - this should be a "sane" max value (taken default value of "absurd_fee_per_kb")
 const TX_FEES_SATSPERKILOVBYTE_MAX: SatsPerKiloVByte = 350_000
 const TX_FEES_SATSPERKILOVBYTE_ADJUSTED_MIN = 1_001 // actual min of `tx_fees` if unit is sats/kilo-vbyte

--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -32,7 +32,7 @@ const TX_FEES_FACTOR_MIN = 0 // 0%
 /**
  * For the same reasons as stated above (comment for `TX_FEES_SATSPERKILOVBYTE_MIN`),
  * the maximum randomization factor must not be too high.
- * Settling on 50% as a reasonable compromise this the problem is addressed.
+ * Settling on 50% as a reasonable compromise until this problem is addressed.
  * Once resolved, this can be set to 100% again.
  */
 const TX_FEES_FACTOR_MAX = 0.5 // 50%

--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -14,12 +14,28 @@ type SatsPerKiloVByte = number
 
 const TX_FEES_BLOCKS_MIN = 1
 const TX_FEES_BLOCKS_MAX = 1_000
-const TX_FEES_SATSPERKILOVBYTE_MIN: SatsPerKiloVByte = 1_000 // 1 sat/vbyte
+
+/**
+ * When the fee target is low, JM sometimes constructs transactions, which are
+ * declined from being relayed. In order to mitigate such situations, the
+ * minimum fee target (when provided in sats/vbyte) must be higher than
+ * 1 sats/vbyte, till the problem is addressed. Once resolved, this
+ * can be lowered to 1 sats/vbyte again.
+ * See https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1360#issuecomment-1262295463
+ * Last checked on 2022-10-06.
+ */
+const TX_FEES_SATSPERKILOVBYTE_MIN: SatsPerKiloVByte = 2_000 // 2 sat/vbyte
 // 350 sats/vbyte - no enforcement by JM - this should be a "sane" max value (taken default value of "absurd_fee_per_kb")
 const TX_FEES_SATSPERKILOVBYTE_MAX: SatsPerKiloVByte = 350_000
 const TX_FEES_SATSPERKILOVBYTE_ADJUSTED_MIN = 1_001 // actual min of `tx_fees` if unit is sats/kilo-vbyte
 const TX_FEES_FACTOR_MIN = 0 // 0%
-const TX_FEES_FACTOR_MAX = 1 // 100%
+/**
+ * For the same reasons as stated above (comment for `TX_FEES_SATSPERKILOVBYTE_MIN`),
+ * the maximum randomization factor must not be too high.
+ * Settling on 50% as a reasonable compromise this the problem is addressed.
+ * Once resolved, this can be set to 100% again.
+ */
+const TX_FEES_FACTOR_MAX = 0.5 // 50%
 const CJ_FEE_ABS_MIN = 1
 const CJ_FEE_ABS_MAX = 1_000_000 // 0.01 BTC - no enforcement by JM - this should be a "sane" max value
 const CJ_FEE_REL_MIN = 0.000001 // 0.0001%

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -172,7 +172,7 @@
     "confirm_locking_modal_body_jam": "A collaborative transaction is being executed. Locking the wallet will stop the service. You can close the browser window to let it run in the background.",
     "fees": {
       "title": "Fee Limits",
-      "description": "Adjust mining fees and collaborator fees according to your needs. Mining fees relate to transaction priority and depend on mempool conditions. Collaborator fees relate to liquidity price and depend on market conditions. Total fees paid for each transaction depend on the amount of collaborators. Additional collaborators increase privacy, but also fees. These settings will be reset to default values when the JoinMarket service restarts, e.g. on a system reboot.",
+      "description": "Adjust mining fees and collaborator fees according to your needs. Mining fees relate to transaction priority and depend on mempool conditions. Collaborator fees relate to liquidity price and depend on market conditions. Total fees paid for each transaction depend on the amount of collaborators. Additional collaborators increase privacy, but also fees. These settings will be reset to default values when the JoinMarket service restarts, e.g. on a system reboot. For more information, <1>see the documentation on fees</1>.",
       "title_general_fee_settings": "Mining fees",
       "radio_tx_fees_blocks": "Block target",
       "radio_tx_fees_satspervbyte": "sats/vByte",


### PR DESCRIPTION
When the fee target is low, JM sometimes constructs transactions, which are declined from being relayed. In order to mitigate such situations, the minimum fee target (when provided in sats/vbyte) has been increased from 1 sat/vByte to 3 sats/vByte, and fee randomization lowered from 0 - 100% to 0 - 50%.

This can only mitigate the problem and should be seen as a temporary solution till the situation has been addressed upstream.

See https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1360#issuecomment-1259638764 and https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1360#issuecomment-1262295463