### PR TITLE
feat: backend version based feature toggles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 .env.production.local
 
 npm-debug.log*
+
+.idea/

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -7,12 +7,14 @@ import App from './App'
 
 jest.mock('../libs/JmWalletApi', () => ({
   ...jest.requireActual('../libs/JmWalletApi'),
+  getGetinfo: jest.fn(),
   getSession: jest.fn(),
 }))
 
 describe('<App />', () => {
   beforeEach(() => {
     const neverResolvingPromise = new Promise(() => {})
+    ;(apiMock.getGetinfo as jest.Mock).mockResolvedValue(neverResolvingPromise)
     ;(apiMock.getSession as jest.Mock).mockResolvedValue(neverResolvingPromise)
   })
 

--- a/src/components/CreateWallet.test.jsx
+++ b/src/components/CreateWallet.test.jsx
@@ -11,6 +11,7 @@ import CreateWallet from './CreateWallet'
 
 jest.mock('../libs/JmWalletApi', () => ({
   ...jest.requireActual('../libs/JmWalletApi'),
+  getGetinfo: jest.fn(),
   getSession: jest.fn(),
   postWalletCreate: jest.fn(),
 }))
@@ -32,6 +33,7 @@ describe('<CreateWallet />', () => {
 
   beforeEach(() => {
     const neverResolvingPromise = new Promise(() => {})
+    apiMock.getGetinfo.mockResolvedValue(neverResolvingPromise)
     apiMock.getSession.mockReturnValue(neverResolvingPromise)
   })
 

--- a/src/components/CreateWallet.test.jsx
+++ b/src/components/CreateWallet.test.jsx
@@ -34,7 +34,7 @@ describe('<CreateWallet />', () => {
   beforeEach(() => {
     const neverResolvingPromise = new Promise(() => {})
     apiMock.getGetinfo.mockResolvedValue(neverResolvingPromise)
-    apiMock.getSession.mockReturnValue(neverResolvingPromise)
+    apiMock.getSession.mockResolvedValue(neverResolvingPromise)
   })
 
   it('should render without errors', () => {

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -227,7 +227,7 @@ export default function Settings({ wallet, stopWallet }) {
             )}
           </rb.Button>
 
-          {isFeatureEnabled('rescanChain', serviceInfo) && isDebugFeatureEnabled('rescanChainPage') && (
+          {serviceInfo && isFeatureEnabled('rescanChain', serviceInfo) && isDebugFeatureEnabled('rescanChainPage') && (
             <Link
               to={routes.rescanChain}
               className={`btn btn-outline-dark ${styles['settings-btn']} position-relative`}

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -17,6 +17,7 @@ import styles from './Settings.module.css'
 import SeedModal from './settings/SeedModal'
 import FeeConfigModal from './settings/FeeConfigModal'
 import { isDebugFeatureEnabled } from '../constants/debugFeatures'
+import { isFeatureEnabled } from '../constants/features'
 
 export default function Settings({ wallet, stopWallet }) {
   const { t, i18n } = useTranslation()
@@ -226,7 +227,7 @@ export default function Settings({ wallet, stopWallet }) {
             )}
           </rb.Button>
 
-          {isDebugFeatureEnabled('rescanChainPage') && (
+          {isFeatureEnabled('rescanChain', serviceInfo) && isDebugFeatureEnabled('rescanChainPage') && (
             <Link
               to={routes.rescanChain}
               className={`btn btn-outline-dark ${styles['settings-btn']} position-relative`}

--- a/src/components/Wallet.test.tsx
+++ b/src/components/Wallet.test.tsx
@@ -9,6 +9,7 @@ import Wallet, { WalletProps } from './Wallet'
 
 jest.mock('../libs/JmWalletApi', () => ({
   ...jest.requireActual('../libs/JmWalletApi'),
+  getGetinfo: jest.fn(),
   getSession: jest.fn(),
 }))
 
@@ -43,7 +44,8 @@ describe('<Wallet />', () => {
 
   beforeEach(() => {
     const neverResolvingPromise = new Promise<Response>(() => {})
-    jest.mocked(apiMock.getSession).mockReturnValue(neverResolvingPromise)
+    ;(apiMock.getGetinfo as jest.Mock).mockResolvedValue(neverResolvingPromise)
+    ;(apiMock.getSession as jest.Mock).mockResolvedValue(neverResolvingPromise)
   })
 
   it('should render inactive wallet without errors', () => {

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -234,44 +234,42 @@ export default function Wallets({ currentWallet, startWallet, stopWallet }) {
           })
         )}
 
-        {serviceInfo && (
-          <div
-            className={classNames('d-flex', 'justify-content-center', 'gap-2', 'mt-4', {
-              'flex-column': walletList?.length === 0,
+        <div
+          className={classNames('d-flex', 'justify-content-center', 'gap-2', 'mt-4', {
+            'flex-column': walletList?.length === 0,
+          })}
+        >
+          <Link
+            to={routes.createWallet}
+            className={classNames('btn', {
+              'btn-lg': walletList?.length === 0,
+              'btn-dark': walletList?.length === 0,
+              'btn-outline-dark': !walletList || walletList.length > 0,
+              disabled: isLoading || isUnlocking,
             })}
+            data-testid="new-wallet-btn"
           >
+            <div className="d-flex justify-content-center align-items-center">
+              <Sprite symbol="plus" width="20" height="20" className="me-2" />
+              <span>{t('wallets.button_new_wallet')}</span>
+            </div>
+          </Link>
+          {serviceInfo && isFeatureEnabled('importWallet', serviceInfo) && (
             <Link
-              to={routes.createWallet}
-              className={classNames('btn', {
+              to={routes.importWallet}
+              className={classNames('btn', 'btn-outline-dark', {
                 'btn-lg': walletList?.length === 0,
-                'btn-dark': walletList?.length === 0,
-                'btn-outline-dark': !walletList || walletList.length > 0,
                 disabled: isLoading || isUnlocking,
               })}
-              data-testid="new-wallet-btn"
+              data-testid="import-wallet-btn"
             >
               <div className="d-flex justify-content-center align-items-center">
-                <Sprite symbol="plus" width="20" height="20" className="me-2" />
-                <span>{t('wallets.button_new_wallet')}</span>
+                <Sprite symbol="arrow-right" width="20" height="20" className="me-2" />
+                <span>{t('wallets.button_import_wallet')}</span>
               </div>
             </Link>
-            {isFeatureEnabled('importWallet', serviceInfo) && (
-              <Link
-                to={routes.importWallet}
-                className={classNames('btn', 'btn-outline-dark', {
-                  'btn-lg': walletList?.length === 0,
-                  disabled: isLoading || isUnlocking,
-                })}
-                data-testid="import-wallet-btn"
-              >
-                <div className="d-flex justify-content-center align-items-center">
-                  <Sprite symbol="arrow-right" width="20" height="20" className="me-2" />
-                  <span>{t('wallets.button_import_wallet')}</span>
-                </div>
-              </Link>
-            )}
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       <ConfirmModal

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -12,6 +12,7 @@ import { walletDisplayName } from '../utils'
 import * as Api from '../libs/JmWalletApi'
 import { routes } from '../constants/routes'
 import { ConfirmModal } from './Modal'
+import { isFeatureEnabled } from '../constants/features'
 
 function arrayEquals(a, b) {
   return Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((val, index) => val === b[index])
@@ -232,40 +233,45 @@ export default function Wallets({ currentWallet, startWallet, stopWallet }) {
             )
           })
         )}
-        <div
-          className={classNames('d-flex', 'justify-content-center', 'gap-2', 'mt-4', {
-            'flex-column': walletList?.length === 0,
-          })}
-        >
-          <Link
-            to={routes.createWallet}
-            className={classNames('btn', {
-              'btn-lg': walletList?.length === 0,
-              'btn-dark': walletList?.length === 0,
-              'btn-outline-dark': !walletList || walletList.length > 0,
-              disabled: isUnlocking,
+
+        {serviceInfo && (
+          <div
+            className={classNames('d-flex', 'justify-content-center', 'gap-2', 'mt-4', {
+              'flex-column': walletList?.length === 0,
             })}
-            data-testid="new-wallet-btn"
           >
-            <div className="d-flex justify-content-center align-items-center">
-              <Sprite symbol="plus" width="20" height="20" className="me-2" />
-              <span>{t('wallets.button_new_wallet')}</span>
-            </div>
-          </Link>
-          <Link
-            to={routes.importWallet}
-            className={classNames('btn', 'btn-outline-dark', {
-              'btn-lg': walletList?.length === 0,
-              disabled: isUnlocking,
-            })}
-            data-testid="import-wallet-btn"
-          >
-            <div className="d-flex justify-content-center align-items-center">
-              <Sprite symbol="arrow-right" width="20" height="20" className="me-2" />
-              <span>{t('wallets.button_import_wallet')}</span>
-            </div>
-          </Link>
-        </div>
+            <Link
+              to={routes.createWallet}
+              className={classNames('btn', {
+                'btn-lg': walletList?.length === 0,
+                'btn-dark': walletList?.length === 0,
+                'btn-outline-dark': !walletList || walletList.length > 0,
+                disabled: isLoading || isUnlocking,
+              })}
+              data-testid="new-wallet-btn"
+            >
+              <div className="d-flex justify-content-center align-items-center">
+                <Sprite symbol="plus" width="20" height="20" className="me-2" />
+                <span>{t('wallets.button_new_wallet')}</span>
+              </div>
+            </Link>
+            {isFeatureEnabled('importWallet', serviceInfo) && (
+              <Link
+                to={routes.importWallet}
+                className={classNames('btn', 'btn-outline-dark', {
+                  'btn-lg': walletList?.length === 0,
+                  disabled: isLoading || isUnlocking,
+                })}
+                data-testid="import-wallet-btn"
+              >
+                <div className="d-flex justify-content-center align-items-center">
+                  <Sprite symbol="arrow-right" width="20" height="20" className="me-2" />
+                  <span>{t('wallets.button_import_wallet')}</span>
+                </div>
+              </Link>
+            )}
+          </div>
+        )}
       </div>
 
       <ConfirmModal

--- a/src/components/Wallets.test.jsx
+++ b/src/components/Wallets.test.jsx
@@ -9,6 +9,7 @@ import Wallets from './Wallets'
 
 jest.mock('../libs/JmWalletApi', () => ({
   ...jest.requireActual('../libs/JmWalletApi'),
+  getGetinfo: jest.fn(),
   getSession: jest.fn(),
   getWalletAll: jest.fn(),
   postWalletUnlock: jest.fn(),
@@ -37,6 +38,7 @@ describe('<Wallets />', () => {
 
   beforeEach(() => {
     const neverResolvingPromise = new Promise(() => {})
+    apiMock.getGetinfo.mockResolvedValue(neverResolvingPromise)
     apiMock.getSession.mockResolvedValue(neverResolvingPromise)
   })
 

--- a/src/components/Wallets.test.jsx
+++ b/src/components/Wallets.test.jsx
@@ -38,8 +38,11 @@ describe('<Wallets />', () => {
 
   beforeEach(() => {
     const neverResolvingPromise = new Promise(() => {})
-    apiMock.getGetinfo.mockResolvedValue(neverResolvingPromise)
     apiMock.getSession.mockResolvedValue(neverResolvingPromise)
+    apiMock.getGetinfo.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: '0.9.10dev' }),
+    })
   })
 
   it('should render without errors', () => {
@@ -104,7 +107,7 @@ describe('<Wallets />', () => {
     const newWalletButtonBeforeAfter = screen.getByTestId('new-wallet-btn')
     expect(newWalletButtonBeforeAfter.classList.contains('btn-lg')).toBe(true)
 
-    const importWalletButton = screen.getByTestId('import-wallet-btn')
+    const importWalletButton = await screen.findByTestId('import-wallet-btn')
     expect(importWalletButton.classList.contains('btn-lg')).toBe(true)
   })
 
@@ -138,7 +141,7 @@ describe('<Wallets />', () => {
     expect(newWalletButton.classList.contains('btn')).toBe(true)
     expect(newWalletButton.classList.contains('btn-lg')).toBe(false)
 
-    const importWalletButton = screen.getByTestId('import-wallet-btn')
+    const importWalletButton = await screen.findByTestId('import-wallet-btn')
     expect(importWalletButton.classList.contains('btn')).toBe(true)
     expect(importWalletButton.classList.contains('btn-lg')).toBe(false)
   })

--- a/src/components/Wallets.test.jsx
+++ b/src/components/Wallets.test.jsx
@@ -39,10 +39,7 @@ describe('<Wallets />', () => {
   beforeEach(() => {
     const neverResolvingPromise = new Promise(() => {})
     apiMock.getSession.mockResolvedValue(neverResolvingPromise)
-    apiMock.getGetinfo.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ version: '0.9.10dev' }),
-    })
+    apiMock.getGetinfo.mockResolvedValue(neverResolvingPromise)
   })
 
   it('should render without errors', () => {
@@ -91,6 +88,10 @@ describe('<Wallets />', () => {
       ok: true,
       json: () => Promise.resolve({ wallets: [] }),
     })
+    apiMock.getGetinfo.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ version: '0.9.10dev' }),
+    })
 
     act(() => setup({}))
 
@@ -126,6 +127,10 @@ describe('<Wallets />', () => {
       ok: true,
       json: () => Promise.resolve({ wallets: ['wallet0.jmdat', 'wallet1.jmdat'] }),
     })
+    apiMock.getGetinfo.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ version: '0.9.10dev' }),
+    })
 
     act(() => setup({}))
 
@@ -144,6 +149,35 @@ describe('<Wallets />', () => {
     const importWalletButton = await screen.findByTestId('import-wallet-btn')
     expect(importWalletButton.classList.contains('btn')).toBe(true)
     expect(importWalletButton.classList.contains('btn-lg')).toBe(false)
+  })
+
+  it('should hide "Import Wallet"-button on unsupported backend version', async () => {
+    apiMock.getSession.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          session: false,
+          maker_running: false,
+          coinjoin_in_process: false,
+          wallet_name: 'None',
+        }),
+    })
+    apiMock.getWalletAll.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ wallets: [] }),
+    })
+    apiMock.getGetinfo.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ version: '0.9.9' }),
+    })
+
+    act(() => setup({}))
+
+    expect(screen.getByText('wallets.text_loading')).toBeInTheDocument()
+    await waitForElementToBeRemoved(screen.getByText('wallets.text_loading'))
+
+    expect(screen.queryByTestId('import-wallet-btn')).not.toBeInTheDocument()
+    expect(screen.getByTestId('new-wallet-btn')).toBeInTheDocument()
   })
 
   describe('<Wallets /> lock/unlock flow', () => {

--- a/src/constants/features.ts
+++ b/src/constants/features.ts
@@ -1,0 +1,24 @@
+import { ServiceInfo } from '../context/ServiceInfoContext'
+
+interface Features {
+  importWallet: SemVer
+}
+
+const features: Features = {
+  importWallet: { major: 0, minor: 9, patch: 10 },
+}
+
+type Feature = keyof Features
+
+const __isFeatureEnabled = (name: Feature, version: SemVer): boolean => {
+  const target = features[name]
+  return (
+    version.major > target.major ||
+    (version.major === target.major && version.minor > target.minor) ||
+    (version.major === target.major && version.minor === target.minor && version.patch >= target.patch)
+  )
+}
+
+export const isFeatureEnabled = (name: Feature, serviceInfo: ServiceInfo): boolean => {
+  return !!serviceInfo.server?.version && __isFeatureEnabled(name, serviceInfo.server.version)
+}

--- a/src/constants/features.ts
+++ b/src/constants/features.ts
@@ -2,10 +2,12 @@ import { ServiceInfo } from '../context/ServiceInfoContext'
 
 interface Features {
   importWallet: SemVer
+  rescanChain: SemVer
 }
 
 const features: Features = {
-  importWallet: { major: 0, minor: 9, patch: 10 },
+  importWallet: { major: 0, minor: 9, patch: 10 }, // added in https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1461
+  rescanChain: { major: 0, minor: 9, patch: 10 }, // added in https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1461
 }
 
 type Feature = keyof Features

--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -57,7 +57,6 @@ interface JmGetInfoData {
   version: string
 }
 
-type SemVer = { major: number; minor: number; patch: number; raw: string }
 const UNKNOWN_VERSION: SemVer = { major: 0, minor: 0, patch: 0, raw: 'unknown' }
 
 type SessionFlag = { sessionActive: boolean }
@@ -326,6 +325,7 @@ export {
   useReloadServiceInfo,
   useDispatchServiceInfo,
   useSessionConnectionError,
+  ServiceInfo,
   Schedule,
   StateFlag,
 }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -8,3 +8,5 @@ type Seconds = number
 declare type MnemonicPhrase = string[]
 
 declare type SimpleAlert = import('react-bootstrap').AlertProps & { message: string | import('react').ReactNode }
+
+declare type SemVer = { major: number; minor: number; patch: number; raw?: string }

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -210,6 +210,12 @@ const Helper = (() => {
   }
 })()
 
+const getGetinfo = async ({ signal }: ApiRequestContext) => {
+  return await fetch(`${basePath()}/v1/getinfo`, {
+    signal,
+  })
+}
+
 const getSession = async ({ token, signal }: ApiRequestContext & { token?: ApiToken }) => {
   return await fetch(`${basePath()}/v1/session`, {
     headers: token ? { ...Helper.buildAuthHeader(token) } : undefined,
@@ -465,6 +471,7 @@ export class JmApiError extends Error {
 }
 
 export {
+  getGetinfo,
   postMakerStart,
   getMakerStop,
   getSession,


### PR DESCRIPTION
Resolves https://github.com/joinmarket-webui/jam/issues/637.

Using the new `/getinfo` endpoint to provide the ability to use backend version based feature toggles.
e.g. as "import wallet" feature will be available with JM v0.9.10, this enables hiding/disabling the button.

### How to test

Change the port from the dev JM backend (port `28183`) to the secondary JM backend (port `29183`), which runs an older version. Restart the ui (`npm run dev:start`) and verify that the "Import Wallet" button is not displayed anymore.

```diff
diff --git a/src/setupProxy.js b/src/setupProxy.js
index 360592a..6cdcfa3 100644
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -7,7 +7,7 @@ const SUPPORTED_BACKENDS = [BACKEND_NATIVE, BACKEND_STANDALONE]
 const {
   PUBLIC_URL = '',
   JAM_BACKEND = BACKEND_NATIVE,
-  JMWALLETD_API_PORT = '28183',
+  JMWALLETD_API_PORT = '29183',
   JMWALLETD_WEBSOCKET_PORT = '28283',
   JMOBWATCH_PORT = '62601',
   JAM_API_PORT = undefined,
```