### PR TITLE
ui(Jars): move jar info next to icon on small screens

### DIFF
--- a/src/components/Jars.module.css
+++ b/src/components/Jars.module.css
@@ -22,9 +22,34 @@
   color: var(--bs-body-color);
 }
 
+.jarsContainer :global .jar-container-hook {
+  flex-direction: row;
+  gap: 1rem;
+  min-width: 11rem;
+}
+
+.jarsContainer :global .jar-info-container-hook {
+  align-items: start;
+}
+.jarsContainer :global .jar-balance-container-hook {
+  justify-content: start !important;
+}
+
 @media only screen and (min-width: 768px) {
   .jarsContainer {
     flex-direction: row;
     gap: 1.5rem;
+  }
+
+  .jarsContainer :global .jar-container-hook {
+    flex-direction: column;
+    gap: 0;
+    min-width: inherit;
+  }
+  .jarsContainer :global .jar-info-container-hook {
+    align-items: center !important;
+  }
+  .jarsContainer :global .jar-balance-container-hook {
+    justify-content: center !important;
   }
 }

--- a/src/components/jars/Jar.module.css
+++ b/src/components/jars/Jar.module.css
@@ -4,6 +4,12 @@
   align-items: center;
 }
 
+.jarInfoContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .jarSprite {
   margin: 0 0 0.25rem 0;
 }
@@ -50,7 +56,6 @@
   min-width: 11.5ch;
 
   font-size: 0.8rem;
-  padding-bottom: 0.8rem;
 }
 
 .selectableJarContainer {
@@ -66,14 +71,13 @@
   cursor: unset;
 }
 
-.selectableJarContainer:not(.selectable) > .selectionCircle {
+.selectableJarContainer > .selectionCircle {
   height: 1.25rem;
   width: 1.25rem;
+  margin-top: 0.8rem;
 }
 
 .selectableJarContainer.selectable > .selectionCircle {
-  height: 1.25rem;
-  width: 1.25rem;
   border-radius: 50%;
   display: inline-block;
   border: 1px solid var(--bs-body-color);

--- a/src/components/jars/Jar.tsx
+++ b/src/components/jars/Jar.tsx
@@ -119,11 +119,13 @@ const Jar = ({ index, balance, fillLevel, isOpen = false }: JarProps) => {
   const flavorName = jarName(index)
 
   return (
-    <div className={styles.jarContainer}>
+    <div className={`${styles.jarContainer} jar-container-hook`}>
       <Sprite className={`${styles.jarSprite} ${flavorStyle}`} symbol={jarSymbol} width="32px" height="48px" />
-      <div className={styles.jarIndex}>{flavorName}</div>
-      <div className={styles.jarBalance}>
-        <Balance valueString={balance.toString()} convertToUnit={settings.unit} showBalance={settings.showBalance} />
+      <div className={`${styles.jarInfoContainer} jar-info-container-hook`}>
+        <div className={styles.jarIndex}>{flavorName}</div>
+        <div className={`${styles.jarBalance} jar-balance-container-hook`}>
+          <Balance valueString={balance.toString()} convertToUnit={settings.unit} showBalance={settings.showBalance} />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Small PR to align the main wallet view with Figma screens.

Places the jar info (name and balance) next to the jar icon on small screens.

## :camera_flash:  Before/After
<img src="https://user-images.githubusercontent.com/3358649/211855168-4b356ad4-81d3-4972-8da1-0d86f3486b3d.png" width=300 /> <img src="https://user-images.githubusercontent.com/3358649/211855073-e0e8e2c1-46b3-4aeb-961e-3f008d7ed9f3.png" width=300 />
