### PR TITLE
chore(import): display warning on large gaplimit values

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,15 +1,23 @@
-import React, { PropsWithChildren, useState } from 'react'
+import { ReactNode, PropsWithChildren, useState } from 'react'
+import classNames from 'classnames'
 import { useSettings } from '../context/SettingsContext'
 import * as rb from 'react-bootstrap'
 import Sprite from './Sprite'
 
 interface AccordionProps {
-  title: string | React.ReactNode
+  title: ReactNode | string
   defaultOpen?: boolean
   disabled?: boolean
+  variant?: 'warning' | 'danger'
 }
 
-const Accordion = ({ title, defaultOpen = false, disabled = false, children }: PropsWithChildren<AccordionProps>) => {
+const Accordion = ({
+  title,
+  defaultOpen = false,
+  disabled = false,
+  variant,
+  children,
+}: PropsWithChildren<AccordionProps>) => {
   const settings = useSettings()
   const [isOpen, setIsOpen] = useState(defaultOpen)
 
@@ -21,7 +29,25 @@ const Accordion = ({ title, defaultOpen = false, disabled = false, children }: P
         onClick={() => setIsOpen((current) => !current)}
         disabled={disabled}
       >
-        {title}
+        <div
+          className={classNames('d-flex align-items-center', {
+            'text-danger': variant === 'danger',
+          })}
+        >
+          {variant && (
+            <div
+              className={classNames('badge rounded-pill p-0 me-2', {
+                'text-dark': variant === 'warning',
+                'bg-warning': variant === 'warning',
+                'text-light': variant === 'danger',
+                'bg-danger': variant === 'danger',
+              })}
+            >
+              <Sprite symbol="warn" width="20" height="20" />
+            </div>
+          )}
+          {title}
+        </div>
         <Sprite symbol={`caret-${isOpen ? 'up' : 'down'}`} className="ms-1" width="20" height="20" />
       </rb.Button>
       <hr className="m-0 pb-4 text-secondary" />

--- a/src/components/ImportWallet.tsx
+++ b/src/components/ImportWallet.tsx
@@ -37,6 +37,16 @@ const GAPLIMIT_SUGGESTIONS = {
 }
 
 const MIN_BLOCKHEIGHT_VALUE = 0
+/**
+ * Maximum blockheight value.
+ * Value choosen based on estimation of blockheight in tge year 2140 (plus some buffer):
+ * 365 × 144 × (2140 - 2009) = 6_885_360 = ~7_000_000
+ * This is necessary because javascript does not handle large values too well,
+ * and the `/rescanblockchain` errors. Not to mention that a value beyond the current
+ * height does not make any sense in the first place.
+ */
+const MAX_BLOCKHEIGHT_VALUE = 10_000_000
+
 const MIN_GAPLIMIT_VALUE = 1
 /**
  * Maximum gaplimit value for importing an existing wallet.
@@ -84,7 +94,11 @@ const ImportWalletDetailsForm = ({
         errors.mnemonicPhrase = t<string>('import_wallet.import_details.feedback_invalid_menmonic_phrase')
       }
 
-      if (!isValidNumber(values.blockheight) || values.blockheight < MIN_BLOCKHEIGHT_VALUE) {
+      if (
+        !isValidNumber(values.blockheight) ||
+        values.blockheight < MIN_BLOCKHEIGHT_VALUE ||
+        values.blockheight > MAX_BLOCKHEIGHT_VALUE
+      ) {
         errors.blockheight = t('import_wallet.import_details.feedback_invalid_blockheight', {
           min: MIN_BLOCKHEIGHT_VALUE.toLocaleString(),
         })
@@ -182,6 +196,7 @@ const ImportWalletDetailsForm = ({
                   isValid={touched.blockheight && !errors.blockheight}
                   isInvalid={touched.blockheight && !!errors.blockheight}
                   min={MIN_BLOCKHEIGHT_VALUE}
+                  max={MAX_BLOCKHEIGHT_VALUE}
                   step={1_000}
                   required
                 />

--- a/src/components/ImportWallet.tsx
+++ b/src/components/ImportWallet.tsx
@@ -64,15 +64,6 @@ const MAX_GAPLIMIT_VALUE = 10_000
  */
 const GAPLIMIT_WARN_THRESHOLD = 250
 
-const GaplimitWarning = () => {
-  const { t } = useTranslation()
-  return (
-    <rb.Alert variant="warning" className="d-flex align-items-center">
-      {t('import_wallet.import_details.alert_high_gaplimit_value')}
-    </rb.Alert>
-  )
-}
-
 const initialImportWalletDetailsFormValues: ImportWalletDetailsFormValues = isDevMode()
   ? {
       mnemonicPhrase: new Array<string>(12).fill(''),
@@ -180,25 +171,8 @@ const ImportWalletDetailsForm = ({
               </rb.Button>
             )}
             <Accordion
-              title={
-                <div
-                  className={classNames('d-flex align-items-center', {
-                    'text-danger': hasImportDetailsSectionErrors,
-                  })}
-                >
-                  {(hasImportDetailsSectionErrors || showGaplimitWarning) && (
-                    <div
-                      className={classNames('badge rounded-pill text-dark p-0 me-2', {
-                        'bg-warning': !hasImportDetailsSectionErrors && showGaplimitWarning,
-                        'bg-danger': hasImportDetailsSectionErrors,
-                      })}
-                    >
-                      <Sprite symbol="warn" width="20" height="20" />
-                    </div>
-                  )}
-                  {t('import_wallet.import_details.import_options')}
-                </div>
-              }
+              title={t('import_wallet.import_details.import_options')}
+              variant={hasImportDetailsSectionErrors ? 'danger' : showGaplimitWarning ? 'warning' : undefined}
               defaultOpen={true}
             >
               <rb.Form.Group controlId="blockheight" className="mb-4">
@@ -344,20 +318,8 @@ const ImportWalletConfirmation = ({
           <WalletInfoSummary walletInfo={walletInfo} revealSensitiveInfo={!isSubmitting && submitCount === 0} />
 
           <Accordion
-            title={
-              <div className="d-flex align-items-center">
-                {showGaplimitWarning && (
-                  <div
-                    className={classNames('badge rounded-pill text-dark p-0 me-2', {
-                      'bg-warning': showGaplimitWarning,
-                    })}
-                  >
-                    <Sprite symbol="warn" width="20" height="20" />
-                  </div>
-                )}
-                {t('import_wallet.import_details.import_options')}
-              </div>
-            }
+            title={t('import_wallet.import_details.import_options')}
+            variant={showGaplimitWarning ? 'warning' : undefined}
           >
             <div className="mb-4">
               <div>{t('import_wallet.import_details.label_blockheight')}</div>

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -169,7 +169,7 @@
       "label_gaplimit": "Address import limit",
       "description_gaplimit": "The amount of addresses that are imported per jar. Set to the highest address index used in any of the jars. Increase this number if your wallet is heavily used.",
       "feedback_invalid_gaplimit": "Please provide a valid value between {{ min }} and {{ max }}.",
-      "alert_high_gaplimit_value": "The given value results in many addresses being imported and an extreme decline in performance and responsiveness is to be expected.",
+      "alert_high_gaplimit_value": "The given value causes many addresses to be imported, which can lead to a decline in performance and responsiveness.",
       "text_button_submit": "Review",
       "text_button_submitting": "Review"
     },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -165,10 +165,10 @@
       "import_options": "Import options",
       "label_blockheight": "Rescan height",
       "description_blockheight": "The blockheight at which the rescan process starts to search for your funds. The earlier the wallet has been created, the lower this value should be.",
-      "feedback_invalid_blockheight": "Please provide a valid blockheight value greater than or equal to {{ min }}.",
+      "feedback_invalid_blockheight": "Please provide a valid value between {{ min }} and the current blockheight.",
       "label_gaplimit": "Address import limit",
       "description_gaplimit": "The amount of addresses that are imported per jar. Set to the highest address index used in any of the jars. Increase this number if your wallet is heavily used.",
-      "feedback_invalid_gaplimit": "Please provide a valid gaplimit value between {{ min }} and {{ max }}.",
+      "feedback_invalid_gaplimit": "Please provide a valid value between {{ min }} and {{ max }}.",
       "text_button_submit": "Review",
       "text_button_submitting": "Review"
     },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -169,6 +169,7 @@
       "label_gaplimit": "Address import limit",
       "description_gaplimit": "The amount of addresses that are imported per jar. Set to the highest address index used in any of the jars. Increase this number if your wallet is heavily used.",
       "feedback_invalid_gaplimit": "Please provide a valid value between {{ min }} and {{ max }}.",
+      "alert_high_gaplimit_value": "The given value results in many addresses being imported and an extreme decline in performance and responsiveness is to be expected.",
       "text_button_submit": "Review",
       "text_button_submitting": "Review"
     },

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -168,7 +168,7 @@
       "feedback_invalid_blockheight": "Please provide a valid blockheight value greater than or equal to {{ min }}.",
       "label_gaplimit": "Address import limit",
       "description_gaplimit": "The amount of addresses that are imported per jar. Set to the highest address index used in any of the jars. Increase this number if your wallet is heavily used.",
-      "feedback_invalid_gaplimit": "Please provide a valid gaplimit value greater than or equal to {{ min }}.",
+      "feedback_invalid_gaplimit": "Please provide a valid gaplimit value between {{ min }} and {{ max }}.",
       "text_button_submit": "Review",
       "text_button_submitting": "Review"
     },


### PR DESCRIPTION
Following changes should improve user experience and prevent some mistakes while importing wallets by adding visual feedback:
- Adds a max blockheight value: `10_000_000` - just to prevent errors during import  (should be lower than the current blockheight anyway)
- Adds a max gaplimit value: `10_000` - rather high , but users should not be prevented from doing it, if they really want to
- Warn on "large" gaplimit values: any value greater than `250` (arbitrarily chosen) will display a warning

## :camera_flash: 
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/371935e1-2c7b-4d66-9bd1-239cdb7ab64f" width=250 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/47eba782-64d2-494c-bf93-eb7fa9f4c867" width=250 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/24389ddd-f323-4ec6-b3aa-344f8f0dc57c" width=250 />


