### PR TITLE
ISSUE-528: improve JarDetailsOverlay header

### DIFF
--- a/src/components/SegmentedTabs.module.css
+++ b/src/components/SegmentedTabs.module.css
@@ -17,11 +17,6 @@
   background-color: var(--bs-gray-800);
 }
 
-:root[data-theme='dark'] .segmented-tabs-lightdark {
-  color: var(--bs-gray-100);
-  background-color: var(--bs-gray-900);
-}
-
 .segmented-tab {
   flex: 1 1 0;
 }

--- a/src/components/SegmentedTabs.module.css
+++ b/src/components/SegmentedTabs.module.css
@@ -17,6 +17,11 @@
   background-color: var(--bs-gray-800);
 }
 
+:root[data-theme='dark'] .segmented-tabs-lightdark {
+  color: var(--bs-gray-100);
+  background-color: var(--bs-gray-900);
+}
+
 .segmented-tab {
   flex: 1 1 0;
 }

--- a/src/components/SegmentedTabs.tsx
+++ b/src/components/SegmentedTabs.tsx
@@ -39,13 +39,7 @@ interface SegmentedTabsProps {
   disabled?: boolean
 }
 
-export default function SegmentedTabs({
-  name,
-  tabs,
-  onChange,
-  initialValue,
-  disabled = false,
-}: SegmentedTabsProps) {
+export default function SegmentedTabs({ name, tabs, onChange, initialValue, disabled = false }: SegmentedTabsProps) {
   const _onChange = (e: React.ChangeEvent<HTMLInputElement>, tab: SegmentedTab) => {
     e.stopPropagation()
     onChange(tab, e.currentTarget.checked)

--- a/src/components/SegmentedTabs.tsx
+++ b/src/components/SegmentedTabs.tsx
@@ -37,7 +37,6 @@ interface SegmentedTabsProps {
   onChange: (tab: SegmentedTab, checked: boolean) => void
   initialValue?: string
   disabled?: boolean
-  bgLightDark?: boolean
 }
 
 export default function SegmentedTabs({
@@ -46,7 +45,6 @@ export default function SegmentedTabs({
   onChange,
   initialValue,
   disabled = false,
-  bgLightDark = false,
 }: SegmentedTabsProps) {
   const _onChange = (e: React.ChangeEvent<HTMLInputElement>, tab: SegmentedTab) => {
     e.stopPropagation()
@@ -54,7 +52,7 @@ export default function SegmentedTabs({
   }
 
   return (
-    <div className={[styles[bgLightDark ? 'segmented-tabs-lightdark' : ''], styles['segmented-tabs']].join(' ')}>
+    <div className={['segmented-tabs-hook', styles['segmented-tabs']].join(' ')}>
       <div className="d-flex gap-1">
         {tabs.map((tab, index) => {
           return (

--- a/src/components/SegmentedTabs.tsx
+++ b/src/components/SegmentedTabs.tsx
@@ -37,16 +37,24 @@ interface SegmentedTabsProps {
   onChange: (tab: SegmentedTab, checked: boolean) => void
   initialValue?: string
   disabled?: boolean
+  bgLightDark?: boolean
 }
 
-export default function SegmentedTabs({ name, tabs, onChange, initialValue, disabled = false }: SegmentedTabsProps) {
+export default function SegmentedTabs({
+  name,
+  tabs,
+  onChange,
+  initialValue,
+  disabled = false,
+  bgLightDark = false,
+}: SegmentedTabsProps) {
   const _onChange = (e: React.ChangeEvent<HTMLInputElement>, tab: SegmentedTab) => {
     e.stopPropagation()
     onChange(tab, e.currentTarget.checked)
   }
 
   return (
-    <div className={styles['segmented-tabs']}>
+    <div className={[styles[bgLightDark ? 'segmented-tabs-lightdark' : ''], styles['segmented-tabs']].join(' ')}>
       <div className="d-flex gap-1">
         {tabs.map((tab, index) => {
           return (

--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -105,6 +105,16 @@
     width: 10rem;
     font-size: 0.8rem;
   }
+  .closeButton {
+    display: flex;
+    width: 25%;
+  }
+}
+
+@media only screen and (max-width: 576px) {
+  .closeButton {
+    display: flex;
+  }
 }
 
 :root[data-theme='dark'] .overlayContainer .tabContainer .utxoListTitleBar .freezeUnfreezeButtonsContainer > button {

--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -38,6 +38,10 @@
   color: var(--bs-body-color);
 }
 
+:root[data-theme='dark'] .overlayContainer :global .segmented-tabs-hook {
+  background-color: var(--bs-gray-900);
+}
+
 .overlayContainer .tabContainer {
   display: flex;
   flex-direction: column;

--- a/src/components/jar_details/JarDetailsOverlay.module.css
+++ b/src/components/jar_details/JarDetailsOverlay.module.css
@@ -109,16 +109,6 @@
     width: 10rem;
     font-size: 0.8rem;
   }
-  .closeButton {
-    display: flex;
-    width: 25%;
-  }
-}
-
-@media only screen and (max-width: 576px) {
-  .closeButton {
-    display: flex;
-  }
 }
 
 :root[data-theme='dark'] .overlayContainer .tabContainer .utxoListTitleBar .freezeUnfreezeButtonsContainer > button {

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -302,7 +302,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
       </rb.Offcanvas.Header>
       <rb.Offcanvas.Body>
         <rb.Container fluid="lg" className="py-3">
-          <div className="d-flex align-items-center flex-grow-1 flex-shrink-0 w-100 justify-content-center">
+          <div className="d-flex align-items-center justify-content-center">
             <div className="mb-3">
               <SegmentedTabs
                 name="jarDetailsTab"

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -13,7 +13,7 @@ import SegmentedTabs from '../SegmentedTabs'
 import UtxoDetailModal from './UtxoDetailModule'
 import { UtxoList } from './UtxoList'
 import { DisplayBranchHeader, DisplayBranchBody } from './DisplayBranch'
-import { jarInitial } from '../jars/Jar'
+import { jarInitial, jarName } from '../jars/Jar'
 import styles from './JarDetailsOverlay.module.css'
 
 const TABS = {
@@ -34,53 +34,32 @@ interface HeaderProps {
 const Header = ({ jar, nextJar, previousJar, setTab, onHide, initialTab, isInitializing }: HeaderProps) => {
   const { t } = useTranslation()
 
-  const tabs = [
-    { label: t('jar_details.title_tab_utxos'), value: TABS.UTXOS },
-    { label: t('jar_details.title_tab_jar_details'), value: TABS.JAR_DETAILS },
-  ]
-
   return (
     <>
-      <div className="w-100 d-flex flex-column flex-md-row gap-3">
-        <div className="d-flex align-items-center flex-1">
-          <div className="d-flex align-items-center ms-auto me-auto ms-md-0">
+      <div className="w-100 d-flex flex-column justify-content-between flex-md-row gap-3">
+        <div />
+        <div className="d-flex align-items-center">
+          <div className="d-flex align-items-center ms-auto me-auto ms-md-0 position-relative">
             <rb.Button variant="link" className={styles.jarStepperButton} onClick={() => previousJar()}>
               <Sprite symbol="caret-left" width="20" height="20" />
             </rb.Button>
             <div className={styles.accountStepperTitle}>
               <Sprite symbol="jar-open-fill-50" width="20" height="20" />
               <span className="slashed-zeroes">
-                <strong>{jarInitial(Number(jar.account))}</strong>
+                <strong>{jarName(Number(jar.account))}</strong>
               </span>
             </div>
             <rb.Button variant="link" className={styles.jarStepperButton} onClick={() => nextJar()}>
               <Sprite symbol="caret-right" width="20" height="20" />
             </rb.Button>
             {isInitializing && (
-              <>
-                {
-                  <rb.Spinner
-                    as="span"
-                    animation="border"
-                    size="sm"
-                    role="status"
-                    aria-hidden="true"
-                    className="ms-3"
-                  />
-                }
-              </>
+              <div className="position-absolute start-100">
+                <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="ms-3" />
+              </div>
             )}
           </div>
         </div>
-        <div className="d-flex align-items-center flex-grow-1 flex-shrink-0">
-          <SegmentedTabs
-            name="jarDetailsTab"
-            tabs={tabs}
-            onChange={(tab, checked) => checked && setTab(tab.value)}
-            initialValue={initialTab}
-          />
-        </div>
-        <div className="d-flex flex-1">
+        <div className="d-flex ml-auto">
           <rb.Button variant="link" className="unstyled px-0 ms-auto me-auto me-md-0" onClick={onHide}>
             <Sprite symbol="cancel" width="32" height="32" />
           </rb.Button>
@@ -114,6 +93,11 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
   const [isLoadingUnfreeze, setIsLoadingUnfreeze] = useState(false)
   const [selectedUtxoIds, setSelectedUtxoIds] = useState<Array<string>>([])
   const [detailUtxo, setDetailUtxo] = useState<Utxo>()
+
+  const tabs = [
+    { label: t('jar_details.title_tab_utxos'), value: TABS.UTXOS },
+    { label: t('jar_details.title_tab_jar_details'), value: TABS.JAR_DETAILS },
+  ]
 
   const jar = useMemo(() => props.jars[jarIndex], [props.jars, jarIndex])
   const utxos = useMemo(() => props.walletInfo.utxosByJar[jarIndex] || [], [props.walletInfo, jarIndex])
@@ -326,6 +310,17 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
       </rb.Offcanvas.Header>
       <rb.Offcanvas.Body>
         <rb.Container fluid="lg" className="py-3">
+          <div className="d-flex align-items-center flex-grow-1 flex-shrink-0 w-100 justify-content-center">
+            <div className="w-25 mb-3">
+              <SegmentedTabs
+                name="jarDetailsTab"
+                tabs={tabs}
+                onChange={(tab, checked) => checked && setSelectedTab(tab.value)}
+                initialValue={selectedTab}
+                bgLightDark={true}
+              />
+            </div>
+          </div>
           {alert && (
             <rb.Row>
               <rb.Col>

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -311,7 +311,6 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                 tabs={tabs}
                 onChange={(tab, checked) => checked && setSelectedTab(tab.value)}
                 initialValue={selectedTab}
-                bgLightDark={true}
               />
             </div>
           </div>

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -25,19 +25,15 @@ interface HeaderProps {
   jar: Account
   nextJar: () => void
   previousJar: () => void
-  setTab: (tab: string) => void
   onHide: () => void
   isInitializing: boolean
-  initialTab: string
 }
 
-const Header = ({ jar, nextJar, previousJar, setTab, onHide, initialTab, isInitializing }: HeaderProps) => {
-  const { t } = useTranslation()
-
+const Header = ({ jar, nextJar, previousJar, onHide, isInitializing }: HeaderProps) => {
   return (
     <>
       <div className="w-100 d-flex flex-column justify-content-between flex-md-row gap-3">
-        <div />
+        <div className="w-25" />
         <div className="d-flex align-items-center">
           <div className="d-flex align-items-center ms-auto me-auto ms-md-0 position-relative">
             <rb.Button variant="link" className={styles.jarStepperButton} onClick={() => previousJar()}>
@@ -59,7 +55,7 @@ const Header = ({ jar, nextJar, previousJar, setTab, onHide, initialTab, isIniti
             )}
           </div>
         </div>
-        <div className="d-flex ml-auto">
+        <div className={styles.closeButton}>
           <rb.Button variant="link" className="unstyled px-0 ms-auto me-auto me-md-0" onClick={onHide}>
             <Sprite symbol="cancel" width="32" height="32" />
           </rb.Button>
@@ -301,9 +297,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
             jar={jar}
             nextJar={nextJar}
             previousJar={previousJar}
-            setTab={setSelectedTab}
             onHide={props.onHide}
-            initialTab={selectedTab}
             isInitializing={isInitializing}
           />
         </rb.Container>
@@ -311,7 +305,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
       <rb.Offcanvas.Body>
         <rb.Container fluid="lg" className="py-3">
           <div className="d-flex align-items-center flex-grow-1 flex-shrink-0 w-100 justify-content-center">
-            <div className="w-25 mb-3">
+            <div className="mb-3">
               <SegmentedTabs
                 name="jarDetailsTab"
                 tabs={tabs}

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -33,29 +33,27 @@ const Header = ({ jar, nextJar, previousJar, onHide, isInitializing }: HeaderPro
   return (
     <>
       <div className="w-100 d-flex flex-column justify-content-between flex-md-row gap-3">
-        <div className="w-25" />
-        <div className="d-flex align-items-center">
-          <div className="d-flex align-items-center ms-auto me-auto ms-md-0 position-relative">
-            <rb.Button variant="link" className={styles.jarStepperButton} onClick={() => previousJar()}>
-              <Sprite symbol="caret-left" width="20" height="20" />
-            </rb.Button>
-            <div className={styles.accountStepperTitle}>
-              <Sprite symbol="jar-open-fill-50" width="20" height="20" />
-              <span className="slashed-zeroes">
-                <strong>{jarName(Number(jar.account))}</strong>
-              </span>
-            </div>
-            <rb.Button variant="link" className={styles.jarStepperButton} onClick={() => nextJar()}>
-              <Sprite symbol="caret-right" width="20" height="20" />
-            </rb.Button>
-            {isInitializing && (
-              <div className="position-absolute start-100">
-                <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="ms-3" />
-              </div>
-            )}
+        <div className="d-flex flex-1" />
+        <div className="d-flex justify-content-center align-items-center">
+          <rb.Button variant="link" className={styles.jarStepperButton} onClick={() => previousJar()}>
+            <Sprite symbol="caret-left" width="20" height="20" />
+          </rb.Button>
+          <div className={styles.accountStepperTitle}>
+            <Sprite symbol="jar-open-fill-50" width="20" height="20" />
+            <span className="slashed-zeroes">
+              <strong>{jarName(Number(jar.account))}</strong>
+            </span>
           </div>
+          <rb.Button variant="link" className={styles.jarStepperButton} onClick={() => nextJar()}>
+            <Sprite symbol="caret-right" width="20" height="20" />
+          </rb.Button>
+          {isInitializing && (
+            <div className="position-absolute start-100">
+              <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="ms-3" />
+            </div>
+          )}
         </div>
-        <div className={styles.closeButton}>
+        <div className="d-flex flex-1">
           <rb.Button variant="link" className="unstyled px-0 ms-auto me-auto me-md-0" onClick={onHide}>
             <Sprite symbol="cancel" width="32" height="32" />
           </rb.Button>


### PR DESCRIPTION
Closes https://github.com/joinmarket-webui/jam/issues/528

This PR moves the "UTXOS | DETAILS" tab out of the header and places it just below the header instead.

Here is screenshots of the changes:
![image](https://user-images.githubusercontent.com/32936978/210861172-87e74379-67ba-449b-9912-ce17b17d8960.png)
![image](https://user-images.githubusercontent.com/32936978/210861224-7ab4d874-8435-4e38-9f9a-c10596170551.png)


I also made sure that all of the other instances of `<SegmentedHeader/>` still look good:
![image](https://user-images.githubusercontent.com/32936978/210861031-91fa9718-77d3-42a5-8dc7-4658705c32f3.png)
![image](https://user-images.githubusercontent.com/32936978/210861124-4a0e3a6d-d7e0-4bc6-944d-9f9612df640a.png)
