### PR TITLE
chore: apply new formatting rules after prettier upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "jest-watch-typeahead": "^0.6.5",
         "jest-websocket-mock": "^2.4.0",
         "lint-staged": "^13.0.3",
-        "prettier": "^2.8.7",
+        "prettier": "^3.0.3",
         "react-scripts": "^5.0.1",
         "typescript": "^4.8.4"
       },
@@ -17593,15 +17593,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -35135,9 +35135,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jest-watch-typeahead": "^0.6.5",
     "jest-websocket-mock": "^2.4.0",
     "lint-staged": "^13.0.3",
-    "prettier": "^2.8.7",
+    "prettier": "^3.0.3",
     "react-scripts": "^5.0.1",
     "typescript": "^4.8.4"
   },

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -55,7 +55,7 @@ export default function App() {
       setSession({ name, token })
       setCurrentWallet({ name, token })
     },
-    [setCurrentWallet]
+    [setCurrentWallet],
   )
 
   const stopWallet = useCallback(() => {
@@ -78,10 +78,10 @@ export default function App() {
               console.info('Finished reloading wallet info.')
               setReloadingWalletInfoCounter((current) => current - 1)
             })
-        }, delay)
+        }, delay),
       )
     },
-    [reloadCurrentWalletInfo]
+    [reloadCurrentWalletInfo],
   )
 
   const router = createBrowserRouter(
@@ -170,11 +170,11 @@ export default function App() {
             </>
           )}
         </Route>
-      </Route>
+      </Route>,
     ),
     {
       basename: window.JM.PUBLIC_PATH,
-    }
+    },
   )
 
   if (settings.showOnboarding === true) {
@@ -244,7 +244,7 @@ const WalletInfoAutoReload = ({ currentWallet, reloadWalletInfo }: WalletInfoAut
   const [currentRescanning, setCurrentRescanning] = useState(serviceInfo?.rescanning || false)
   const rescanningFinished = useMemo(
     () => previousRescanning === true && currentRescanning === false,
-    [previousRescanning, currentRescanning]
+    [previousRescanning, currentRescanning],
   )
 
   useEffect(() => {
@@ -258,7 +258,7 @@ const WalletInfoAutoReload = ({ currentWallet, reloadWalletInfo }: WalletInfoAut
 
       reloadWalletInfo(RELOAD_WALLET_INFO_DELAY.AFTER_UNLOCK).catch((err) => console.error(err))
     },
-    [currentWallet, reloadWalletInfo]
+    [currentWallet, reloadWalletInfo],
   )
 
   useEffect(
@@ -272,7 +272,7 @@ const WalletInfoAutoReload = ({ currentWallet, reloadWalletInfo }: WalletInfoAut
         currentBalance: Api.AmountSats,
         delay: Milliseconds,
         maxCalls: number,
-        callCounter: number = 0
+        callCounter: number = 0,
       ) => {
         if (callCounter >= maxCalls) return
         const info = await reloadWalletInfo(delay)
@@ -287,12 +287,12 @@ const WalletInfoAutoReload = ({ currentWallet, reloadWalletInfo }: WalletInfoAut
           reloadWhileBalanceChangesRecursively(
             info.balanceSummary.calculatedTotalBalanceInSats,
             RELOAD_WALLET_INFO_DELAY.AFTER_RESCAN,
-            MAX_RECURSIVE_WALLET_INFO_RELOADS
-          )
+            MAX_RECURSIVE_WALLET_INFO_RELOADS,
+          ),
         )
         .catch((err) => console.error(err))
     },
-    [currentWallet, rescanningFinished, reloadWalletInfo]
+    [currentWallet, rescanningFinished, reloadWalletInfo],
   )
 
   return <></>

--- a/src/components/CoinjoinPreconditionViolationAlert.tsx
+++ b/src/components/CoinjoinPreconditionViolationAlert.tsx
@@ -96,5 +96,5 @@ export const CoinjoinPreconditionViolationAlert = forwardRef(
     }
 
     return <></>
-  }
+  },
 )

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -3,11 +3,11 @@ import { ReactNode, PropsWithChildren, useState, useEffect, useRef } from 'react
 const copyToClipboard = (
   text: string,
   fallbackInputField: HTMLInputElement,
-  errorMessage?: string
+  errorMessage?: string,
 ): Promise<boolean> => {
   const copyToClipboardFallback = (
     inputField: HTMLInputElement,
-    errorMessage = 'Cannot copy value to clipboard'
+    errorMessage = 'Cannot copy value to clipboard',
   ): Promise<boolean> =>
     new Promise((resolve, reject) => {
       inputField.select()

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -23,7 +23,7 @@ const BackupConfirmation = ({ wallet, onSuccess, onCancel }) => {
 
   const isSeedBackupConfirmed = useMemo(
     () => givenWords.every((word, index) => word === seedphrase[index]),
-    [givenWords, seedphrase]
+    [givenWords, seedphrase],
   )
 
   return (
@@ -108,7 +108,7 @@ export default function CreateWallet({ parentRoute, startWallet }) {
         setAlert({ variant: 'danger', message })
       }
     },
-    [setAlert, setCreatedWallet, t]
+    [setAlert, setCreatedWallet, t],
   )
 
   const walletConfirmed = useCallback(() => {
@@ -123,7 +123,7 @@ export default function CreateWallet({ parentRoute, startWallet }) {
 
   const isCreated = useMemo(
     () => createdWallet?.walletFileName && createdWallet?.seedphrase && createdWallet?.password,
-    [createdWallet]
+    [createdWallet],
   )
   const canCreate = useMemo(() => !isCreated && !serviceInfo?.walletName, [isCreated, serviceInfo])
   const [showBackupConfirmation, setShowBackupConfirmation] = useState(false)

--- a/src/components/CreateWallet.test.jsx
+++ b/src/components/CreateWallet.test.jsx
@@ -27,7 +27,7 @@ describe('<CreateWallet />', () => {
     render(
       <BrowserRouter>
         <CreateWallet startWallet={startWallet} />
-      </BrowserRouter>
+      </BrowserRouter>,
     )
   }
 

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -157,7 +157,7 @@ const EarnReportTable = ({ data }: EarnReportTableProps) => {
         [SORT_KEYS.inputCount]: (array) => array.sort((a, b) => +a.inputCount - +b.inputCount),
         [SORT_KEYS.inputAmountInSats]: (array) => array.sort((a, b) => +a.inputAmount - +b.inputAmount),
       },
-    }
+    },
   )
 
   return (
@@ -362,7 +362,7 @@ export function EarnReportOverlay({ show, onHide }: rb.OffcanvasProps) {
           setAlert({ variant: 'danger', message })
         })
     },
-    [t]
+    [t],
   )
 
   useEffect(() => {

--- a/src/components/ImportWallet.tsx
+++ b/src/components/ImportWallet.tsx
@@ -81,7 +81,7 @@ const ImportWalletDetailsForm = ({
       }
       return errors
     },
-    [t]
+    [t],
   )
 
   return (
@@ -249,7 +249,7 @@ const ImportWalletConfirmation = ({
       password: walletDetails.password,
       seedphrase: importDetails.mnemonicPhrase.join(' '),
     }),
-    [walletDetails, importDetails]
+    [walletDetails, importDetails],
   )
 
   return (
@@ -331,7 +331,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
   const isRecovered = useMemo(() => !!recoveredWallet?.walletFileName && recoveredWallet?.token, [recoveredWallet])
   const canRecover = useMemo(
     () => !isRecovered && !serviceInfo?.walletName && !serviceInfo?.rescanning,
-    [isRecovered, serviceInfo]
+    [isRecovered, serviceInfo],
   )
 
   const [step, setStep] = useState<ImportWalletSteps>(ImportWalletSteps.wallet_details)
@@ -369,7 +369,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
         seedphrase,
         gaplimit,
         blockheight,
-      }: { walletname: Api.WalletName; password: string; seedphrase: string; gaplimit: number; blockheight: number }
+      }: { walletname: Api.WalletName; password: string; seedphrase: string; gaplimit: number; blockheight: number },
     ) => {
       setAlert(undefined)
 
@@ -465,7 +465,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
       updateConfigValues,
       dispatchServiceInfo,
       t,
-    ]
+    ],
   )
 
   return (
@@ -523,7 +523,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
                 t(
                   isSubmitting
                     ? 'import_wallet.wallet_details.text_button_submitting'
-                    : 'import_wallet.wallet_details.text_button_submit'
+                    : 'import_wallet.wallet_details.text_button_submit',
                 )
               }
             />
@@ -535,7 +535,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
                 t(
                   isSubmitting
                     ? 'import_wallet.import_details.text_button_submitting'
-                    : 'import_wallet.import_details.text_button_submit'
+                    : 'import_wallet.import_details.text_button_submit',
                 )
               }
               onCancel={() => previousStep()}
@@ -553,7 +553,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
                 t(
                   isSubmitting
                     ? 'import_wallet.confirmation.text_button_submitting'
-                    : 'import_wallet.confirmation.text_button_submit'
+                    : 'import_wallet.confirmation.text_button_submit',
                 )
               }
               onCancel={() => previousStep()}

--- a/src/components/Jam.tsx
+++ b/src/components/Jam.tsx
@@ -24,7 +24,7 @@ const DEST_ADDRESS_COUNT_TEST = 1
 const getNewAddressesForTesting = (
   walletInfo: WalletInfo,
   count: number,
-  mixdepth: number
+  mixdepth: number,
 ): Array<Api.BitcoinAddress> => {
   const externalBranch = walletInfo.data.display.walletinfo.accounts[mixdepth].branches.find((branch) => {
     return branch.branch.split('\t')[0] === 'external addresses'
@@ -42,7 +42,7 @@ const getNewAddressesForTesting = (
 const getNewAddressesForTestingOrEmpty = (
   walletInfo: WalletInfo | undefined,
   count: number,
-  mixdepth = 0
+  mixdepth = 0,
 ): Array<Api.BitcoinAddress | ''> => {
   if (!walletInfo) {
     return Array(count).fill('')
@@ -67,7 +67,7 @@ const isValidAddress = (candidate: any) => {
 const isAddressReused = (
   walletInfo: WalletInfo,
   destination: Api.BitcoinAddress,
-  inputAddresses: Api.BitcoinAddress[]
+  inputAddresses: Api.BitcoinAddress[],
 ) => {
   if (!destination) return false
 
@@ -164,18 +164,18 @@ export default function Jam({ wallet }: JamProps) {
 
   const collaborativeOperationRunning = useMemo(
     () => serviceInfo?.coinjoinInProgress || serviceInfo?.makerRunning || false,
-    [serviceInfo]
+    [serviceInfo],
   )
 
   const schedulerPreconditionSummary = useMemo(
     () => buildCoinjoinRequirementSummary(walletInfo?.data.utxos.utxos || []),
-    [walletInfo]
+    [walletInfo],
   )
 
   const [useInsecureTestingSettings, setUseInsecureTestingSettings] = useState(false)
   const addressCount = useMemo(
     () => (useInsecureTestingSettings ? DEST_ADDRESS_COUNT_TEST : DEST_ADDRESS_COUNT_PROD),
-    [useInsecureTestingSettings]
+    [useInsecureTestingSettings],
   )
 
   const initialFormValues = useMemo<FormikValues>(() => {
@@ -207,7 +207,7 @@ export default function Jam({ wallet }: JamProps) {
           setIsLoading(false)
         })
     },
-    [reloadServiceInfo, reloadCurrentWalletInfo, t]
+    [reloadServiceInfo, reloadCurrentWalletInfo, t],
   )
 
   useEffect(() => {
@@ -462,7 +462,7 @@ export default function Jam({ wallet }: JamProps) {
                                     try {
                                       const newAddresses = getNewAddressesForTestingOrEmpty(
                                         walletInfo,
-                                        DEST_ADDRESS_COUNT_TEST
+                                        DEST_ADDRESS_COUNT_TEST,
                                       )
                                       newAddresses.forEach((newAddress, index) => {
                                         setFieldValue(`dest${index + 1}`, newAddress, true)

--- a/src/components/LogOverlay.tsx
+++ b/src/components/LogOverlay.tsx
@@ -95,7 +95,7 @@ export function LogOverlay({ currentWallet, show, onHide }: LogOverlayProps) {
           setIsLoading(false)
         })
     },
-    [currentWallet, t]
+    [currentWallet, t],
   )
 
   useEffect(() => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -221,7 +221,7 @@ function FastThemeToggle() {
         settingsDispatch({ theme })
       }
     },
-    [settingsDispatch]
+    [settingsDispatch],
   )
 
   return (
@@ -250,11 +250,11 @@ export default function Navbar() {
   const rescanInProgress = useMemo(() => serviceInfo?.rescanning === true, [serviceInfo])
   const schedulerRunning = useMemo(
     () => (serviceInfo?.coinjoinInProgress && serviceInfo?.schedule !== null) || false,
-    [serviceInfo]
+    [serviceInfo],
   )
   const singleCoinJoinRunning = useMemo(
     () => (serviceInfo?.coinjoinInProgress && serviceInfo?.schedule === null) || false,
-    [serviceInfo]
+    [serviceInfo],
   )
 
   const joiningRoute = useMemo(() => {

--- a/src/components/Onboarding.jsx
+++ b/src/components/Onboarding.jsx
@@ -38,7 +38,7 @@ export default function Onboarding() {
         icon: <Sprite symbol="shield-outline" width="11rem" height="11rem" />,
       },
     ],
-    [t]
+    [t],
   )
 
   const next = useCallback(() => {

--- a/src/components/Orderbook.tsx
+++ b/src/components/Orderbook.tsx
@@ -168,7 +168,7 @@ const OrderbookTable = ({ data }: OrderbookTableProps) => {
           }),
         [SORT_KEYS.bondValue]: (array) => array.sort((a, b) => a.bondValue - b.bondValue),
       },
-    }
+    },
   )
 
   return (
@@ -283,7 +283,7 @@ export function Orderbook({ orders, refresh, nickname }: OrderbookProps) {
   const counterpartyCount = useMemo(() => new Set(orders.map((it) => it.counterparty)).size, [orders])
   const counterpartyCountFiltered = useMemo(
     () => new Set(tableData.nodes.map((it) => it.counterparty)).size,
-    [tableData]
+    [tableData],
   )
 
   useEffect(() => {
@@ -412,7 +412,7 @@ export function OrderbookOverlay({ nickname, show, onHide }: OrderbookOverlayPro
           setAlert({ variant: 'danger', message })
         })
     },
-    [t]
+    [t],
   )
 
   useEffect(() => {

--- a/src/components/PreventLeavingPageByMistake.tsx
+++ b/src/components/PreventLeavingPageByMistake.tsx
@@ -19,7 +19,7 @@ const PreventLeavingPageByMistake = () => {
         // return something to trigger a dialog
         return ''
       },
-      { signal: abortCtrl.signal }
+      { signal: abortCtrl.signal },
     )
 
     return () => abortCtrl.abort()

--- a/src/components/Receive.jsx
+++ b/src/components/Receive.jsx
@@ -33,7 +33,7 @@ export default function Receive({ wallet }) {
   const sortedAccountBalances = useMemo(() => {
     if (!walletInfo) return []
     return Object.values(walletInfo.balanceSummary.accountBalances).sort(
-      (lhs, rhs) => lhs.accountIndex - rhs.accountIndex
+      (lhs, rhs) => lhs.accountIndex - rhs.accountIndex,
     )
   }, [walletInfo])
 
@@ -142,7 +142,7 @@ export default function Receive({ wallet }) {
                     isSelected={it.accountIndex === selectedJarIndex}
                     fillLevel={jarFillLevel(
                       it.calculatedTotalBalanceInSats,
-                      walletInfo.balanceSummary.calculatedTotalBalanceInSats
+                      walletInfo.balanceSummary.calculatedTotalBalanceInSats,
                     )}
                     onClick={(jarIndex) => setSelectedJarIndex(jarIndex)}
                   />

--- a/src/components/RescanChain.tsx
+++ b/src/components/RescanChain.tsx
@@ -138,7 +138,7 @@ export default function RescanChain({ wallet }: RescanChainProps) {
         setAlert({ variant: 'danger', message })
       }
     },
-    [wallet, setAlert, dispatchServiceInfo, t]
+    [wallet, setAlert, dispatchServiceInfo, t],
   )
 
   return (

--- a/src/components/ScheduleProgress.jsx
+++ b/src/components/ScheduleProgress.jsx
@@ -36,7 +36,7 @@ const scheduleToSteps = (schedule) => {
   // it takes to find and talk to makers and wait for tx confirmations on the timechain.
   const totalWaitTime = Math.max(
     1,
-    schedule.slice(0, schedule.length - 1).reduce((acc, tx) => acc + tx[4] * 60, 0)
+    schedule.slice(0, schedule.length - 1).reduce((acc, tx) => acc + tx[4] * 60, 0),
   )
   // Distribute the tx's on the progress bar relative to the waittime after the previous tx completes.
   const txs = schedule.map((tx, i) => {

--- a/src/components/Send/FeeBreakdown.tsx
+++ b/src/components/Send/FeeBreakdown.tsx
@@ -69,7 +69,7 @@ const FeeBreakdown = ({
       feeConfigValues?.max_cj_fee_rel
         ? `${factorToPercentage(feeConfigValues.max_cj_fee_rel)}%`
         : t('send.fee_breakdown.placeholder_config_value_not_present'),
-    [feeConfigValues, t]
+    [feeConfigValues, t],
   )
 
   /** eg: 44658 (expressed in sats) */
@@ -78,7 +78,7 @@ const FeeBreakdown = ({
       feeConfigValues?.max_cj_fee_rel && numCollaborators && amount && amount > 0
         ? Math.ceil(amount * feeConfigValues.max_cj_fee_rel) * numCollaborators
         : null,
-    [feeConfigValues, amount, numCollaborators]
+    [feeConfigValues, amount, numCollaborators],
   )
 
   /** eg: "8,636 sats" */
@@ -87,26 +87,26 @@ const FeeBreakdown = ({
       feeConfigValues?.max_cj_fee_abs
         ? `${formatSats(feeConfigValues.max_cj_fee_abs)} sats`
         : t('send.fee_breakdown.placeholder_config_value_not_present'),
-    [feeConfigValues, t]
+    [feeConfigValues, t],
   )
 
   /** eg: 77724 (expressed in sats) */
   const maxEstimatedAbsoluteFee = useMemo(
     () =>
       feeConfigValues?.max_cj_fee_abs && numCollaborators ? feeConfigValues.max_cj_fee_abs * numCollaborators : null,
-    [feeConfigValues, numCollaborators]
+    [feeConfigValues, numCollaborators],
   )
 
   const isAbsoluteFeeHighlighted = useMemo(
     () =>
       maxEstimatedAbsoluteFee && maxEstimatedRelativeFee ? maxEstimatedAbsoluteFee > maxEstimatedRelativeFee : false,
-    [maxEstimatedAbsoluteFee, maxEstimatedRelativeFee]
+    [maxEstimatedAbsoluteFee, maxEstimatedRelativeFee],
   )
 
   const isRelativeFeeHighlighted = useMemo(
     () =>
       maxEstimatedAbsoluteFee && maxEstimatedRelativeFee ? maxEstimatedRelativeFee > maxEstimatedAbsoluteFee : false,
-    [maxEstimatedAbsoluteFee, maxEstimatedRelativeFee]
+    [maxEstimatedAbsoluteFee, maxEstimatedRelativeFee],
   )
 
   return (

--- a/src/components/Send/helpers.ts
+++ b/src/components/Send/helpers.ts
@@ -32,7 +32,7 @@ export const isValidNumCollaborators = (candidate: number | null, minNumCollabor
 export const enhanceDirectPaymentErrorMessageIfNecessary = async (
   httpStatus: number,
   errorMessage: string,
-  onBadRequest: (errorMessage: string) => string
+  onBadRequest: (errorMessage: string) => string,
 ) => {
   const tryEnhanceMessage = httpStatus === 400
   if (tryEnhanceMessage) {
@@ -46,7 +46,7 @@ export const enhanceTakerErrorMessageIfNecessary = async (
   loadConfigValue: ServiceConfigContextEntry['loadConfigValueIfAbsent'],
   httpStatus: number,
   errorMessage: string,
-  onMaxFeeSettingsMissing: (errorMessage: string) => string
+  onMaxFeeSettingsMissing: (errorMessage: string) => string,
 ) => {
   const tryEnhanceMessage = httpStatus === 409
   if (tryEnhanceMessage) {

--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -91,12 +91,12 @@ export default function Send({ wallet }: SendProps) {
 
   const isOperationDisabled = useMemo(
     () => isCoinjoinInProgress || isMakerRunning || isRescanningInProgress || waitForUtxosToBeSpent.length > 0,
-    [isCoinjoinInProgress, isMakerRunning, isRescanningInProgress, waitForUtxosToBeSpent]
+    [isCoinjoinInProgress, isMakerRunning, isRescanningInProgress, waitForUtxosToBeSpent],
   )
   const [isInitializing, setIsInitializing] = useState(!isOperationDisabled)
   const isLoading = useMemo(
     () => !walletInfo || isInitializing || waitForUtxosToBeSpent.length > 0,
-    [walletInfo, isInitializing, waitForUtxosToBeSpent]
+    [walletInfo, isInitializing, waitForUtxosToBeSpent],
   )
 
   const [destination, setDestination] = useState<Api.BitcoinAddress | null>(INITIAL_DESTINATION)
@@ -108,7 +108,7 @@ export default function Send({ wallet }: SendProps) {
   const sortedAccountBalances = useMemo(() => {
     if (!walletInfo) return []
     return Object.values(walletInfo.balanceSummary.accountBalances).sort(
-      (lhs, rhs) => lhs.accountIndex - rhs.accountIndex
+      (lhs, rhs) => lhs.accountIndex - rhs.accountIndex,
     )
   }, [walletInfo])
 
@@ -125,7 +125,7 @@ export default function Send({ wallet }: SendProps) {
         return jarsWithBalance[0].accountIndex
       })
     },
-    [isLoading, sourceJarIndex, sortedAccountBalances]
+    [isLoading, sourceJarIndex, sortedAccountBalances],
   )
 
   const accountBalance = useMemo(() => {
@@ -240,7 +240,7 @@ export default function Send({ wallet }: SendProps) {
         clearTimeout(timer)
       }
     },
-    [waitForUtxosToBeSpent, reloadCurrentWalletInfo, t]
+    [waitForUtxosToBeSpent, reloadCurrentWalletInfo, t],
   )
 
   useEffect(
@@ -293,12 +293,12 @@ export default function Send({ wallet }: SendProps) {
         })
 
       Promise.all([loadingServiceInfo, loadingWalletInfoAndUtxos, loadingMinimumMakerConfig]).finally(
-        () => !abortCtrl.signal.aborted && setIsInitializing(false)
+        () => !abortCtrl.signal.aborted && setIsInitializing(false),
       )
 
       return () => abortCtrl.abort()
     },
-    [isOperationDisabled, wallet, reloadCurrentWalletInfo, reloadServiceInfo, loadConfigValue, t]
+    [isOperationDisabled, wallet, reloadCurrentWalletInfo, reloadServiceInfo, loadConfigValue, t],
   )
 
   useEffect(
@@ -312,13 +312,13 @@ export default function Send({ wallet }: SendProps) {
 
       setDestinationIsReusedAddress(false)
     },
-    [walletInfo, destination]
+    [walletInfo, destination],
   )
 
   const sendPayment = async (
     sourceJarIndex: JarIndex,
     destination: Api.BitcoinAddress,
-    amount_sats: Api.AmountSats
+    amount_sats: Api.AmountSats,
   ) => {
     setAlert(undefined)
     setPaymentSuccessfulInfoAlert(undefined)
@@ -351,7 +351,7 @@ export default function Send({ wallet }: SendProps) {
         const displayMessage = await enhanceDirectPaymentErrorMessageIfNecessary(
           res.status,
           message,
-          (errorMessage) => `${errorMessage} ${t('send.direct_payment_error_message_bad_request')}`
+          (errorMessage) => `${errorMessage} ${t('send.direct_payment_error_message_bad_request')}`,
         )
         setAlert({ variant: 'danger', message: displayMessage })
       }
@@ -369,7 +369,7 @@ export default function Send({ wallet }: SendProps) {
     sourceJarIndex: JarIndex,
     destination: Api.BitcoinAddress,
     amount_sats: Api.AmountSats,
-    counterparties: number
+    counterparties: number,
   ) => {
     setAlert(undefined)
     setIsSending(true)
@@ -394,7 +394,7 @@ export default function Send({ wallet }: SendProps) {
           loadConfigValue,
           res.status,
           message,
-          (errorMessage) => `${errorMessage} ${t('send.taker_error_message_max_fees_config_missing')}`
+          (errorMessage) => `${errorMessage} ${t('send.taker_error_message_max_fees_config_missing')}`,
         )
 
         setAlert({ variant: 'danger', message: displayMessage })
@@ -655,7 +655,7 @@ export default function Send({ wallet }: SendProps) {
                 mixdepth: selectedJar,
               })
                 .then((res) =>
-                  res.ok ? res.json() : Api.Helper.throwError(res, t('receive.error_loading_address_failed'))
+                  res.ok ? res.json() : Api.Helper.throwError(res, t('receive.error_loading_address_failed')),
                 )
                 .then((data) => {
                   if (abortCtrl.signal.aborted) return
@@ -691,7 +691,7 @@ export default function Send({ wallet }: SendProps) {
                     isSelected={it.accountIndex === sourceJarIndex}
                     fillLevel={jarFillLevel(
                       it.calculatedTotalBalanceInSats,
-                      walletInfo.balanceSummary.calculatedTotalBalanceInSats
+                      walletInfo.balanceSummary.calculatedTotalBalanceInSats,
                     )}
                     variant={
                       it.accountIndex === sourceJarIndex &&

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -69,7 +69,7 @@ export default function Settings({ wallet, stopWallet }) {
         setAlert({ variant: 'danger', dismissible: false, message: e.message })
       }
     },
-    [wallet, stopWallet, navigate, serviceInfo]
+    [wallet, stopWallet, navigate, serviceInfo],
   )
 
   useEffect(() => {

--- a/src/components/Settings.test.jsx
+++ b/src/components/Settings.test.jsx
@@ -12,7 +12,7 @@ describe('<Settings />', () => {
     render(
       <BrowserRouter>
         <Settings wallet={wallet} />
-      </BrowserRouter>
+      </BrowserRouter>,
     )
   }
 
@@ -23,7 +23,7 @@ describe('<Settings />', () => {
           name: dummyWalletName,
           token: dummyToken,
         },
-      })
+      }),
     )
 
     expect(screen.getByText('settings.section_title_display')).toBeVisible()

--- a/src/components/Wallet.test.tsx
+++ b/src/components/Wallet.test.tsx
@@ -38,7 +38,7 @@ describe('<Wallet />', () => {
           coinjoinInProgress={coinjoinInProgress}
           makerRunning={makerRunning}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     )
   }
 
@@ -89,7 +89,7 @@ describe('<Wallet />', () => {
         name: dummyWalletName,
         isActive: true,
         unlockWallet: mockUnlockWallet,
-      })
+      }),
     )
 
     expect(screen.getByText(walletDisplayName(dummyWalletName))).toBeInTheDocument()
@@ -106,7 +106,7 @@ describe('<Wallet />', () => {
         name: dummyWalletName,
         isActive: true,
         lockWallet: mockLockWallet,
-      })
+      }),
     )
 
     expect(screen.getByText(walletDisplayName(dummyWalletName))).toBeInTheDocument()
@@ -123,7 +123,7 @@ describe('<Wallet />', () => {
         name: dummyWalletName,
         isActive: true,
         lockWallet: mockLockWallet,
-      })
+      }),
     )
 
     expect(screen.getByText('wallets.wallet_preview.wallet_active')).toBeInTheDocument()

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -85,7 +85,7 @@ const WalletUnlockForm = ({ walletName, unlockWallet }: WalletUnlockFormProps) =
       const { password } = values
       await unlockWallet(walletName, password)
     },
-    [walletName, unlockWallet]
+    [walletName, unlockWallet],
   )
 
   return (

--- a/src/components/WalletCreationForm.tsx
+++ b/src/components/WalletCreationForm.tsx
@@ -49,7 +49,7 @@ const WalletCreationForm = ({
       }
       return errors
     },
-    [t]
+    [t],
   )
 
   return (

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -74,7 +74,7 @@ export default function Wallets({ currentWallet, startWallet, stopWallet }) {
         setUnlockWalletName(undefined)
       }
     },
-    [currentWallet, setAlert, startWallet, t, navigate]
+    [currentWallet, setAlert, startWallet, t, navigate],
   )
 
   const lockWallet = useCallback(
@@ -135,7 +135,7 @@ export default function Wallets({ currentWallet, startWallet, stopWallet }) {
         setAlert({ variant: 'danger', dismissible: false, message: e.message })
       }
     },
-    [currentWallet, coinjoinInProgress, makerRunning, setAlert, stopWallet, t]
+    [currentWallet, coinjoinInProgress, makerRunning, setAlert, stopWallet, t],
   )
 
   useEffect(() => {

--- a/src/components/Wallets.test.jsx
+++ b/src/components/Wallets.test.jsx
@@ -32,7 +32,7 @@ describe('<Wallets />', () => {
     render(
       <BrowserRouter>
         <Wallets currentWallet={currentWallet} startWallet={mockStartWallet} stopWallet={mockStopWallet} />
-      </BrowserRouter>
+      </BrowserRouter>,
     )
   }
 
@@ -299,7 +299,7 @@ describe('<Wallets />', () => {
             name: dummyWalletName,
             token: dummyToken,
           },
-        })
+        }),
       )
 
       expect(screen.getByText('wallets.wallet_preview.wallet_active')).toBeInTheDocument()
@@ -346,7 +346,7 @@ describe('<Wallets />', () => {
             name: dummyWalletName,
             token: dummyToken,
           },
-        })
+        }),
       )
 
       expect(screen.getByText('wallets.wallet_preview.wallet_active')).toBeInTheDocument()
@@ -397,7 +397,7 @@ describe('<Wallets />', () => {
               name: dummyWalletName,
               token: dummyToken,
             },
-          })
+          }),
         )
 
         // modal is initially not shown
@@ -441,7 +441,7 @@ describe('<Wallets />', () => {
         await waitForElementToBeRemoved(screen.getByText('wallets.wallet_preview.modal_lock_wallet_title'))
 
         expect(mockStopWallet).toHaveBeenCalled()
-      }
+      },
     )
   })
 })

--- a/src/components/fb/CreateFidelityBond.tsx
+++ b/src/components/fb/CreateFidelityBond.tsx
@@ -131,10 +131,10 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
         } else {
           return Api.Helper.throwError(
             res,
-            freeze ? t('earn.fidelity_bond.error_freezing_utxos') : t('earn.fidelity_bond.error_unfreezing_utxos')
+            freeze ? t('earn.fidelity_bond.error_freezing_utxos') : t('earn.fidelity_bond.error_unfreezing_utxos'),
           )
         }
-      })
+      }),
     )
 
     Promise.all(freezeCalls)
@@ -180,10 +180,10 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
         mixdepth: jarIndex,
         destination: address,
         amount_sats: 0, // sweep
-      }
+      },
     )
       .then((res) =>
-        res.ok ? res.json() : Api.Helper.throwError(res, t('earn.fidelity_bond.error_creating_fidelity_bond'))
+        res.ok ? res.json() : Api.Helper.throwError(res, t('earn.fidelity_bond.error_creating_fidelity_bond')),
       )
       .then((body) => setUtxoIdsToBeSpent(body.txinfo.inputs.map((input: any) => input.outpoint)))
       .then((_) => setAlert(undefined))
@@ -380,7 +380,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
         return t('earn.fidelity_bond.select_utxos.text_primary_button')
       case steps.freezeUtxos:
         const utxosAreFrozen = fb.utxo.allAreFrozen(
-          fb.utxo.utxosToFreeze(walletInfo.utxosByJar[selectedJar!], selectedUtxos)
+          fb.utxo.utxosToFreeze(walletInfo.utxosByJar[selectedJar!], selectedUtxos),
         )
 
         if (utxosAreFrozen) {
@@ -417,7 +417,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
 
   const onlyCjOutOrFbUtxosSelected = () => {
     return selectedUtxos.every(
-      (utxo) => walletInfo.addressSummary[utxo.address]?.status === 'cj-out' || utxo.locktime !== undefined
+      (utxo) => walletInfo.addressSummary[utxo.address]?.status === 'cj-out' || utxo.locktime !== undefined,
     )
   }
 
@@ -469,7 +469,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
       }
 
       const utxosAreFrozen = fb.utxo.allAreFrozen(
-        fb.utxo.utxosToFreeze(walletInfo.utxosByJar[selectedJar!], selectedUtxos)
+        fb.utxo.utxosToFreeze(walletInfo.utxosByJar[selectedJar!], selectedUtxos),
       )
       if (utxosAreFrozen) {
         return steps.reviewInputs

--- a/src/components/fb/LockdateForm.tsx
+++ b/src/components/fb/LockdateForm.tsx
@@ -36,7 +36,7 @@ export const _selectableMonths = (
   year: number,
   yearsRange: fb.YearsRange,
   now = new Date(),
-  locale?: string
+  locale?: string,
 ): SelectableMonth[] => {
   const minMonth = _minMonth(year, yearsRange, now)
   return Array(12)
@@ -80,7 +80,7 @@ const LockdateForm = ({ onChange, now, yearsRange }: LockdateFormProps) => {
   const selectableYears = useMemo(() => _selectableYears(_yearsRange, _now), [_yearsRange, _now])
   const selectableMonths = useMemo(
     () => _selectableMonths(lockdateYear, _yearsRange, _now, i18n.resolvedLanguage || i18n.language),
-    [lockdateYear, _yearsRange, _now, i18n]
+    [lockdateYear, _yearsRange, _now, i18n],
   )
 
   const isLockdateYearValid = useMemo(() => selectableYears.includes(lockdateYear), [lockdateYear, selectableYears])
@@ -90,7 +90,7 @@ const LockdateForm = ({ onChange, now, yearsRange }: LockdateFormProps) => {
         .filter((it) => !it.disabled)
         .map((it) => it.value)
         .includes(lockdateMonth),
-    [lockdateMonth, selectableMonths]
+    [lockdateMonth, selectableMonths],
   )
 
   useEffect(() => {

--- a/src/components/fb/SpendFidelityBondModal.tsx
+++ b/src/components/fb/SpendFidelityBondModal.tsx
@@ -62,7 +62,7 @@ type UtxoDirectSendHook = {
 const spendUtxosWithDirectSend = async (
   context: Api.WalletRequestContext,
   request: UtxoDirectSendRequest,
-  hooks: UtxoDirectSendHook
+  hooks: UtxoDirectSendHook,
 ) => {
   const utxosFromSameJar = request.utxos.every((it) => it.mixdepth === request.sourceJarIndex)
   if (!utxosFromSameJar || request.utxos.length === 0) {
@@ -93,7 +93,7 @@ const spendUtxosWithDirectSend = async (
       Api.postFreeze(context, { utxo: utxo.utxo, freeze: true }).then((res) => {
         if (!res.ok) return hooks.onFreezeUtxosError(res)
         utxosThatWereFrozen.push(utxo.utxo)
-      })
+      }),
     )
     // freeze unused coins not part of the payment
     await Promise.all(freezeCalls)
@@ -104,7 +104,7 @@ const spendUtxosWithDirectSend = async (
         Api.postFreeze(context, { utxo: utxo.utxo, freeze: false }).then((res) => {
           if (!res.ok) return hooks.onUnfreezeUtxosError(res)
           utxosThatWereUnfrozen.push(utxo.utxo)
-        })
+        }),
       )
     // unfreeze potentially frozen coins that are about to be spent
     await Promise.all(unfreezeCalls)
@@ -160,7 +160,7 @@ const SpendFidelityBondModal = ({
 
   const [alert, setAlert] = useState<SimpleAlert>()
   const [selectedDestinationJarIndex, setSelectedDestinationJarIndex] = useState<JarIndex | undefined>(
-    destinationJarIndex
+    destinationJarIndex,
   )
 
   const [txInfo, setTxInfo] = useState<TxInfo | undefined>()
@@ -290,7 +290,7 @@ const SpendFidelityBondModal = ({
           Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_unfreezing_fidelity_bond')),
         onSendError: (res) =>
           Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_spending_fidelity_bond')),
-      }
+      },
     )
   }
 
@@ -406,7 +406,7 @@ const SpendFidelityBondModal = ({
           data={{
             sourceJarIndex: undefined, // dont show a source jar - might be confusing in this context
             destination: String(
-              t('send.confirm_send_modal.text_source_jar', { jarId: jarInitial(selectedDestinationJarIndex) })
+              t('send.confirm_send_modal.text_source_jar', { jarId: jarInitial(selectedDestinationJarIndex) }),
             ),
             amount: fidelityBond.value,
             isSweep: true,

--- a/src/components/fb/utils.test.ts
+++ b/src/components/fb/utils.test.ts
@@ -16,7 +16,7 @@ const makeUtxo = (id: string, address = '', frozen = false) =>
     confirmations: 0,
     frozen: frozen,
     utxo: id,
-  } as Utxo)
+  }) as Utxo
 
 describe('utils', () => {
   describe('lockdate', () => {
@@ -80,7 +80,7 @@ describe('utils', () => {
           makeUtxo('foo:2'),
           makeUtxo('foo:3'),
           makeUtxo('foo:4'),
-        ])
+        ]),
       ).toBe(true)
 
       expect(
@@ -90,7 +90,7 @@ describe('utils', () => {
           makeUtxo('foo:2'),
           makeUtxo('foo:3'),
           makeUtxo('foo:4'),
-        ])
+        ]),
       ).toBe(true)
 
       expect(
@@ -100,7 +100,7 @@ describe('utils', () => {
           makeUtxo('foo:2'),
           makeUtxo('foo:3'),
           makeUtxo('foo:4'),
-        ])
+        ]),
       ).toBe(true)
 
       expect(
@@ -110,7 +110,7 @@ describe('utils', () => {
           makeUtxo('foo:2'),
           makeUtxo('foo:3'),
           makeUtxo('foo:4'),
-        ])
+        ]),
       ).toBe(false)
     })
 

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -101,7 +101,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
   const serviceInfo = useServiceInfo()
   const isTakerOrMakerRunning = useMemo(
     () => serviceInfo && (serviceInfo.makerRunning || serviceInfo.coinjoinInProgress),
-    [serviceInfo]
+    [serviceInfo],
   )
 
   const [alert, setAlert] = useState<SimpleAlert>()
@@ -132,7 +132,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
   const utxos = useMemo(() => props.walletInfo.utxosByJar[jarIndex] || [], [props.walletInfo, jarIndex])
   const selectedUtxos = useMemo(
     () => utxos.filter((utxo: Utxo) => selectedUtxoIds.includes(utxo.utxo)),
-    [utxos, selectedUtxoIds]
+    [utxos, selectedUtxoIds],
   )
   const selectedUtxosBalance: Api.AmountSats = useMemo(() => {
     return selectedUtxos.map((it) => it.value).reduce((acc, curr) => acc + curr, 0)
@@ -140,11 +140,11 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
 
   const nextJar = useCallback(
     () => setJarIndex((current) => (current + 1 >= props.jars.length ? 0 : current + 1)),
-    [props.jars]
+    [props.jars],
   )
   const previousJar = useCallback(
     () => setJarIndex((current) => (current - 1 < 0 ? props.jars.length - 1 : current - 1)),
-    [props.jars]
+    [props.jars],
   )
 
   useEffect(() => {
@@ -179,7 +179,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
       if (e.code === 'ArrowLeft') previousJar()
       else if (e.code === 'ArrowRight') nextJar()
     },
-    [previousJar, nextJar]
+    [previousJar, nextJar],
   )
 
   useEffect(() => {
@@ -228,11 +228,11 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
             if (!res.ok) {
               return Api.Helper.throwError(
                 res,
-                freeze ? t('fidelity_bond.error_freezing_utxos') : t('fidelity_bond.error_unfreezing_utxos')
+                freeze ? t('fidelity_bond.error_freezing_utxos') : t('fidelity_bond.error_unfreezing_utxos'),
               )
             }
-          }
-        )
+          },
+        ),
       )
 
       return Promise.all(freezeCalls)
@@ -247,7 +247,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
           freeze ? setIsLoadingFreeze(false) : setIsLoadingUnfreeze(false)
         })
     },
-    [isActionsEnabled, props.wallet, reloadCurrentWalletInfo, t]
+    [isActionsEnabled, props.wallet, reloadCurrentWalletInfo, t],
   )
 
   const utxoListTitle = useMemo(() => {

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -189,7 +189,7 @@ const UtxoList = ({
         _confs: utxoConfirmations(utxo),
       })),
     }),
-    [utxos, walletInfo, t]
+    [utxos, walletInfo, t],
   )
 
   const tableTheme = useTheme(TABLE_THEME)
@@ -213,7 +213,7 @@ const UtxoList = ({
     {
       rowSelect: SelectTypes.MultiSelect,
       buttonSelect: SelectTypes.MultiSelect,
-    }
+    },
   )
 
   const tableSort = useSort(
@@ -253,7 +253,7 @@ const UtxoList = ({
         [SORT_KEYS.tags]: (array) =>
           array.sort((a, b) => (String(a._tags[0]?.tag) || 'z').localeCompare(String(b._tags[0]?.tag) || 'z')),
       },
-    }
+    },
   )
 
   return (

--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -63,7 +63,7 @@ interface FeeConfigFormProps {
 const FeeConfigForm = forwardRef(
   (
     { onSubmit, validate, initialValues, defaultActiveSectionKey }: FeeConfigFormProps,
-    ref: React.Ref<HTMLFormElement>
+    ref: React.Ref<HTMLFormElement>,
   ) => {
     const { t, i18n } = useTranslation()
 
@@ -210,7 +210,7 @@ const FeeConfigForm = forwardRef(
                     {t(
                       txFeesUnit === 'sats/kilo-vbyte'
                         ? 'settings.fees.description_tx_fees_satspervbyte'
-                        : 'settings.fees.description_tx_fees_blocks'
+                        : 'settings.fees.description_tx_fees_blocks',
                     )}
                   </rb.Form.Text>
                   <rb.Form.Group controlId="tx_fees" className="mb-4">
@@ -316,7 +316,7 @@ const FeeConfigForm = forwardRef(
         )}
       </Formik>
     )
-  }
+  },
 )
 
 export default function FeeConfigModal({
@@ -409,7 +409,7 @@ export default function FeeConfigModal({
       setSaveErrorMessage((_) =>
         t('settings.fees.error_saving_fee_config_failed', {
           reason: err instanceof Error ? err.message : 'Unknown',
-        })
+        }),
       )
     }
   }
@@ -480,7 +480,7 @@ export default function FeeConfigModal({
       }
       return errors
     },
-    [t]
+    [t],
   )
 
   const cancel = useCallback(() => {

--- a/src/context/BalanceSummary.test.tsx
+++ b/src/context/BalanceSummary.test.tsx
@@ -47,7 +47,7 @@ describe('BalanceSummary', () => {
           },
         },
       },
-      now
+      now,
     )
 
     expect(balanceSummary).not.toBeNull()
@@ -117,7 +117,7 @@ describe('BalanceSummary', () => {
           },
         },
       },
-      now
+      now,
     )
 
     expect(balanceSummary).not.toBeNull()

--- a/src/context/BalanceSummary.ts
+++ b/src/context/BalanceSummary.ts
@@ -42,22 +42,25 @@ const toBalanceSummary = (rawWalletData: CombinedRawWalletData, now?: Millisecon
   const accounts = rawWalletData.display.walletinfo.accounts
   const utxos = rawWalletData.utxos.utxos
 
-  const utxosByAccount = utxos.reduce((acc, utxo) => {
-    const key = `${utxo.mixdepth}`
-    acc[key] = acc[key] || []
-    acc[key].push(utxo)
-    return acc
-  }, {} as { [key: string]: Utxos })
+  const utxosByAccount = utxos.reduce(
+    (acc, utxo) => {
+      const key = `${utxo.mixdepth}`
+      acc[key] = acc[key] || []
+      acc[key].push(utxo)
+      return acc
+    },
+    {} as { [key: string]: Utxos },
+  )
 
   const totalCalculatedByAccount = Object.fromEntries(
     Object.entries(utxosByAccount).map(([account, utxos]) => {
       return [account, utxos.reduce((acc, utxo) => acc + utxo.value, 0)]
-    })
+    }),
   )
   const frozenOrLockedCalculatedByAccount = Object.fromEntries(
     Object.entries(utxosByAccount).map(([account, utxos]) => {
       return [account, calculateFrozenOrLockedBalance(utxos, refTime)]
-    })
+    }),
   )
 
   const accountsBalanceSummary = accounts
@@ -76,12 +79,12 @@ const toBalanceSummary = (rawWalletData: CombinedRawWalletData, now?: Millisecon
 
   const walletTotalCalculated: AmountSats = Object.values(totalCalculatedByAccount).reduce(
     (acc, totalSats) => acc + totalSats,
-    0
+    0,
   )
 
   const walletFrozenOrLockedCalculated: AmountSats = Object.values(frozenOrLockedCalculatedByAccount).reduce(
     (acc, frozenOrLockedSats) => acc + frozenOrLockedSats,
-    0
+    0,
   )
 
   const walletAvailableCalculated = walletTotalCalculated - walletFrozenOrLockedCalculated

--- a/src/context/ServiceConfigContext.tsx
+++ b/src/context/ServiceConfigContext.tsx
@@ -88,7 +88,7 @@ const pushConfigValues = async ({
         section: update.key.section,
         field: update.key.field,
         value: update.value,
-      }
+      },
     )
       .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res)))
       .then((_) => update)
@@ -128,7 +128,7 @@ const ServiceConfigProvider = ({ children }: React.PropsWithChildren<{}>) => {
           return result
         })
     },
-    [currentWallet]
+    [currentWallet],
   )
 
   const loadConfigValueIfAbsent = useCallback(
@@ -152,7 +152,7 @@ const ServiceConfigProvider = ({ children }: React.PropsWithChildren<{}>) => {
         } as ServiceConfigUpdate
       })
     },
-    [refreshConfigValues]
+    [refreshConfigValues],
   )
 
   const updateConfigValues = useCallback(
@@ -174,7 +174,7 @@ const ServiceConfigProvider = ({ children }: React.PropsWithChildren<{}>) => {
           return result
         })
     },
-    [currentWallet]
+    [currentWallet],
   )
 
   useEffect(() => {

--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -29,7 +29,7 @@ type ScheduleEntry = [
   SchedulerDestinationAddress,
   WaitTimeInMinutes,
   Rounding,
-  StateFlag
+  StateFlag,
 ]
 type Schedule = ScheduleEntry[]
 
@@ -121,8 +121,8 @@ const ServiceInfoProvider = ({ children }: React.PropsWithChildren<{}>) => {
   const fetchSessionInProgress = useRef<Promise<ServiceInfo> | null>(null)
 
   const [serviceInfo, dispatchServiceInfo] = useReducer(
-    (state: ServiceInfo | null, obj: ServiceInfoUpdate) => ({ ...state, ...obj } as ServiceInfo | null),
-    null
+    (state: ServiceInfo | null, obj: ServiceInfoUpdate) => ({ ...state, ...obj }) as ServiceInfo | null,
+    null,
   )
   const [connectionError, setConnectionError] = useState<Error>()
 
@@ -238,7 +238,7 @@ const ServiceInfoProvider = ({ children }: React.PropsWithChildren<{}>) => {
           throw err
         })
     },
-    [currentWallet, setCurrentWallet]
+    [currentWallet, setCurrentWallet],
   )
 
   useEffect(() => {

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -38,7 +38,7 @@ const settingsReducer = (oldSettings: Settings, action: Partial<Settings>) => {
 const SettingsProvider = ({ children }: React.PropsWithChildren<{}>) => {
   const [settings, dispatch] = useReducer(
     settingsReducer,
-    Object.assign({}, initialSettings, JSON.parse(window.localStorage.getItem(localStorageKey) || '{}')) as Settings
+    Object.assign({}, initialSettings, JSON.parse(window.localStorage.getItem(localStorageKey) || '{}')) as Settings,
   )
 
   useEffect(() => {

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -201,10 +201,10 @@ const WalletProvider = ({ children }: PropsWithChildren<any>) => {
 
       const { name: walletName, token } = currentWallet
       return await Api.getWalletUtxos({ walletName, token, signal }).then(
-        (res): Promise<UtxosResponse> => (res.ok ? res.json() : Api.Helper.throwError(res))
+        (res): Promise<UtxosResponse> => (res.ok ? res.json() : Api.Helper.throwError(res)),
       )
     },
-    [currentWallet]
+    [currentWallet],
   )
 
   const fetchDisplay = useCallback(
@@ -215,10 +215,10 @@ const WalletProvider = ({ children }: PropsWithChildren<any>) => {
 
       const { name: walletName, token } = currentWallet
       return await Api.getWalletDisplay({ walletName, token, signal }).then(
-        (res): Promise<WalletDisplayResponse> => (res.ok ? res.json() : Api.Helper.throwError(res))
+        (res): Promise<WalletDisplayResponse> => (res.ok ? res.json() : Api.Helper.throwError(res)),
       )
     },
-    [currentWallet]
+    [currentWallet],
   )
 
   const reloadUtxos = useCallback(
@@ -229,7 +229,7 @@ const WalletProvider = ({ children }: PropsWithChildren<any>) => {
       }
       return response
     },
-    [fetchUtxos]
+    [fetchUtxos],
   )
 
   const reloadDisplay = useCallback(
@@ -240,7 +240,7 @@ const WalletProvider = ({ children }: PropsWithChildren<any>) => {
       }
       return response
     },
-    [fetchDisplay]
+    [fetchDisplay],
   )
 
   const reloadAll = useCallback(
@@ -248,7 +248,7 @@ const WalletProvider = ({ children }: PropsWithChildren<any>) => {
       Promise.all([reloadUtxos({ signal }), reloadDisplay({ signal })])
         .then((data) => toCombinedRawData(data[0], data[1]))
         .then((raw) => toWalletInfo(raw)),
-    [reloadUtxos, reloadDisplay]
+    [reloadUtxos, reloadDisplay],
   )
 
   const combinedRawData = useMemo<CombinedRawWalletData | undefined>(() => {
@@ -266,7 +266,7 @@ const WalletProvider = ({ children }: PropsWithChildren<any>) => {
       reloadAll,
       reloadUtxos,
     }),
-    [reloadAll, reloadUtxos]
+    [reloadAll, reloadUtxos],
   )
 
   useEffect(() => {

--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -147,7 +147,7 @@ const WebsocketProvider = ({ children }) => {
       const needsForceClose = websocket.readyState === WebSocket.CONNECTING
       logToDebugConsoleInDevMode(
         `[Websocket] ${new Date().toLocaleString()} Check if a force-close is needed..`,
-        needsForceClose
+        needsForceClose,
       )
       if (needsForceClose) {
         websocket.close(1000, 'Force-close pending connection')
@@ -177,7 +177,7 @@ const WebsocketProvider = ({ children }) => {
           {
             once: true,
             signal: abortCtrl.signal,
-          }
+          },
         )
       }
     }

--- a/src/hooks/CoinjoinRequirements.ts
+++ b/src/hooks/CoinjoinRequirements.ts
@@ -46,13 +46,13 @@ const filterUtxosViolatingTriesLeftRequirement = (utxos: Utxos) => {
 
 const buildCoinjoinViolationSummaryForJar = (
   utxos: Utxos,
-  options: CoinjoinRequirementOptions
+  options: CoinjoinRequirementOptions,
 ): CoinjoinRequirementViolation => {
   const eligibleUtxos = filterEligibleUtxos(utxos)
   const utxosViolatingRetriesLeft = filterUtxosViolatingTriesLeftRequirement(eligibleUtxos)
   const utxosViolatingMinConfirmations = filterUtxosViolatingMinConfirmationRequirement(
     eligibleUtxos,
-    options.minConfirmations
+    options.minConfirmations,
   )
 
   const hasViolations = utxosViolatingRetriesLeft.length > 0 || utxosViolatingMinConfirmations.length > 0
@@ -66,7 +66,7 @@ const buildCoinjoinViolationSummaryForJar = (
 
 export const buildCoinjoinRequirementSummary = (
   utxos: Utxos,
-  options = DEFAULT_REQUIREMENT_OPTIONS
+  options = DEFAULT_REQUIREMENT_OPTIONS,
 ): CoinjoinRequirementSummary => {
   const eligibleUtxos = filterEligibleUtxos(utxos)
   const utxosByJars = groupByJar(eligibleUtxos)
@@ -85,8 +85,8 @@ export const buildCoinjoinRequirementSummary = (
     .map((it) =>
       it.utxosViolatingMinConfirmations.reduce(
         (acc, utxo) => Math.min(acc, utxo.confirmations),
-        Number.MAX_SAFE_INTEGER
-      )
+        Number.MAX_SAFE_INTEGER,
+      ),
     )
     .reduce((acc, lowestConfPerJar) => Math.min(acc, lowestConfPerJar), Number.MAX_SAFE_INTEGER)
 

--- a/src/hooks/Fees.ts
+++ b/src/hooks/Fees.ts
@@ -49,7 +49,7 @@ export const useLoadFeeConfigValues = () => {
       }
       return feeValues
     },
-    [refreshConfigValues]
+    [refreshConfigValues],
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -4,14 +4,17 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url('./fonts/Inter-Thin.woff2?v=3.19') format('woff2'), url('./fonts/Inter-Thin.woff?v=3.19') format('woff');
+  src:
+    url('./fonts/Inter-Thin.woff2?v=3.19') format('woff2'),
+    url('./fonts/Inter-Thin.woff?v=3.19') format('woff');
 }
 @font-face {
   font-family: 'Inter';
   font-style: italic;
   font-weight: 100;
   font-display: swap;
-  src: url('./fonts/Inter-ThinItalic.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-ThinItalic.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-ThinItalic.woff?v=3.19') format('woff');
 }
 
@@ -20,7 +23,8 @@
   font-style: normal;
   font-weight: 200;
   font-display: swap;
-  src: url('./fonts/Inter-ExtraLight.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-ExtraLight.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-ExtraLight.woff?v=3.19') format('woff');
 }
 @font-face {
@@ -28,7 +32,8 @@
   font-style: italic;
   font-weight: 200;
   font-display: swap;
-  src: url('./fonts/Inter-ExtraLightItalic.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-ExtraLightItalic.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-ExtraLightItalic.woff?v=3.19') format('woff');
 }
 
@@ -37,14 +42,17 @@
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url('./fonts/Inter-Light.woff2?v=3.19') format('woff2'), url('./fonts/Inter-Light.woff?v=3.19') format('woff');
+  src:
+    url('./fonts/Inter-Light.woff2?v=3.19') format('woff2'),
+    url('./fonts/Inter-Light.woff?v=3.19') format('woff');
 }
 @font-face {
   font-family: 'Inter';
   font-style: italic;
   font-weight: 300;
   font-display: swap;
-  src: url('./fonts/Inter-LightItalic.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-LightItalic.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-LightItalic.woff?v=3.19') format('woff');
 }
 
@@ -53,7 +61,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('./fonts/Inter-Regular.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-Regular.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-Regular.woff?v=3.19') format('woff');
 }
 @font-face {
@@ -61,7 +70,9 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('./fonts/Inter-Italic.woff2?v=3.19') format('woff2'), url('./fonts/Inter-Italic.woff?v=3.19') format('woff');
+  src:
+    url('./fonts/Inter-Italic.woff2?v=3.19') format('woff2'),
+    url('./fonts/Inter-Italic.woff?v=3.19') format('woff');
 }
 
 @font-face {
@@ -69,14 +80,17 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('./fonts/Inter-Medium.woff2?v=3.19') format('woff2'), url('./fonts/Inter-Medium.woff?v=3.19') format('woff');
+  src:
+    url('./fonts/Inter-Medium.woff2?v=3.19') format('woff2'),
+    url('./fonts/Inter-Medium.woff?v=3.19') format('woff');
 }
 @font-face {
   font-family: 'Inter';
   font-style: italic;
   font-weight: 500;
   font-display: swap;
-  src: url('./fonts/Inter-MediumItalic.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-MediumItalic.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-MediumItalic.woff?v=3.19') format('woff');
 }
 
@@ -85,7 +99,8 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url('./fonts/Inter-SemiBold.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-SemiBold.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-SemiBold.woff?v=3.19') format('woff');
 }
 @font-face {
@@ -93,7 +108,8 @@
   font-style: italic;
   font-weight: 600;
   font-display: swap;
-  src: url('./fonts/Inter-SemiBoldItalic.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-SemiBoldItalic.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-SemiBoldItalic.woff?v=3.19') format('woff');
 }
 
@@ -102,14 +118,17 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('./fonts/Inter-Bold.woff2?v=3.19') format('woff2'), url('./fonts/Inter-Bold.woff?v=3.19') format('woff');
+  src:
+    url('./fonts/Inter-Bold.woff2?v=3.19') format('woff2'),
+    url('./fonts/Inter-Bold.woff?v=3.19') format('woff');
 }
 @font-face {
   font-family: 'Inter';
   font-style: italic;
   font-weight: 700;
   font-display: swap;
-  src: url('./fonts/Inter-BoldItalic.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-BoldItalic.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-BoldItalic.woff?v=3.19') format('woff');
 }
 
@@ -118,7 +137,8 @@
   font-style: normal;
   font-weight: 800;
   font-display: swap;
-  src: url('./fonts/Inter-ExtraBold.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-ExtraBold.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-ExtraBold.woff?v=3.19') format('woff');
 }
 @font-face {
@@ -126,7 +146,8 @@
   font-style: italic;
   font-weight: 800;
   font-display: swap;
-  src: url('./fonts/Inter-ExtraBoldItalic.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-ExtraBoldItalic.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-ExtraBoldItalic.woff?v=3.19') format('woff');
 }
 
@@ -135,14 +156,17 @@
   font-style: normal;
   font-weight: 900;
   font-display: swap;
-  src: url('./fonts/Inter-Black.woff2?v=3.19') format('woff2'), url('./fonts/Inter-Black.woff?v=3.19') format('woff');
+  src:
+    url('./fonts/Inter-Black.woff2?v=3.19') format('woff2'),
+    url('./fonts/Inter-Black.woff?v=3.19') format('woff');
 }
 @font-face {
   font-family: 'Inter';
   font-style: italic;
   font-weight: 900;
   font-display: swap;
-  src: url('./fonts/Inter-BlackItalic.woff2?v=3.19') format('woff2'),
+  src:
+    url('./fonts/Inter-BlackItalic.woff2?v=3.19') format('woff2'),
     url('./fonts/Inter-BlackItalic.woff?v=3.19') format('woff');
 }
 
@@ -273,11 +297,36 @@ main {
 .slashed-zeroes {
   font-family: Inter;
   font-weight: 400;
-  font-feature-settings: 'tnum' on, 'lnum' on, 'zero' on, 'case' on, 'calt' off;
-  -moz-font-feature-settings: 'tnum' on, 'lnum' on, 'zero' on, 'case' on, 'calt' off;
-  -ms-font-feature-settings: 'tnum' on, 'lnum' on, 'zero' on, 'case' on, 'calt' off;
-  -webkit-font-feature-settings: 'tnum' on, 'lnum' on, 'zero' on, 'case' on, 'calt' off;
-  -o-font-feature-settings: 'tnum' on, 'lnum' on, 'zero' on, 'case' on, 'calt' off;
+  font-feature-settings:
+    'tnum' on,
+    'lnum' on,
+    'zero' on,
+    'case' on,
+    'calt' off;
+  -moz-font-feature-settings:
+    'tnum' on,
+    'lnum' on,
+    'zero' on,
+    'case' on,
+    'calt' off;
+  -ms-font-feature-settings:
+    'tnum' on,
+    'lnum' on,
+    'zero' on,
+    'case' on,
+    'calt' off;
+  -webkit-font-feature-settings:
+    'tnum' on,
+    'lnum' on,
+    'zero' on,
+    'case' on,
+    'calt' off;
+  -o-font-feature-settings:
+    'tnum' on,
+    'lnum' on,
+    'zero' on,
+    'case' on,
+    'calt' off;
 }
 
 .break-word {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,5 +28,5 @@ ReactDOM.render(
       </WalletProvider>
     </SettingsProvider>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById('root'),
 )

--- a/src/libs/JmObwatchApi.ts
+++ b/src/libs/JmObwatchApi.ts
@@ -57,7 +57,7 @@ const parseOrderbook = (res: Response): Promise<Order[]> => {
       .map((cols) => {
         const data: unknown = ORDER_KEYS.map((key, index) => ({ [key]: cols[index].innerHTML })).reduce(
           (acc, curr) => ({ ...acc, ...curr }),
-          {}
+          {},
         )
         return data as Order
       })

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -182,7 +182,7 @@ const Helper = (() => {
 
   const throwResolved = async (
     response: Response,
-    { resolver = DEFAULT_RESOLVER, fallbackReason = response.statusText } = {}
+    { resolver = DEFAULT_RESOLVER, fallbackReason = response.statusText } = {},
   ): Promise<never> => {
     const reason = await extractErrorMessage(response, fallbackReason)
     const errorMessage = resolver(response, reason) || reason
@@ -292,7 +292,7 @@ const getWalletLock = async ({ token, signal, walletName }: WalletRequestContext
 
 const postWalletUnlock = async (
   { signal, walletName }: ApiRequestContext & WithWalletName,
-  { password }: WalletUnlockRequest
+  { password }: WalletUnlockRequest,
 ) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletName)}/unlock`, {
     method: 'POST',
@@ -384,7 +384,7 @@ const getYieldgenReport = async ({ signal }: ApiRequestContext) => {
 
 const postFreeze = async (
   { token, signal, walletName }: WalletRequestContext,
-  { utxo, freeze = true }: FreezeRequest
+  { utxo, freeze = true }: FreezeRequest,
 ) => {
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletName)}/freeze`, {
     method: 'POST',

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -38,7 +38,7 @@ module.exports = (app) => {
         changeOrigin: true,
         secure: false,
         ws: true,
-      })
+      }),
     )
     app.use(
       createProxyMiddleware(`${PUBLIC_URL}/api/`, {
@@ -51,7 +51,7 @@ module.exports = (app) => {
             proxyReq.setHeader('Authorization', req.headers['x-jm-authorization'])
           }
         },
-      })
+      }),
     )
     app.use(
       createProxyMiddleware(`${PUBLIC_URL}/obwatch/`, {
@@ -59,7 +59,7 @@ module.exports = (app) => {
         pathRewrite: { [`^${PUBLIC_URL}/obwatch/`]: '' },
         changeOrigin: true,
         secure: false,
-      })
+      }),
     )
   } else if (JAM_BACKEND === BACKEND_STANDALONE) {
     /**
@@ -75,7 +75,7 @@ module.exports = (app) => {
         changeOrigin: true,
         secure: false,
         ws: true,
-      })
+      }),
     )
     app.use(
       createProxyMiddleware(`${PUBLIC_URL}/api/`, {
@@ -83,7 +83,7 @@ module.exports = (app) => {
         pathRewrite: { [`^${PUBLIC_URL}`]: '' },
         changeOrigin: true,
         secure: false,
-      })
+      }),
     )
     app.use(
       createProxyMiddleware(`${PUBLIC_URL}/obwatch/`, {
@@ -91,7 +91,7 @@ module.exports = (app) => {
         pathRewrite: { [`^${PUBLIC_URL}`]: '' },
         changeOrigin: true,
         secure: false,
-      })
+      }),
     )
     app.use(
       createProxyMiddleware(`${PUBLIC_URL}/jam/`, {
@@ -99,7 +99,7 @@ module.exports = (app) => {
         pathRewrite: { [`^${PUBLIC_URL}`]: '' },
         changeOrigin: true,
         secure: false,
-      })
+      }),
     )
   }
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -18,8 +18,8 @@ global.__DEV__.addToAppSettings = () => {
     JSON.stringify(
       Object.assign({}, global.localStorage.getItem(global.JM.SETTINGS_STORE_KEY) || {}, {
         showOnboarding: false,
-      })
-    )
+      }),
+    ),
   )
 }
 ;(function setupWebsocketServerMock() {


### PR DESCRIPTION
Apply changes when running `npm run format` after new prettier update.