### PR TITLE
fix(fees): allow min tx fee of 1sat/vbyte

### DIFF
--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -24,7 +24,7 @@ const TX_FEES_BLOCKS_MAX = 1_000
  * See https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1360#issuecomment-1262295463
  * Last checked on 2022-10-06.
  */
-const TX_FEES_SATSPERKILOVBYTE_MIN: SatsPerKiloVByte = 3_000 // 3 sat/vbyte
+const TX_FEES_SATSPERKILOVBYTE_MIN: SatsPerKiloVByte = 1_000 // 1 sat/vbyte
 // 350 sats/vbyte - no enforcement by JM - this should be a "sane" max value (taken default value of "absurd_fee_per_kb")
 const TX_FEES_SATSPERKILOVBYTE_MAX: SatsPerKiloVByte = 350_000
 const TX_FEES_SATSPERKILOVBYTE_ADJUSTED_MIN = 1_001 // actual min of `tx_fees` if unit is sats/kilo-vbyte


### PR DESCRIPTION
Requires JM `v0.9.9` or greater -> needs #585 to be merged and a recreated dev environment by running `npm run regtest:rebuild`!

Before this commit, minimum in Jam was 3 sats/vbyte as prior ot JM `v0.9.9`, this resulted in an error, as JM used to little fees and the tx was rejected from the mempool.
When this commit is applied, setting the tx fee to 1 sat/vbyte is allowed.

## How to test
Set your tx fees to 1 sat/vbyte (with 0% randomization) and try to spend an expired fidelity bond.