### PR TITLE
feat: Show jar total amount in detail view

### DIFF
--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -75,26 +75,6 @@
   background-color: var(--bs-gray-800);
 }
 
-.overlayContainer .tabContainer .utxoListTitleBar .operationsContainer {
-  display: flex;
-  width: 100%;
-  justify-content: space-between;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.5rem;
-}
-
-.selectedUtxosSumContainer {
-  align-self: end;
-}
-
-@media only screen and (min-width: 576px) {
-  .overlayContainer .tabContainer .utxoListTitleBar .operationsContainer {
-    flex-direction: row;
-    align-items: center;
-  }
-}
-
 .overlayContainer .tabContainer .utxoListTitleBar .freezeUnfreezeButtonsContainer {
   display: flex;
   flex-direction: row;

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -367,15 +367,17 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                           </Trans>
                         </div>
                       </div>
-                      <div className={styles.operationsContainer}>
+                      <div className="d-flex justify-content-between align-items-center w-100 flex-sm-row flex-column gap-2">
                         {utxos.length > 0 && (
-                          <div className={styles.freezeUnfreezeButtonsContainer}>
-                            {freezeUnfreezeButton({ freeze: true })}
-                            {freezeUnfreezeButton({ freeze: false })}
+                          <div className="order-1 order-sm-0">
+                            <div className={styles.freezeUnfreezeButtonsContainer}>
+                              {freezeUnfreezeButton({ freeze: true })}
+                              {freezeUnfreezeButton({ freeze: false })}
+                            </div>
                           </div>
                         )}
                         {selectedUtxosBalance > 0 && (
-                          <div className={styles.selectedUtxosSumContainer}>
+                          <div className="order-0 order-sm-1">
                             <Trans i18nKey="jar_details.utxo_list.text_balance_sum_selected">
                               <Balance
                                 valueString={String(selectedUtxosBalance)}

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -358,7 +358,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                           {utxoListTitle()}
                         </div>
                         <div>
-                          <Trans i18nKey="jar_details.total_label">
+                          <Trans i18nKey="jar_details.utxo_list.text_balance_sum_total">
                             <Balance
                               valueString={jar.account_balance}
                               convertToUnit={settings.unit}

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -352,9 +352,20 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                 {selectedTab === TABS.UTXOS ? (
                   <>
                     <div className={styles.utxoListTitleBar}>
-                      <div className="d-flex justify-content-center align-items-center gap-2">
-                        {refreshButton()}
-                        {utxoListTitle()}
+                      <div className="d-flex justify-content-between align-items-center w-100 flex-sm-row flex-column">
+                        <div className="d-flex justify-content-center align-items-center gap-2">
+                          {refreshButton()}
+                          {utxoListTitle()}
+                        </div>
+                        <div>
+                          <Trans i18nKey="jar_details.total_label">
+                            <Balance
+                              valueString={jar.account_balance}
+                              convertToUnit={settings.unit}
+                              showBalance={settings.showBalance}
+                            />
+                          </Trans>
+                        </div>
                       </div>
                       <div className={styles.operationsContainer}>
                         {utxos.length > 0 && (

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -554,6 +554,7 @@
   "jar_details": {
     "title_tab_utxos": "UTXOs",
     "title_tab_jar_details": "Details",
+    "total_label": "<0></0> total",
     "utxo_list": {
       "title_zero": "No UTXOs in Jar {{ jar }}",
       "title_one": "{{ count }} UTXO in Jar {{ jar }}",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -554,11 +554,11 @@
   "jar_details": {
     "title_tab_utxos": "UTXOs",
     "title_tab_jar_details": "Details",
-    "total_label": "<0></0> total",
     "utxo_list": {
       "title_zero": "No UTXOs in Jar {{ jar }}",
       "title_one": "{{ count }} UTXO in Jar {{ jar }}",
       "title_other": "{{ count }} UTXOs in Jar {{ jar }}",
+      "text_balance_sum_total": "<0></0> total",
       "text_balance_sum_selected": "<0></0> selected",
       "button_freeze": "Freeze",
       "button_unfreeze": "Unfreeze",


### PR DESCRIPTION
Closes #517.
 I added total balance next to the tab selector so that it will be always visible.

<img width="1359" alt="Screenshot 2022-10-26 at 12 10 57" src="https://user-images.githubusercontent.com/36515569/197999846-27e58439-e92c-459f-897b-dc0a497095b2.png">
