### PR TITLE
fix: correctly render existing bonds in Safari

### DIFF
--- a/src/components/fb/CreateFidelityBond.jsx
+++ b/src/components/fb/CreateFidelityBond.jsx
@@ -555,7 +555,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
           }}
         >
           {t('earn.fidelity_bond.confirm_modal.body', {
-            date: new Date(lockDate).toUTCString(),
+            date: new Date(fb.lockdate.toTimestamp(lockDate)).toUTCString(),
             humanReadableDuration: fb.time.humanReadableDuration({
               to: fb.lockdate.toTimestamp(lockDate),
               locale: i18n.resolvedLanguage || i18n.language,

--- a/src/components/fb/ExistingFidelityBond.tsx
+++ b/src/components/fb/ExistingFidelityBond.tsx
@@ -18,10 +18,11 @@ const ExistingFidelityBond = ({ fidelityBond, children }: PropsWithChildren<Exis
   const { t, i18n } = useTranslation()
 
   const isExpired = useMemo(() => !fb.utxo.isLocked(fidelityBond), [fidelityBond])
-  const humanReadableDuration = useMemo(() => {
-    if (!fidelityBond.locktime) return '-'
+  const humanReadableLockDuration = useMemo(() => {
+    const locktime = fb.utxo.getLocktime(fidelityBond)
+    if (!locktime) return '-'
     return fb.time.humanReadableDuration({
-      to: new Date(fidelityBond.locktime).getTime(),
+      to: locktime,
       locale: i18n.resolvedLanguage || i18n.language,
     })
   }, [i18n, fidelityBond])
@@ -70,7 +71,7 @@ const ExistingFidelityBond = ({ fidelityBond, children }: PropsWithChildren<Exis
                 {t(`earn.fidelity_bond.existing.${isExpired ? 'label_expired_on' : 'label_locked_until'}`)}
               </div>
               <div className={styles.content}>
-                {fidelityBond.locktime} ({humanReadableDuration})
+                {fidelityBond.locktime} ({humanReadableLockDuration})
               </div>
             </div>
           </div>

--- a/src/components/fb/FidelityBondSteps.tsx
+++ b/src/components/fb/FidelityBondSteps.tsx
@@ -287,7 +287,7 @@ const ReviewInputs = ({ lockDate, jar, utxos, selectedUtxos, timelockedAddress }
       label: t('earn.fidelity_bond.review_inputs.label_lock_date'),
       content: (
         <>
-          {new Date(lockDate).toUTCString()}(
+          {new Date(fb.lockdate.toTimestamp(lockDate)).toUTCString()} (
           {fb.time.humanReadableDuration({
             to: fb.lockdate.toTimestamp(lockDate),
             locale: i18n.resolvedLanguage || i18n.language,
@@ -357,6 +357,17 @@ const ReviewInputs = ({ lockDate, jar, utxos, selectedUtxos, timelockedAddress }
 const CreatedFidelityBond = ({ fbUtxo, frozenUtxos }: CreatedFidelityBondProps) => {
   const { t, i18n } = useTranslation()
 
+  const humanReadableLockDuration = useMemo(() => {
+    if (!fbUtxo) return '-'
+
+    const locktime = fb.utxo.getLocktime(fbUtxo)
+    if (!locktime) return '-'
+    return fb.time.humanReadableDuration({
+      to: locktime,
+      locale: i18n.resolvedLanguage || i18n.language,
+    })
+  }, [i18n, fbUtxo])
+
   return (
     <div className="d-flex flex-column gap-3">
       <Done text={t('earn.fidelity_bond.create_fidelity_bond.success_text')} />
@@ -372,12 +383,7 @@ const CreatedFidelityBond = ({ fbUtxo, frozenUtxos }: CreatedFidelityBondProps) 
                 </div>
                 {fbUtxo.locktime && (
                   <div className={styles.confirmationStepContent}>
-                    {fbUtxo.locktime} (
-                    {fb.time.humanReadableDuration({
-                      to: new Date(fbUtxo.locktime).getTime(),
-                      locale: i18n.resolvedLanguage || i18n.language,
-                    })}
-                    )
+                    {fbUtxo.locktime} ({humanReadableLockDuration})
                   </div>
                 )}
               </div>

--- a/src/components/fb/utils.ts
+++ b/src/components/fb/utils.ts
@@ -92,19 +92,24 @@ export const utxo = (() => {
 
   const isFidelityBond = (utxo: Utxo) => !!utxo.locktime
 
-  const isLocked = (utxo: Utxo, refTime: Milliseconds = Date.now()) => {
-    if (!isFidelityBond(utxo)) return false
+  const getLocktime = (utxo: Utxo): Milliseconds | null => {
+    if (!isFidelityBond(utxo)) return null
 
     const pathAndLocktime = utxo.path.split(':')
-    if (pathAndLocktime.length !== 2) return false
+    if (pathAndLocktime.length !== 2) return null
 
     const locktimeUnixTimestamp: Seconds = parseInt(pathAndLocktime[1], 10)
-    if (Number.isNaN(locktimeUnixTimestamp)) return false
+    if (Number.isNaN(locktimeUnixTimestamp)) return null
 
-    return locktimeUnixTimestamp * 1_000 >= refTime
+    return locktimeUnixTimestamp * 1_000
   }
 
-  return { isEqual, isInList, utxosToFreeze, allAreFrozen, isFidelityBond, isLocked }
+  const isLocked = (utxo: Utxo, refTime: Milliseconds = Date.now()) => {
+    const locktime = getLocktime(utxo)
+    return locktime !== null && locktime >= refTime
+  }
+
+  return { isEqual, isInList, utxosToFreeze, allAreFrozen, isFidelityBond, isLocked, getLocktime }
 })()
 
 export const time = (() => {

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -24,7 +24,9 @@ export type Utxo = {
   confirmations: number
   frozen: boolean
   utxo: Api.UtxoId
-  locktime?: Api.Lockdate
+  // `locktime` in format "yyyy-MM-dd 00:00:00"
+  // NOTE: it is unparsable with safari Date constructor
+  locktime?: string
 }
 
 export type Utxos = Utxo[]


### PR DESCRIPTION
It seems Safari is not able to construct `Date` objects from strings formatted as `yyyy-MM-dd 00:00:00` (see [stackoverflow#4310953](https://stackoverflow.com/questions/4310953/invalid-date-in-safari)).
Before this commit, as soon as a user on Safari created a fidelity bond, an error was thrown and the page became Earn page did not render.
After this commit, the fidelity bond is shown correctly and the Earn page renders successfully.

This is an _untested_ change, as every attempt to run Safari failed on my workstation. It be great if someone can verify that it works as expected. However, the root problem should be addressed, as all date objects are instantiated with a timestamp (type `number`) which every browser supports. 