### PR TITLE
fix(fees): allow input for relative fee limit of 0.0001%

### DIFF
--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -450,7 +450,7 @@ export default function FeeConfigModal({ show, onHide }: FeeConfigModalProps) {
 
       if (
         !isValidNumber(values.max_cj_fee_rel) ||
-        values.max_cj_fee_rel! <= CJ_FEE_REL_MIN ||
+        values.max_cj_fee_rel! < CJ_FEE_REL_MIN ||
         values.max_cj_fee_rel! > CJ_FEE_REL_MAX
       ) {
         errors.max_cj_fee_rel = t('settings.fees.feedback_invalid_max_cj_fee_rel', {


### PR DESCRIPTION
Resolves #602.

This seems to have been just an oversight. 
Before this PR, the fee modal did not let users specify 0.0001% as relative fee limit.
After this PR, 0.0001% is allowed and accepted as valid value. 

Tested by setting "absolute fee limit" to 10 sats (makers in regest use 250 sats as absolute fee)  and "relative fee limit" to 0.0001% (factor: 0.000001), then sending a collaborative transaction sweeping Jar A with 2 collaborators on regtest. 
Success :heavy_check_mark:

Verify the transaction by watching the logs with `npm run regtest:logs:jmwalletd`.