### PR TITLE
ui: improve all overlay content on small screens

### DIFF
--- a/src/components/EarnReport.module.css
+++ b/src/components/EarnReport.module.css
@@ -6,12 +6,13 @@
 .overlayContainer .earnReportContainer {
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 0.5rem;
   background-color: var(--bs-body-bg);
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 992px) {
   .overlayContainer .earnReportContainer {
+    gap: 1.5rem;
     padding: 2rem;
     border-radius: 0.5rem;
   }
@@ -24,25 +25,25 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 0.5rem;
-  padding: 0 0 0.8rem 0;
+  padding: 0 0.5rem 0.8rem 0.5rem;
   background-color: var(--bs-gray-100);
 }
 
-@media only screen and (min-width: 768px) {
-  .overlayContainer .earnReportContainer > .titleBar {
-    align-items: center;
+@media only screen and (min-width: 992px) {
+  .overlayContainer .earnReportContainer .titleBar {
     padding: 0.8rem 1rem;
     border-radius: 0.6rem;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .overlayContainer .earnReportContainer > .titleBar {
+  .overlayContainer .earnReportContainer .titleBar {
+    align-items: center;
     flex-direction: row;
   }
 }
 
-:root[data-theme='dark'] .overlayContainer .earnReportContainer > .titleBar {
+:root[data-theme='dark'] .overlayContainer .earnReportContainer .titleBar {
   background-color: var(--bs-gray-800);
 }
 

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -168,6 +168,7 @@ const EarnReportTable = ({ data }: EarnReportTableProps) => {
         pagination={pagination}
         sort={tableSort}
         layout={{ custom: true, horizontalScroll: true }}
+        className="table striped"
       >
         {(tableList) => (
           <>

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -223,7 +223,7 @@ const EarnReportTable = ({ data }: EarnReportTableProps) => {
           </>
         )}
       </Table>
-      <div className="mt-4 mb-4 mb-md-0">
+      <div className="mt-4 mb-4 mb-lg-0">
         <TablePagination data={data} pagination={pagination} />
       </div>
     </>
@@ -389,7 +389,7 @@ export function EarnReportOverlay({ show, onHide }: rb.OffcanvasProps) {
       placement="bottom"
     >
       <rb.Offcanvas.Header>
-        <rb.Container>
+        <rb.Container fluid="lg">
           <div className="w-100 d-flex">
             <div className="d-flex align-items-center flex-1">
               <rb.Offcanvas.Title>{t('earn.report.title')}</rb.Offcanvas.Title>
@@ -403,7 +403,7 @@ export function EarnReportOverlay({ show, onHide }: rb.OffcanvasProps) {
         </rb.Container>
       </rb.Offcanvas.Header>
       <rb.Offcanvas.Body>
-        <rb.Container fluid="md" className="py-4 py-sm-5">
+        <rb.Container fluid="lg" className="py-3">
           {!isInitialized && isLoading ? (
             Array(5)
               .fill('')
@@ -419,7 +419,7 @@ export function EarnReportOverlay({ show, onHide }: rb.OffcanvasProps) {
               {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}
               {entries && (
                 <rb.Row>
-                  <rb.Col>
+                  <rb.Col className="px-0">
                     <EarnReport entries={entries} refresh={refresh} />
                   </rb.Col>
                 </rb.Row>

--- a/src/components/LogOverlay.module.css
+++ b/src/components/LogOverlay.module.css
@@ -6,31 +6,31 @@
 .overlayContainer .logContentContainer {
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 0.5rem;
   background-color: var(--bs-body-bg);
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 992px) {
   .overlayContainer .logContentContainer {
+    gap: 1.5rem;
     padding: 2rem;
     border-radius: 0.5rem;
   }
 }
 
-.overlayContainer .logContentContainer > .titleBar {
+.overlayContainer .logContentContainer .titleBar {
   min-height: 3.6rem;
   display: flex;
   justify-content: space-between;
   flex-direction: column;
   align-items: flex-start;
   gap: 0.5rem;
-  padding: 0 0 0.8rem 0;
+  padding: 0 0.5rem 0.8rem 0.5rem;
   background-color: var(--bs-gray-100);
 }
 
-@media only screen and (min-width: 768px) {
-  .overlayContainer .logContentContainer > .titleBar {
-    align-items: center;
+@media only screen and (min-width: 992px) {
+  .overlayContainer .logContentContainer .titleBar {
     padding: 0.8rem 1rem;
     border-radius: 0.6rem;
   }
@@ -38,15 +38,16 @@
 
 @media only screen and (min-width: 768px) {
   .overlayContainer .logContentContainer > .titleBar {
+    align-items: center;
     flex-direction: row;
   }
 }
 
-:root[data-theme='dark'] .overlayContainer .logContentContainer > .titleBar {
+:root[data-theme='dark'] .overlayContainer .logContentContainer .titleBar {
   background-color: var(--bs-gray-800);
 }
 
-.overlayContainer .logContentContainer > .titleBar .refreshButton {
+.overlayContainer .logContentContainer .titleBar .refreshButton {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -58,6 +59,6 @@
 
 .logContent {
   min-height: 300px;
-  max-height: 50vh;
+  max-height: 60vh;
   overflow: scroll;
 }

--- a/src/components/LogOverlay.tsx
+++ b/src/components/LogOverlay.tsx
@@ -57,7 +57,7 @@ export function LogContent({ content, refresh }: LogContentProps) {
           </rb.Button>
         </div>
       </div>
-      <div className="px-md-3 pb-2">
+      <div className="py-2 px-2">
         <pre ref={logContentRef} className={styles.logContent}>
           {content}
         </pre>
@@ -123,7 +123,7 @@ export function LogOverlay({ currentWallet, show, onHide }: LogOverlayProps) {
       placement="bottom"
     >
       <rb.Offcanvas.Header>
-        <rb.Container>
+        <rb.Container fluid="lg">
           <div className="w-100 d-flex">
             <div className="d-flex align-items-center flex-1">
               <rb.Offcanvas.Title>{t('logs.title')}</rb.Offcanvas.Title>
@@ -137,7 +137,7 @@ export function LogOverlay({ currentWallet, show, onHide }: LogOverlayProps) {
         </rb.Container>
       </rb.Offcanvas.Header>
       <rb.Offcanvas.Body>
-        <rb.Container fluid="md" className="py-4 py-sm-5">
+        <rb.Container fluid="lg" className="py-3">
           {!isInitialized && isLoading ? (
             Array(12)
               .fill('')
@@ -153,7 +153,7 @@ export function LogOverlay({ currentWallet, show, onHide }: LogOverlayProps) {
               {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}
               {content && (
                 <rb.Row>
-                  <rb.Col>
+                  <rb.Col className="px-0">
                     <LogContent content={content} refresh={refresh} />
                   </rb.Col>
                 </rb.Row>

--- a/src/components/Orderbook.module.css
+++ b/src/components/Orderbook.module.css
@@ -43,7 +43,7 @@
   }
 }
 
-:root[data-theme='dark'] .overlayContainer .orderbookContainer > .titleBar {
+:root[data-theme='dark'] .overlayContainer .orderbookContainer .titleBar {
   background-color: var(--bs-gray-800);
 }
 

--- a/src/components/Orderbook.module.css
+++ b/src/components/Orderbook.module.css
@@ -57,20 +57,6 @@
   border: none;
 }
 
-.orderbookContainer tr:nth-child(2n) td {
-  background-color: var(--bs-gray-100);
-}
-:root[data-theme='dark'] .orderbookContainer tr:nth-child(2n) td {
-  background-color: var(--bs-gray-800);
-}
-
-.orderbookContainer tr:hover td {
-  background-color: var(--bs-gray-200) !important;
-}
-:root[data-theme='dark'] tr:hover td {
-  background-color: var(--bs-gray-700) !important;
-}
-
 .orderbookContainer tr.highlighted td {
   background-color: rgba(var(--bs-success-rgb), 0.33) !important;
 }

--- a/src/components/Orderbook.tsx
+++ b/src/components/Orderbook.tsx
@@ -179,6 +179,7 @@ const OrderbookTable = ({ data }: OrderbookTableProps) => {
         pagination={pagination}
         sort={tableSort}
         layout={{ custom: true, horizontalScroll: true }}
+        className="table striped"
       >
         {(tableList) => (
           <>

--- a/src/index.css
+++ b/src/index.css
@@ -329,8 +329,22 @@ main {
   background-color: var(--bs-gray-800);
 }
 
-/* Navbar Styles */
+/* Table Styles */
+table.striped tr:nth-child(2n) td {
+  background-color: var(--bs-gray-100);
+}
+:root[data-theme='dark'] table.striped tr:nth-child(2n) td {
+  background-color: var(--bs-gray-800);
+}
 
+table.striped tr:hover td {
+  background-color: var(--bs-gray-200) !important;
+}
+:root[data-theme='dark'] table.striped tr:hover td {
+  background-color: var(--bs-gray-700) !important;
+}
+
+/* Navbar Styles */
 #mainNav .nav-link {
   font-weight: 600 !important;
 }


### PR DESCRIPTION
Changes:
- Striped table rows on Earn Report
- Improved mobile view for Earn Report
- Improved mobile view for Log Overlay

All fullscreen overlays (JarDetails, Orderbook, Earn Report, Log Overlay) should now have identical styles on mobile devices and small screens.
Still quite a bit duplicate code - this has not been refactored in this PR.

## :camera_flash: Before/After

![image](https://user-images.githubusercontent.com/3358649/200381989-04995ba9-7164-458d-b87a-cff23551aa3f.png)

![image](https://user-images.githubusercontent.com/3358649/200381579-efb6f83d-36d1-4e6b-95dd-47556d9a6d68.png)

### How to test
To test the Log Overlay changes, you need to start the UI with `npm run dev:start:secondary`!
To test the Earn Report and see the changes, your need to start the maker at least twice (to get two rows in the report).