### PR TITLE
fix(fb): correctly display success screen after unlocking fb

### DIFF
--- a/src/components/Earn.jsx
+++ b/src/components/Earn.jsx
@@ -400,55 +400,51 @@ export default function Earn({ wallet }) {
                 subtitle={t('earn.subtitle_fidelity_bonds')}
               />
               <div className="d-flex flex-column gap-3">
-                {currentWalletInfo && fidelityBonds.length > 0 && (
-                  <>
-                    {moveToJarFidelityBondId && (
-                      <SpendFidelityBondModal
-                        show={true}
-                        fidelityBondId={moveToJarFidelityBondId}
-                        wallet={wallet}
-                        walletInfo={currentWalletInfo}
-                        destinationJarIndex={0}
-                        onClose={({ mustReload }) => {
-                          setMoveToJarFidelityBondId(undefined)
-                          if (mustReload) {
-                            reloadFidelityBonds({ delay: 0 })
-                          }
-                        }}
-                      />
-                    )}
-                    {fidelityBonds.map((fidelityBond, index) => {
-                      const isExpired = !fb.utxo.isLocked(fidelityBond)
-                      const actionsEnabled =
-                        isExpired &&
-                        serviceInfo &&
-                        !serviceInfo.coinjoinInProgress &&
-                        !serviceInfo.makerRunning &&
-                        !isWaitingMakerStart &&
-                        !isWaitingMakerStop &&
-                        !isLoading
-                      return (
-                        <ExistingFidelityBond key={index} fidelityBond={fidelityBond}>
-                          {actionsEnabled && (
-                            <div className="mt-4">
-                              <div className="">
-                                <rb.Button
-                                  variant={settings.theme === 'dark' ? 'light' : 'dark'}
-                                  className="w-50 d-flex justify-content-center align-items-center"
-                                  disabled={moveToJarFidelityBondId !== undefined}
-                                  onClick={() => setMoveToJarFidelityBondId(fidelityBond.utxo)}
-                                >
-                                  <Sprite className="me-1 mb-1" symbol="unlock" width="24" height="24" />
-                                  {t('earn.fidelity_bond.existing.button_spend')}
-                                </rb.Button>
-                              </div>
-                            </div>
-                          )}
-                        </ExistingFidelityBond>
-                      )
-                    })}
-                  </>
+                {currentWalletInfo && moveToJarFidelityBondId && (
+                  <SpendFidelityBondModal
+                    show={true}
+                    fidelityBondId={moveToJarFidelityBondId}
+                    wallet={wallet}
+                    walletInfo={currentWalletInfo}
+                    destinationJarIndex={0}
+                    onClose={({ mustReload }) => {
+                      setMoveToJarFidelityBondId(undefined)
+                      if (mustReload) {
+                        reloadFidelityBonds({ delay: 0 })
+                      }
+                    }}
+                  />
                 )}
+                {fidelityBonds.map((fidelityBond, index) => {
+                  const isExpired = !fb.utxo.isLocked(fidelityBond)
+                  const actionsEnabled =
+                    isExpired &&
+                    serviceInfo &&
+                    !serviceInfo.coinjoinInProgress &&
+                    !serviceInfo.makerRunning &&
+                    !isWaitingMakerStart &&
+                    !isWaitingMakerStop &&
+                    !isLoading
+                  return (
+                    <ExistingFidelityBond key={index} fidelityBond={fidelityBond}>
+                      {actionsEnabled && (
+                        <div className="mt-4">
+                          <div className="">
+                            <rb.Button
+                              variant={settings.theme === 'dark' ? 'light' : 'dark'}
+                              className="w-50 d-flex justify-content-center align-items-center"
+                              disabled={moveToJarFidelityBondId !== undefined}
+                              onClick={() => setMoveToJarFidelityBondId(fidelityBond.utxo)}
+                            >
+                              <Sprite className="me-1 mb-1" symbol="unlock" width="24" height="24" />
+                              {t('earn.fidelity_bond.existing.button_spend')}
+                            </rb.Button>
+                          </div>
+                        </div>
+                      )}
+                    </ExistingFidelityBond>
+                  )
+                })}
                 <>
                   {!serviceInfo?.makerRunning &&
                     !isWaitingMakerStart &&

--- a/src/components/fb/SpendFidelityBondModal.tsx
+++ b/src/components/fb/SpendFidelityBondModal.tsx
@@ -393,7 +393,7 @@ const SpendFidelityBondModal = ({
           <div className="w-100 d-flex gap-4 justify-content-center align-items-center">
             <rb.Button
               variant="light"
-              disabled={isSending}
+              disabled={isLoading}
               onClick={() => onClose({ txInfo, mustReload: parentMustReload })}
               className="flex-1 d-flex justify-content-center align-items-center"
             >


### PR DESCRIPTION
There has been a bug when unlocking an expired fidelity bond: After the tx had been broadcasted, the success screen disappeared, as the modal was hidden as soon as no FB was present anymore.

With this fix, the success screen is shown correctly after an expired FB has been unlocked.

### How to test?
On master, verify you can reproduce the bug: After you spend an expired Fidelity Bond, no success screen is displayed.
Then checkout this branch and repeat the procedure. This time the success screen should be displayed.
