### PR TITLE
feat: add dedicated error page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-dom": "^17.0.2",
         "react-i18next": "^12.0.0",
         "react-router-bootstrap": "^0.26.2",
-        "react-router-dom": "^6.4.3"
+        "react-router-dom": "^6.6.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -3773,9 +3773,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
-      "integrity": "sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.2.1.tgz",
+      "integrity": "sha512-XiY0IsyHR+DXYS5vBxpoBe/8veTeoRpMHP+vDosLZxL5bnpetzI0igkxkLZS235ldLzyfkxF+2divEwWHP3vMQ==",
       "engines": {
         "node": ">=14"
       }
@@ -18299,11 +18299,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
-      "integrity": "sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.6.1.tgz",
+      "integrity": "sha512-YkvlYRusnI/IN0kDtosUCgxqHeulN5je+ew8W+iA1VvFhf86kA+JEI/X/8NqYcr11hCDDp906S+SGMpBheNeYQ==",
       "dependencies": {
-        "@remix-run/router": "1.0.3"
+        "@remix-run/router": "1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -18325,12 +18325,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz",
-      "integrity": "sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.6.1.tgz",
+      "integrity": "sha512-u+8BKUtelStKbZD5UcY0NY90WOzktrkJJhyhNg7L0APn9t1qJNLowzrM9CHdpB6+rcPt6qQrlkIXsTvhuXP68g==",
       "dependencies": {
-        "@remix-run/router": "1.0.3",
-        "react-router": "6.4.3"
+        "@remix-run/router": "1.2.1",
+        "react-router": "6.6.1"
       },
       "engines": {
         "node": ">=14"
@@ -24936,9 +24936,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
-      "integrity": "sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.2.1.tgz",
+      "integrity": "sha512-XiY0IsyHR+DXYS5vBxpoBe/8veTeoRpMHP+vDosLZxL5bnpetzI0igkxkLZS235ldLzyfkxF+2divEwWHP3vMQ=="
     },
     "@restart/hooks": {
       "version": "0.4.7",
@@ -35658,11 +35658,11 @@
       "dev": true
     },
     "react-router": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
-      "integrity": "sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.6.1.tgz",
+      "integrity": "sha512-YkvlYRusnI/IN0kDtosUCgxqHeulN5je+ew8W+iA1VvFhf86kA+JEI/X/8NqYcr11hCDDp906S+SGMpBheNeYQ==",
       "requires": {
-        "@remix-run/router": "1.0.3"
+        "@remix-run/router": "1.2.1"
       }
     },
     "react-router-bootstrap": {
@@ -35674,12 +35674,12 @@
       }
     },
     "react-router-dom": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz",
-      "integrity": "sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.6.1.tgz",
+      "integrity": "sha512-u+8BKUtelStKbZD5UcY0NY90WOzktrkJJhyhNg7L0APn9t1qJNLowzrM9CHdpB6+rcPt6qQrlkIXsTvhuXP68g==",
       "requires": {
-        "@remix-run/router": "1.0.3",
-        "react-router": "6.4.3"
+        "@remix-run/router": "1.2.1",
+        "react-router": "6.6.1"
       }
     },
     "react-scripts": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^17.0.2",
     "react-i18next": "^12.0.0",
     "react-router-bootstrap": "^0.26.2",
-    "react-router-dom": "^6.4.3"
+    "react-router-dom": "^6.6.1"
   },
   "scripts": {
     "dev:start": "REACT_APP_JAM_DEV_MODE=true npm start",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -14,9 +14,10 @@ import { useSessionConnectionError } from '../context/ServiceInfoContext'
 import { useSettings } from '../context/SettingsContext'
 import { useCurrentWallet, useSetCurrentWallet } from '../context/WalletContext'
 import { clearSession, setSession } from '../session'
+import { isDebugFeatureEnabled } from '../constants/debugFeatures'
 import CreateWallet from './CreateWallet'
 import Earn from './Earn'
-import ErrorPage from './ErrorPage'
+import ErrorPage, { ErrorThrowingComponent } from './ErrorPage'
 import Footer from './Footer'
 import Jam from './Jam'
 import Layout from './Layout'
@@ -116,6 +117,9 @@ export default function App() {
                     element={<Settings wallet={currentWallet} stopWallet={stopWallet} />}
                   />
                 </>
+              )}
+              {isDebugFeatureEnabled('errorExamplePage') && (
+                <Route id="error-example" path={routes.__errorExample} element={<ErrorThrowingComponent />} />
               )}
               <Route id="404" path="*" element={<Navigate to={routes.home} replace={true} />} />
             </>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -16,6 +16,7 @@ import { useCurrentWallet, useSetCurrentWallet } from '../context/WalletContext'
 import { clearSession, setSession } from '../session'
 import CreateWallet from './CreateWallet'
 import Earn from './Earn'
+import ErrorPage from './ErrorPage'
 import Footer from './Footer'
 import Jam from './Jam'
 import Layout from './Layout'
@@ -62,51 +63,54 @@ export default function App() {
             <Footer />
           </>
         }
+        errorElement={<ErrorPage />}
       >
-        {/**
-         * This sections defines all routes that can be displayed, even if the connection
-         * to the backend is down, e.g. "create-wallet" shows the seed quiz and it is important
-         * that it stays visible in case the backend becomes unavailable.
-         */}
-        <Route id="create-wallet" path={routes.createWallet} element={<CreateWallet startWallet={startWallet} />} />
+        <Route id="errorBoundary" element={<Outlet />} errorElement={<ErrorPage />}>
+          {/**
+           * This sections defines all routes that can be displayed, even if the connection
+           * to the backend is down, e.g. "create-wallet" shows the seed quiz and it is important
+           * that it stays visible in case the backend becomes unavailable.
+           */}
+          <Route id="create-wallet" path={routes.createWallet} element={<CreateWallet startWallet={startWallet} />} />
 
-        {sessionConnectionError ? (
-          <Route
-            id="404"
-            path="*"
-            element={
-              <rb.Alert variant="danger">
-                {t('app.alert_no_connection', { connectionError: sessionConnectionError.message })}.
-              </rb.Alert>
-            }
-          />
-        ) : (
-          <>
-            {/**
-             * This section defines all routes that are displayed only if the backend is reachable.
-             */}
+          {sessionConnectionError ? (
             <Route
-              id="wallets"
-              path={routes.home}
-              element={<Wallets currentWallet={currentWallet} startWallet={startWallet} stopWallet={stopWallet} />}
+              id="404"
+              path="*"
+              element={
+                <rb.Alert variant="danger">
+                  {t('app.alert_no_connection', { connectionError: sessionConnectionError.message })}.
+                </rb.Alert>
+              }
             />
-            {currentWallet && (
-              <>
-                <Route id="wallet" path={routes.wallet} element={<MainWalletView wallet={currentWallet} />} />
-                <Route id="jam" path={routes.jam} element={<Jam wallet={currentWallet} />} />
-                <Route id="send" path={routes.send} element={<Send wallet={currentWallet} />} />
-                <Route id="earn" path={routes.earn} element={<Earn wallet={currentWallet} />} />
-                <Route id="receive" path={routes.receive} element={<Receive wallet={currentWallet} />} />
-                <Route
-                  id="settings"
-                  path={routes.settings}
-                  element={<Settings wallet={currentWallet} stopWallet={stopWallet} />}
-                />
-              </>
-            )}
-            <Route id="404" path="*" element={<Navigate to={routes.home} replace={true} />} />
-          </>
-        )}
+          ) : (
+            <>
+              {/**
+               * This section defines all routes that are displayed only if the backend is reachable.
+               */}
+              <Route
+                id="wallets"
+                path={routes.home}
+                element={<Wallets currentWallet={currentWallet} startWallet={startWallet} stopWallet={stopWallet} />}
+              />
+              {currentWallet && (
+                <>
+                  <Route id="wallet" path={routes.wallet} element={<MainWalletView wallet={currentWallet} />} />
+                  <Route id="jam" path={routes.jam} element={<Jam wallet={currentWallet} />} />
+                  <Route id="send" path={routes.send} element={<Send wallet={currentWallet} />} />
+                  <Route id="earn" path={routes.earn} element={<Earn wallet={currentWallet} />} />
+                  <Route id="receive" path={routes.receive} element={<Receive wallet={currentWallet} />} />
+                  <Route
+                    id="settings"
+                    path={routes.settings}
+                    element={<Settings wallet={currentWallet} stopWallet={stopWallet} />}
+                  />
+                </>
+              )}
+              <Route id="404" path="*" element={<Navigate to={routes.home} replace={true} />} />
+            </>
+          )}
+        </Route>
       </Route>
     ),
     {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -56,16 +56,26 @@ export default function App() {
           <>
             <Navbar />
             <rb.Container as="main" className="py-4 py-sm-5">
-              <Layout>
-                <Outlet />
-              </Layout>
+              <Outlet />
             </rb.Container>
             <Footer />
           </>
         }
         errorElement={<ErrorPage />}
       >
-        <Route id="errorBoundary" element={<Outlet />} errorElement={<ErrorPage />}>
+        <Route
+          id="error-boundary"
+          element={
+            <Layout>
+              <Outlet />
+            </Layout>
+          }
+          errorElement={
+            <Layout variant="wide">
+              <ErrorPage />
+            </Layout>
+          }
+        >
           {/**
            * This sections defines all routes that can be displayed, even if the connection
            * to the backend is down, e.g. "create-wallet" shows the seed quiz and it is important

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -3,6 +3,14 @@ import * as rb from 'react-bootstrap'
 import { useRouteError } from 'react-router-dom'
 import PageTitle from './PageTitle'
 import { t } from 'i18next'
+import { useEffect } from 'react'
+
+export function ErrorThrowingComponent() {
+  useEffect(() => {
+    throw new Error('This error is thrown on purpose. Only to be used for testing.')
+  }, [])
+  return <></>
+}
 
 interface ErrorViewProps {
   title: string

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -26,7 +26,7 @@ function ErrorView({ title, subtitle, reason, stacktrace }: ErrorViewProps) {
 
       <p>
         <Trans i18nKey="error_page.report_bug">
-          Please,{' '}
+          Please{' '}
           <a
             href="https://github.com/joinmarket-webui/jam/issues/new?labels=bug&template=bug_report.md"
             target="_blank"
@@ -34,7 +34,7 @@ function ErrorView({ title, subtitle, reason, stacktrace }: ErrorViewProps) {
           >
             open an issue on GitHub
           </a>{' '}
-          for this to be reviewed and for the error to be resolved in an upcoming version.
+          for this error to be reviewed and resolved in an upcoming version.
         </Trans>
       </p>
 

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from 'react-i18next'
+import { useRouteError } from 'react-router-dom'
+
+export default function ErrorPage() {
+  const { t } = useTranslation()
+  const error = useRouteError()
+
+  return (
+    <div>
+      <p>Error</p>
+    </div>
+  )
+}

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -1,13 +1,84 @@
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
+import * as rb from 'react-bootstrap'
 import { useRouteError } from 'react-router-dom'
+import PageTitle from './PageTitle'
+import { t } from 'i18next'
 
-export default function ErrorPage() {
-  const { t } = useTranslation()
-  const error = useRouteError()
+interface ErrorViewProps {
+  title: string
+  subtitle: string
+  reason: string
+  stacktrace?: string
+}
 
+function ErrorView({ title, subtitle, reason, stacktrace }: ErrorViewProps) {
   return (
     <div>
-      <p>Error</p>
+      <PageTitle title={title} subtitle={subtitle} />
+
+      <p>
+        <Trans i18nKey="error_page.report_bug">
+          Please,{' '}
+          <a
+            href="https://github.com/joinmarket-webui/jam/issues/new?labels=bug&template=bug_report.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            open an issue on GitHub
+          </a>{' '}
+          for this to be reviewed and for the error to be resolved in an upcoming version.
+        </Trans>
+      </p>
+
+      <div className="my-4">
+        <h6>{t('error_page.heading_reason')}</h6>
+        <rb.Alert variant="danger">{reason}</rb.Alert>
+      </div>
+
+      {stacktrace && (
+        <div className="my-4">
+          <h6>{t('error_page.heading_stacktrace')}</h6>
+          <pre className="border p-2">
+            <code>{stacktrace}</code>
+          </pre>
+        </div>
+      )}
     </div>
   )
+}
+
+function UnknownError({ error }: { error: any }) {
+  const { t } = useTranslation()
+
+  return (
+    <ErrorView
+      title={t('error_page.unknown_error.title')}
+      subtitle={t('error_page.unknown_error.subtitle')}
+      reason={error.message || t('global.errors.reason_unknown')}
+      stacktrace={error.stack}
+    />
+  )
+}
+
+function ErrorWithDetails({ error }: { error: Error }) {
+  const { t } = useTranslation()
+
+  return (
+    <ErrorView
+      title={t('error_page.error_with_details.title')}
+      subtitle={t('error_page.error_with_details.subtitle')}
+      reason={error.message || t('global.errors.reason_unknown')}
+      stacktrace={error.stack}
+    />
+  )
+}
+
+export default function ErrorPage() {
+  const error = useRouteError()
+
+  if (error instanceof Error) {
+    return <ErrorWithDetails error={error} />
+  } else {
+    return <UnknownError error={error} />
+  }
 }

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,7 +1,13 @@
-import React from 'react'
 import Sprite from './Sprite'
 
-export default function PageTitle({ title, subtitle, success = false, center = false }) {
+interface PageTitleProps {
+  title: string
+  subtitle?: string
+  success?: boolean
+  center?: boolean
+}
+
+export default function PageTitle({ title, subtitle, success = false, center = false }: PageTitleProps) {
   return (
     <div className={`mb-4 ${center && 'text-center'}`}>
       {success && (

--- a/src/constants/debugFeatures.ts
+++ b/src/constants/debugFeatures.ts
@@ -2,6 +2,7 @@ interface DebugFeatures {
   insecureScheduleTesting: boolean
   allowCreatingExpiredFidelityBond: boolean
   skipWalletBackupConfirmation: boolean
+  errorExamplePage: boolean
 }
 
 const devMode = process.env.NODE_ENV === 'development' && process.env.REACT_APP_JAM_DEV_MODE === 'true'
@@ -10,6 +11,7 @@ const debugFeatures: DebugFeatures = {
   allowCreatingExpiredFidelityBond: devMode,
   insecureScheduleTesting: devMode,
   skipWalletBackupConfirmation: devMode,
+  errorExamplePage: devMode,
 }
 
 type DebugFeature = keyof DebugFeatures

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -8,4 +8,5 @@ export const routes = {
   settings: '/settings',
   wallet: '/wallet',
   createWallet: '/create-wallet',
+  __errorExample: '/error-example',
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -73,6 +73,19 @@
     "button_next": "Next",
     "button_complete": "Let's go!"
   },
+  "error_page": {
+    "unknown_error": {
+      "title": "An unknown error has been encountered",
+      "subtitle": "The source of the error could not be determined."
+    },
+    "error_with_details": {
+      "title": "An error has been encountered : (",
+      "subtitle": ""
+    },
+    "heading_reason": "Reason",
+    "heading_stacktrace": "Stacktrace",
+    "report_bug": "Please, <2>open an issue on GitHub</2> for this to be reviewed and for the error to be resolved in an upcoming version."
+  },
   "wallets": {
     "title": "Your Wallets",
     "subtitle_no_wallets": "It looks like you do not have a wallet, yet.",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -79,12 +79,12 @@
       "subtitle": "The source of the error could not be determined."
     },
     "error_with_details": {
-      "title": "An error has been encountered : (",
+      "title": "Something broke :(",
       "subtitle": ""
     },
-    "heading_reason": "Reason",
-    "heading_stacktrace": "Stacktrace",
-    "report_bug": "Please, <2>open an issue on GitHub</2> for this to be reviewed and for the error to be resolved in an upcoming version."
+    "heading_reason": "Reason:",
+    "heading_stacktrace": "Stacktrace:",
+    "report_bug": "Please <2>open an issue on GitHub</2> for this error to be reviewed and resolved in an upcoming version."
   },
   "wallets": {
     "title": "Your Wallets",


### PR DESCRIPTION
Before this commit, in case there was an error, a generic error page had been shown.
After this commit, a dedicated error page, including the navbar, the footer and with a link to create an issue on GitHub, will be displayed.

Whenever you browse the app, this page should never render in the first place, as all error are to be handled by the actual component. However, some errors slip through (e.g. with the date parsing bug in safari #584) and then, the user should be presented with a better view.

The page is really just the bare minimum. The error is unexpected and in most cases, cannot be resolved by the user without support.

In order for this to work properly, the dependency `react-router-dom` has been upgraded from `v6.4.3` to `v6.6.1`.

## How to test

In dev mode (when starting with `npm run dev:start`), a special route with name `error-example` is present.
Visit http://localhost:3000/error-example to view this page.


## :camera_flash: Before
![image](https://user-images.githubusercontent.com/3358649/210429670-9a135b83-3699-4498-bbbc-eaa0037fbb64.png)


## :camera_flash: After
![image](https://user-images.githubusercontent.com/3358649/210429539-b7a94f99-2873-4f50-8915-da1cb940c1d2.png)
