### PR TITLE
feat: quickly review/adapt fee settings before sweeping

### DIFF
--- a/src/components/Jam.jsx
+++ b/src/components/Jam.jsx
@@ -14,6 +14,7 @@ import ToggleSwitch from './ToggleSwitch'
 import Sprite from './Sprite'
 import Balance from './Balance'
 import ScheduleProgress from './ScheduleProgress'
+import FeeConfigModal from './settings/FeeConfigModal'
 
 import styles from './Jam.module.css'
 
@@ -50,6 +51,7 @@ export default function Jam({ wallet }) {
 
   const [alert, setAlert] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [showingFeeConfig, setShowingFeeConfig] = useState(false)
   const [schedule, setSchedule] = useState(null)
   const [isWaitingSchedulerStart, setIsWaitingSchedulerStart] = useState(false)
   const [isWaitingSchedulerStop, setIsWaitingSchedulerStop] = useState(false)
@@ -421,6 +423,22 @@ export default function Jam({ wallet }) {
                       )}
                     </Formik>
                   )}
+
+                  <rb.Row className="mt-5 mb-3">
+                    <rb.Col className="d-flex justify-content-center">
+                      <rb.Button
+                        variant="outline-dark"
+                        className="border-0 mb-2 d-inline-flex align-items-center"
+                        onClick={() => setShowingFeeConfig(true)}
+                      >
+                        <Sprite symbol="coins" width="24" height="24" className="me-1" />
+                        {t('settings.show_fee_config')}
+                      </rb.Button>
+                      {showingFeeConfig && (
+                        <FeeConfigModal show={showingFeeConfig} onHide={() => setShowingFeeConfig(false)} />
+                      )}
+                    </rb.Col>
+                  </rb.Row>
                 </>
               )}
             </>


### PR DESCRIPTION
Closes  #542.

This PR adds a button to quickly adapt the fee settings before sweeping.
Fee settings are randomized on every startup, so this can serve as a hint to review and/or adapt them before doing a sweep.

@editwentyone This is just a suggestion. Please close if you think it is redundant.

<img src="https://user-images.githubusercontent.com/3358649/200137579-b678ee48-2081-44bc-aa9f-3f6051f9913c.png" width=300 /> <img src="https://user-images.githubusercontent.com/3358649/200137604-d19df5af-7ca2-4242-ae4c-84a515b1cd08.png" width=300 />
