### PR TITLE
dev(regtest): update to docker-compose

### DIFF
--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -131,6 +131,8 @@ services:
       - 28332 # ZMQ
       - 28333 # ZMQ
       - 28334 # ZMQ
+    ports:
+      - "43782:43782"
     volumes:
       - "bitcoin_datadir:/data"
       - "bitcoin_wallet_datadir:/walletdata"

--- a/docker/regtest/docker-compose.yml
+++ b/docker/regtest/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       - 28333 # ZMQ
       - 28334 # ZMQ
     ports:
-      - "43782:43782"
+      - "17782:43782"
     volumes:
       - "bitcoin_datadir:/data"
       - "bitcoin_wallet_datadir:/walletdata"


### PR DESCRIPTION
added port mapping for bitcoind so that external wallet software can access the regtest env to test the sweep function