### PR TITLE
fix: no. of collaborators as integer

### DIFF
--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -85,32 +85,22 @@ const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators, minNumCo
   }
 
   return (
-    <rb.Form noValidate className={styles['collaborators-selector']} disabled={disabled}>
+    <rb.Form noValidate className={styles.collaboratorsSelector} disabled={disabled}>
       <rb.Form.Group>
         <rb.Form.Label className="mb-0">{t('send.label_num_collaborators', { numCollaborators })}</rb.Form.Label>
         <div className="mb-2">
           <rb.Form.Text className="text-secondary">{t('send.description_num_collaborators')}</rb.Form.Text>
         </div>
-        <div className={`${styles['collaborators-selector-flex']} d-flex flex-row flex-wrap`}>
+        <div className="d-flex flex-row flex-wrap gap-2">
           {defaultCollaboratorsSelection.map((number) => {
+            const isSelected = !usesCustomNumCollaborators && numCollaborators === number
             return (
               <rb.Button
                 key={number}
                 variant={settings.theme === 'light' ? 'white' : 'dark'}
-                className={classNames(
-                  styles['collaborators-selector-button'],
-                  'p-2',
-                  'border',
-                  'border-1',
-                  'rounded',
-                  'text-center',
-                  {
-                    'border-dark':
-                      !usesCustomNumCollaborators && numCollaborators === number && settings.theme === 'light',
-                    [styles['selected-dark']]:
-                      !usesCustomNumCollaborators && numCollaborators === number && settings.theme !== 'light',
-                  }
-                )}
+                className={classNames(styles.collaboratorsSelectorElement, 'border', 'border-1', {
+                  [styles.selected]: isSelected,
+                })}
                 onClick={() => {
                   setUsesCustomNumCollaborators(false)
                   setNumCollaborators(number)
@@ -128,18 +118,9 @@ const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators, minNumCo
             isInvalid={!isValidNumCollaborators(numCollaborators, minNumCollaborators)}
             placeholder={t('send.input_num_collaborators_placeholder')}
             defaultValue=""
-            className={classNames(
-              styles['collaborators-selector-input'],
-              'p-2',
-              'border',
-              'border-1',
-              'rounded',
-              'text-center',
-              {
-                'border-dark': usesCustomNumCollaborators && settings.theme === 'light',
-                [styles['selected-dark']]: usesCustomNumCollaborators && settings.theme !== 'light',
-              }
-            )}
+            className={classNames(styles.collaboratorsSelectorElement, 'border', 'border-1', {
+              [styles.selected]: usesCustomNumCollaborators,
+            })}
             onChange={(e) => {
               setUsesCustomNumCollaborators(true)
               validateAndSetCustomNumCollaborators(e.target.value)

--- a/src/components/Send.jsx
+++ b/src/components/Send.jsx
@@ -70,17 +70,18 @@ const CollaboratorsSelector = ({ numCollaborators, setNumCollaborators, minNumCo
 
   const [usesCustomNumCollaborators, setUsesCustomNumCollaborators] = useState(false)
 
+  const defaultCollaboratorsSelection = useMemo(() => {
+    const start = Math.max(minNumCollaborators, 8)
+    return [start, start + 1, start + 2]
+  }, [minNumCollaborators])
+
   const validateAndSetCustomNumCollaborators = (candidate) => {
-    if (isValidNumCollaborators(candidate, minNumCollaborators)) {
-      setNumCollaborators(candidate)
+    const parsed = parseInt(candidate, 10)
+    if (isValidNumCollaborators(parsed, minNumCollaborators)) {
+      setNumCollaborators(parsed)
     } else {
       setNumCollaborators(null)
     }
-  }
-
-  var defaultCollaboratorsSelection = [8, 9, 10]
-  if (minNumCollaborators > 8) {
-    defaultCollaboratorsSelection = [minNumCollaborators, minNumCollaborators + 1, minNumCollaborators + 2]
   }
 
   return (

--- a/src/components/Send.module.css
+++ b/src/components/Send.module.css
@@ -113,28 +113,26 @@ input[type='number'] {
   width: 100%;
 }
 
-.collaborators-selector-button {
+.collaboratorsSelectorElement {
   min-width: 6rem;
   flex: 1;
+  padding: 0.5rem;
+  text-align: center;
+  border-radius: var(--bs-border-radius);
 }
 
-.collaborators-selector-input {
-  min-width: 6rem;
-  flex: 1;
-}
-
-:root[data-theme='dark'] .collaborators-selector-input {
+:root[data-theme='dark'] input.collaboratorsSelectorElement {
   background-color: var(--bs-gray-800);
   color: var(--bs-white);
 }
 
-:root[data-theme='dark'] .collaborators-selector .selected-dark {
-  background-color: var(--bs-gray-dark);
-  border-color: var(--bs-gray-dark) !important;
+.collaboratorsSelectorElement.selected {
+  border-color: var(--bs-dark-rgb) !important;
 }
 
-.collaborators-selector-flex {
-  gap: 0.5rem;
+:root[data-theme='dark'] .collaboratorsSelectorElement.selected {
+  background-color: var(--bs-gray-dark);
+  border-color: var(--bs-gray-dark) !important;
 }
 
 .input-loader {
@@ -146,7 +144,7 @@ input[type='number'] {
   filter: blur(2px);
 }
 
-.service-running .collaborators-selector {
+.service-running .collaboratorsSelector {
   filter: blur(2px);
 }
 


### PR DESCRIPTION
Before this PR, Jam displayed and sent a fractional number as collaborators to the backend (which rounded down to the nearest int). After this commit is applied the number of collaborators as always parsed and displayed as integer.

Before:
![image](https://user-images.githubusercontent.com/3358649/204814805-d032c0f3-634f-41ac-82fe-8ad97067c552.png)

After:
![image](https://user-images.githubusercontent.com/3358649/204814912-9bc786a8-b06b-4f4d-9f86-c9d80940216c.png)
