### PR TITLE
fix: install python3-venv in regtest environment

### DIFF
--- a/docker/regtest/dockerfile-deps/joinmarket/directory_node/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/directory_node/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-20220801-slim
 RUN apt-get update \
     && apt-get install -qq --no-install-recommends gnupg tini procps vim git iproute2 supervisor \
        # joinmarket dependencies
-       curl build-essential automake pkg-config libtool python3-dev python3-pip python3-setuptools libltdl-dev \
+       curl build-essential automake pkg-config libtool python3-dev python3-venv python3-pip python3-setuptools libltdl-dev \
        # tor dependencies
        libevent-dev libssl-dev zlib1g-dev \
        && rm -rf /var/lib/apt/lists/*

--- a/docker/regtest/dockerfile-deps/joinmarket/directory_node/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/directory_node/Dockerfile
@@ -36,7 +36,7 @@ COPY docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
 
 # payjoin server
-EXPOSE 8080
+EXPOSE 8082
 # obwatch
 EXPOSE 62601 
 # joinmarketd daemon

--- a/docker/regtest/dockerfile-deps/joinmarket/directory_node/default.cfg
+++ b/docker/regtest/dockerfile-deps/joinmarket/directory_node/default.cfg
@@ -328,7 +328,7 @@ tor_control_port = 9051
 # (note the *virtual port*, that the client uses,
 # is hardcoded to 80):
 onion_serving_host = 127.0.0.1
-onion_serving_port = 8080
+onion_serving_port = 8082
 
 # in some exceptional case the HS may be SSL configured,
 # this feature is not yet implemented in code, but here for the

--- a/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bullseye-20220801-slim
 RUN apt-get update \
     && apt-get install -qq --no-install-recommends gnupg tini procps vim git iproute2 supervisor \
        # joinmarket dependencies
-       curl build-essential automake pkg-config libtool python3-dev python3-pip python3-setuptools libltdl-dev \
+       curl build-essential automake pkg-config libtool python3-dev python3-venv python3-pip python3-setuptools libltdl-dev \
        tor \
        && rm -rf /var/lib/apt/lists/*
 

--- a/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
@@ -34,7 +34,7 @@ COPY jam-entrypoint.sh /
 RUN chmod +x /jam-entrypoint.sh
 
 # payjoin server
-EXPOSE 8080
+EXPOSE 8082
 # obwatch
 EXPOSE 62601 
 # joinmarketd daemon

--- a/docker/regtest/dockerfile-deps/joinmarket/latest/default.cfg
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/default.cfg
@@ -342,7 +342,7 @@ tor_control_port = 9051
 # (note the *virtual port*, that the client uses,
 # is hardcoded to 80):
 onion_serving_host = 127.0.0.1
-onion_serving_port = 8080
+onion_serving_port = 8082
 
 # in some exceptional case the HS may be SSL configured,
 # this feature is not yet implemented in code, but here for the

--- a/docker/regtest/dockerfile-deps/joinmarket/webui-standalone/default.cfg
+++ b/docker/regtest/dockerfile-deps/joinmarket/webui-standalone/default.cfg
@@ -342,7 +342,7 @@ tor_control_port = 9051
 # (note the *virtual port*, that the client uses,
 # is hardcoded to 80):
 onion_serving_host = 127.0.0.1
-onion_serving_port = 8080
+onion_serving_port = 8082
 
 # in some exceptional case the HS may be SSL configured,
 # this feature is not yet implemented in code, but here for the


### PR DESCRIPTION
Fixes https://github.com/joinmarket-webui/jam/issues/581

Quick workaround to make the regtest environment compatible with the current state of master ([`ea7a6e`](https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/ea7a6e1a5b9dde5eb0af2b22d831e843f4800020)) again. This can be removed [once the install script is fixed upstream](https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1396#issuecomment-1369975749).

Also, adapts the payjoin server port from `8080` to `8082` according to [`2749da1`](https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/2749da174ac0cf7c5186b88af15b2970df5dce49) - included in JM `v0.9.9`.