### PR TITLE
 feat: new authentication mechanism (access/refresh token)

### DIFF
--- a/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
 
 ENV REPO https://github.com/JoinMarket-Org/joinmarket-clientserver
 ENV REPO_BRANCH master
-ENV REPO_REF v0.9.10
+ENV REPO_REF master
 
 WORKDIR /src
 RUN git clone "$REPO" . --depth=10 --branch "$REPO_BRANCH" && git checkout "$REPO_REF"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -51,9 +51,9 @@ export default function App() {
   const isReloadingWalletInfo = useMemo(() => reloadingWalletInfoCounter > 0, [reloadingWalletInfoCounter])
 
   const startWallet = useCallback(
-    (name: Api.WalletName, token: Api.ApiToken) => {
-      setSession({ name, token })
-      setCurrentWallet({ name, token })
+    (name: Api.WalletName, auth: Api.ApiAuthContext) => {
+      setSession({ name, auth })
+      setCurrentWallet({ name, token: auth.token })
     },
     [setCurrentWallet],
   )

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -19,6 +19,7 @@ import {
   CurrentWallet,
   useCurrentWallet,
   useSetCurrentWallet,
+  useClearCurrentWallet,
   useReloadCurrentWalletInfo,
 } from '../context/WalletContext'
 import { clearSession, setSession } from '../session'
@@ -44,6 +45,7 @@ export default function App() {
   const settings = useSettings()
   const currentWallet = useCurrentWallet()
   const setCurrentWallet = useSetCurrentWallet()
+  const clearCurrentWallet = useClearCurrentWallet()
   const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
   const serviceInfo = useServiceInfo()
   const sessionConnectionError = useSessionConnectionError()
@@ -59,9 +61,9 @@ export default function App() {
   )
 
   const stopWallet = useCallback(() => {
+    clearCurrentWallet()
     clearSession()
-    setCurrentWallet(null)
-  }, [setCurrentWallet])
+  }, [clearCurrentWallet])
 
   const reloadWalletInfo = useCallback(
     (delay: Milliseconds) => {

--- a/src/components/BitcoinQR.jsx
+++ b/src/components/BitcoinQR.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import QRCode from 'qrcode'
 
 import { satsToBtc } from '../utils'

--- a/src/components/CoinjoinPreconditionViolationAlert.tsx
+++ b/src/components/CoinjoinPreconditionViolationAlert.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import { Ref, forwardRef } from 'react'
 import * as rb from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSettings } from '../context/SettingsContext'
@@ -14,7 +14,7 @@ interface CoinjoinPreconditionViolationAlertProps {
 }
 
 export const CoinjoinPreconditionViolationAlert = forwardRef(
-  ({ summary, i18nPrefix = '' }: CoinjoinPreconditionViolationAlertProps, ref: React.Ref<HTMLDivElement>) => {
+  ({ summary, i18nPrefix = '' }: CoinjoinPreconditionViolationAlertProps, ref: Ref<HTMLDivElement>) => {
     const { t } = useTranslation()
     const settings = useSettings()
 

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -99,8 +99,15 @@ export default function CreateWallet({ parentRoute, startWallet }) {
         const res = await Api.postWalletCreate({}, { walletname: walletName, password })
         const body = await (res.ok ? res.json() : Api.Helper.throwError(res))
 
-        const { seedphrase, token, walletname: createdWalletFileName } = body
-        setCreatedWallet({ walletFileName: createdWalletFileName, seedphrase, password, token })
+        const { seedphrase, walletname: createdWalletFileName } = body
+        const auth = {
+          token: body.token,
+          token_type: body.token_type,
+          expires_in: body.expires_in,
+          scope: body.scope,
+          refresh_token: body.refresh_token,
+        }
+        setCreatedWallet({ walletFileName: createdWalletFileName, seedphrase, password, auth })
       } catch (e) {
         const message = t('create_wallet.error_creating_failed', {
           reason: e.message || 'Unknown reason',
@@ -112,9 +119,9 @@ export default function CreateWallet({ parentRoute, startWallet }) {
   )
 
   const walletConfirmed = useCallback(() => {
-    if (createdWallet?.walletFileName && createdWallet?.token) {
+    if (createdWallet?.walletFileName && createdWallet?.auth) {
       setAlert(null)
-      startWallet(createdWallet.walletFileName, createdWallet.token)
+      startWallet(createdWallet.walletFileName, createdWallet.auth)
       navigate(routes.wallet)
     } else {
       setAlert({ variant: 'danger', message: t('create_wallet.alert_confirmation_failed') })

--- a/src/components/CreateWallet.jsx
+++ b/src/components/CreateWallet.jsx
@@ -100,13 +100,7 @@ export default function CreateWallet({ parentRoute, startWallet }) {
         const body = await (res.ok ? res.json() : Api.Helper.throwError(res))
 
         const { seedphrase, walletname: createdWalletFileName } = body
-        const auth = {
-          token: body.token,
-          token_type: body.token_type,
-          expires_in: body.expires_in,
-          scope: body.scope,
-          refresh_token: body.refresh_token,
-        }
+        const auth = Api.Helper.parseAuthProps(body)
         setCreatedWallet({ walletFileName: createdWalletFileName, seedphrase, password, auth })
       } catch (e) {
         const message = t('create_wallet.error_creating_failed', {

--- a/src/components/EarnReport.tsx
+++ b/src/components/EarnReport.tsx
@@ -7,7 +7,6 @@ import { useTheme } from '@table-library/react-table-library/theme'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import * as Api from '../libs/JmWalletApi'
-// @ts-ignore
 import { useSettings } from '../context/SettingsContext'
 import Balance from './Balance'
 import Sprite from './Sprite'

--- a/src/components/ImportWallet.tsx
+++ b/src/components/ImportWallet.tsx
@@ -441,13 +441,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
         const recoverBody = await (recoverResponse.ok ? recoverResponse.json() : Api.Helper.throwError(recoverResponse))
 
         const { walletname: importedWalletFileName } = recoverBody
-        let auth: Api.ApiAuthContext = {
-          token: recoverBody.token,
-          token_type: recoverBody.token_type,
-          expires_in: recoverBody.token_type,
-          scope: recoverBody.token_type,
-          refresh_token: recoverBody.token_type,
-        }
+        let auth: Api.ApiAuthContext = Api.Helper.parseAuthProps(recoverBody)
         setRecoveredWallet({ walletFileName: importedWalletFileName, auth })
 
         // Step #2: update the gaplimit config value if necessary
@@ -482,13 +476,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
 
         const unlockResponse = await Api.postWalletUnlock({ walletName: importedWalletFileName }, { password })
         const unlockBody = await (unlockResponse.ok ? unlockResponse.json() : Api.Helper.throwError(unlockResponse))
-        auth = {
-          token: unlockBody.token,
-          token_type: unlockBody.token_type,
-          expires_in: unlockBody.expires_in,
-          scope: unlockBody.scope,
-          refresh_token: unlockBody.refresh_token,
-        }
+        auth = Api.Helper.parseAuthProps(unlockBody)
 
         // Step #4: reset `gaplimit´ to previous value if necessary
         if (gaplimitUpdateNecessary) {

--- a/src/components/ImportWallet.tsx
+++ b/src/components/ImportWallet.tsx
@@ -374,7 +374,7 @@ enum ImportWalletSteps {
 
 interface ImportWalletProps {
   parentRoute: Route
-  startWallet: (name: Api.WalletName, token: Api.ApiToken) => void
+  startWallet: (name: Api.WalletName, auth: Api.ApiAuthContext) => void
 }
 
 export default function ImportWallet({ parentRoute, startWallet }: ImportWalletProps) {
@@ -388,9 +388,9 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
   const [alert, setAlert] = useState<SimpleAlert>()
   const [createWalletFormValues, setCreateWalletFormValues] = useState<CreateWalletFormValues>()
   const [importDetailsFormValues, setImportDetailsFormValues] = useState<ImportWalletDetailsFormValues>()
-  const [recoveredWallet, setRecoveredWallet] = useState<{ walletFileName: Api.WalletName; token: Api.ApiToken }>()
+  const [recoveredWallet, setRecoveredWallet] = useState<{ walletFileName: Api.WalletName; auth: Api.ApiAuthContext }>()
 
-  const isRecovered = useMemo(() => !!recoveredWallet?.walletFileName && recoveredWallet?.token, [recoveredWallet])
+  const isRecovered = useMemo(() => !!recoveredWallet?.walletFileName && recoveredWallet?.auth, [recoveredWallet])
   const canRecover = useMemo(
     () => !isRecovered && !serviceInfo?.walletName && !serviceInfo?.rescanning,
     [isRecovered, serviceInfo],
@@ -441,13 +441,20 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
         const recoverBody = await (recoverResponse.ok ? recoverResponse.json() : Api.Helper.throwError(recoverResponse))
 
         const { walletname: importedWalletFileName } = recoverBody
-        setRecoveredWallet({ walletFileName: importedWalletFileName, token: recoverBody.token })
+        let auth: Api.ApiAuthContext = {
+          token: recoverBody.token,
+          token_type: recoverBody.token_type,
+          expires_in: recoverBody.token_type,
+          scope: recoverBody.token_type,
+          refresh_token: recoverBody.token_type,
+        }
+        setRecoveredWallet({ walletFileName: importedWalletFileName, auth })
 
         // Step #2: update the gaplimit config value if necessary
         const originalGaplimit = await refreshConfigValues({
           signal,
           keys: [JM_GAPLIMIT_CONFIGKEY],
-          wallet: { name: importedWalletFileName, token: recoverBody.token },
+          wallet: { name: importedWalletFileName, token: auth.token },
         })
           .then((it) => it[JM_GAPLIMIT_CONFIGKEY.section] || {})
           .then((it) => parseInt(it[JM_GAPLIMIT_CONFIGKEY.field] || String(JM_GAPLIMIT_DEFAULT), 10))
@@ -465,16 +472,23 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
                 value: String(gaplimit),
               },
             ],
-            wallet: { name: importedWalletFileName, token: recoverBody.token },
+            wallet: { name: importedWalletFileName, token: auth.token },
           })
         }
 
         // Step #3: lock and unlock the wallet (for new addresses to be imported)
-        const lockResponse = await Api.getWalletLock({ walletName: importedWalletFileName, token: recoverBody.token })
+        const lockResponse = await Api.getWalletLock({ walletName: importedWalletFileName, token: auth.token })
         if (!lockResponse.ok) await Api.Helper.throwError(lockResponse)
 
         const unlockResponse = await Api.postWalletUnlock({ walletName: importedWalletFileName }, { password })
         const unlockBody = await (unlockResponse.ok ? unlockResponse.json() : Api.Helper.throwError(unlockResponse))
+        auth = {
+          token: unlockBody.token,
+          token_type: unlockBody.token_type,
+          expires_in: unlockBody.expires_in,
+          scope: unlockBody.scope,
+          refresh_token: unlockBody.refresh_token,
+        }
 
         // Step #4: reset `gaplimit´ to previous value if necessary
         if (gaplimitUpdateNecessary) {
@@ -487,7 +501,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
                 value: String(originalGaplimit),
               },
             ],
-            wallet: { name: importedWalletFileName, token: unlockBody.token },
+            wallet: { name: importedWalletFileName, token: auth.token },
           })
         }
 
@@ -508,7 +522,7 @@ export default function ImportWallet({ parentRoute, startWallet }: ImportWalletP
           })
         }
 
-        startWallet(importedWalletFileName, unlockBody.token)
+        startWallet(importedWalletFileName, auth)
         navigate(routes.wallet)
       } catch (e: any) {
         if (signal.aborted) return

--- a/src/components/LogOverlay.tsx
+++ b/src/components/LogOverlay.tsx
@@ -1,9 +1,8 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { Helper as ApiHelper } from '../libs/JmWalletApi'
 import { fetchLog } from '../libs/JamApi'
-// @ts-ignore
 import { useSettings } from '../context/SettingsContext'
 import { CurrentWallet } from '../context/WalletContext'
 import Sprite from './Sprite'

--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { ChangeEvent } from 'react'
 import styles from './ToggleSwitch.module.css'
 
 interface ToggleSwitchProps {
@@ -16,7 +16,7 @@ export default function ToggleSwitch({
   toggledOn,
   disabled = false,
 }: ToggleSwitchProps) {
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation()
     onToggle(e.currentTarget.checked)
   }

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -65,13 +65,8 @@ export default function Wallets({ currentWallet, startWallet, stopWallet }) {
 
         setUnlockWalletName(undefined)
 
-        const auth = {
-          token: body.token,
-          token_type: body.token_type,
-          expires_in: body.expires_in,
-          scope: body.scope,
-          refresh_token: body.refresh_token,
-        }
+        const auth = Api.Helper.parseAuthProps(body)
+
         startWallet(body.walletname, auth)
         navigate(routes.wallet)
       } catch (e) {

--- a/src/components/Wallets.jsx
+++ b/src/components/Wallets.jsx
@@ -65,8 +65,14 @@ export default function Wallets({ currentWallet, startWallet, stopWallet }) {
 
         setUnlockWalletName(undefined)
 
-        const { walletname: unlockedWalletName, token } = body
-        startWallet(unlockedWalletName, token)
+        const auth = {
+          token: body.token,
+          token_type: body.token_type,
+          expires_in: body.expires_in,
+          scope: body.scope,
+          refresh_token: body.refresh_token,
+        }
+        startWallet(body.walletname, auth)
         navigate(routes.wallet)
       } catch (e) {
         const message = e.message.replace('Wallet', walletName)

--- a/src/components/Wallets.test.jsx
+++ b/src/components/Wallets.test.jsx
@@ -202,7 +202,12 @@ describe('<Wallets />', () => {
       })
       apiMock.postWalletUnlock.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ walletname: dummyWalletName, token: dummyToken }),
+        json: () =>
+          Promise.resolve({
+            walletname: dummyWalletName,
+            token: dummyToken,
+            refresh_token: dummyToken,
+          }),
       })
 
       await act(async () => setup({}))
@@ -223,7 +228,10 @@ describe('<Wallets />', () => {
         await waitFor(() => screen.findByText('wallets.wallet_preview.button_unlock'))
       })
 
-      expect(mockStartWallet).toHaveBeenCalledWith(dummyWalletName, dummyToken)
+      expect(mockStartWallet).toHaveBeenCalledWith(dummyWalletName, {
+        token: dummyToken,
+        refresh_token: dummyToken,
+      })
       expect(mockedNavigate).toHaveBeenCalledWith('/wallet')
     })
 

--- a/src/components/jar_details/DisplayBranch.tsx
+++ b/src/components/jar_details/DisplayBranch.tsx
@@ -1,9 +1,7 @@
-import React from 'react'
+import { ReactNode } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
-// @ts-ignore
 import Balance from '../Balance'
-// @ts-ignore
 import { useSettings } from '../../context/SettingsContext'
 import { Branch, BranchEntry } from '../../context/WalletContext'
 import styles from './DisplayBranch.module.css'
@@ -28,7 +26,7 @@ const toSimpleStatus = (value: string) => {
   return value.substring(0, indexOfBracket).trim()
 }
 
-const toLabelNode = (simpleStatus: string): React.ReactNode => {
+const toLabelNode = (simpleStatus: string): ReactNode => {
   if (simpleStatus === 'new') return <rb.Badge bg="success">{simpleStatus}</rb.Badge>
   if (simpleStatus === 'used') return <rb.Badge bg="secondary">{simpleStatus}</rb.Badge>
 

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -17,3 +17,5 @@ export const JM_MINIMUM_MAKERS_DEFAULT = 4
 export const CJ_STATE_TAKER_RUNNING = 0
 export const CJ_STATE_MAKER_RUNNING = 1
 export const CJ_STATE_NONE_RUNNING = 2
+
+export const JM_API_AUTH_TOKEN_EXPIRY: Milliseconds = Math.round(0.5 * 60 * 60 * 1_000)

--- a/src/constants/features.ts
+++ b/src/constants/features.ts
@@ -22,5 +22,5 @@ const __isFeatureEnabled = (name: Feature, version: SemVer): boolean => {
 }
 
 export const isFeatureEnabled = (name: Feature, serviceInfo: ServiceInfo): boolean => {
-  return !!serviceInfo.server?.version && __isFeatureEnabled(name, serviceInfo.server.version)
+  return !!serviceInfo.server && __isFeatureEnabled(name, serviceInfo.server.version)
 }

--- a/src/context/ServiceConfigContext.tsx
+++ b/src/context/ServiceConfigContext.tsx
@@ -1,5 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useRef } from 'react'
-// @ts-ignore
+import { PropsWithChildren, createContext, useCallback, useContext, useEffect, useRef } from 'react'
 import { CurrentWallet, useCurrentWallet } from './WalletContext'
 
 import * as Api from '../libs/JmWalletApi'
@@ -105,7 +104,7 @@ export interface ServiceConfigContextEntry {
 
 const ServiceConfigContext = createContext<ServiceConfigContextEntry | undefined>(undefined)
 
-const ServiceConfigProvider = ({ children }: React.PropsWithChildren<{}>) => {
+const ServiceConfigProvider = ({ children }: PropsWithChildren<{}>) => {
   const currentWallet = useCurrentWallet()
   const serviceConfig = useRef<ServiceConfig | null>(null)
 

--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -80,7 +80,7 @@ type SessionInfo = {
 }
 type ServerInfo = {
   server?: {
-    version?: SemVer
+    version: SemVer
   }
 }
 
@@ -118,20 +118,12 @@ const ServiceInfoProvider = ({ children }: PropsWithChildren<{}>) => {
 
     Api.getGetinfo({ signal: abortCtrl.signal })
       .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res)))
-      .then((data: JmGetInfoData) => {
-        dispatchServiceInfo({
-          server: {
-            version: toSemVer(data.version),
-          },
-        })
-      })
-      .catch((err) => {
-        const notFound = err.response.status === 404
-        if (notFound) {
+      .then((data: JmGetInfoData) => toSemVer(data.version))
+      .catch((_) => UNKNOWN_VERSION)
+      .then((version) => {
+        if (!abortCtrl.signal.aborted) {
           dispatchServiceInfo({
-            server: {
-              version: UNKNOWN_VERSION,
-            },
+            server: { version },
           })
         }
       })

--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -9,7 +9,7 @@ import {
   useEffect,
   useRef,
 } from 'react'
-import { useCurrentWallet, useSetCurrentWallet } from './WalletContext'
+import { useCurrentWallet, useClearCurrentWallet } from './WalletContext'
 // @ts-ignore
 import { useWebsocket } from './WebsocketContext'
 import { clearSession } from '../session'
@@ -102,7 +102,7 @@ const ServiceInfoContext = createContext<ServiceInfoContextEntry | undefined>(un
 
 const ServiceInfoProvider = ({ children }: PropsWithChildren<{}>) => {
   const currentWallet = useCurrentWallet()
-  const setCurrentWallet = useSetCurrentWallet()
+  const clearCurrentWallet = useClearCurrentWallet()
   const websocket = useWebsocket()
 
   const fetchSessionInProgress = useRef<Promise<ServiceInfo> | null>(null)
@@ -146,14 +146,14 @@ const ServiceInfoProvider = ({ children }: PropsWithChildren<{}>) => {
       // Just reset the wallet info, not the session storage (token),
       // as the connection might be down shortly and auth information
       // is still valid most of the time.
-      setCurrentWallet(null)
+      clearCurrentWallet()
     }
-  }, [connectionError, setCurrentWallet])
+  }, [connectionError, clearCurrentWallet])
 
   const reloadServiceInfo = useCallback(
     async ({ signal }: { signal: AbortSignal }) => {
       const resetWalletAndClearSession = () => {
-        setCurrentWallet(null)
+        clearCurrentWallet()
         clearSession()
       }
 
@@ -225,7 +225,7 @@ const ServiceInfoProvider = ({ children }: PropsWithChildren<{}>) => {
           throw err
         })
     },
-    [currentWallet, setCurrentWallet],
+    [currentWallet, clearCurrentWallet],
   )
 
   useEffect(() => {

--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -1,5 +1,14 @@
-import React, { createContext, useCallback, useContext, useReducer, useState, useEffect, useRef } from 'react'
-// @ts-ignore
+import {
+  PropsWithChildren,
+  Dispatch,
+  createContext,
+  useCallback,
+  useContext,
+  useReducer,
+  useState,
+  useEffect,
+  useRef,
+} from 'react'
 import { useCurrentWallet, useSetCurrentWallet } from './WalletContext'
 // @ts-ignore
 import { useWebsocket } from './WebsocketContext'
@@ -85,13 +94,13 @@ type ServiceInfo = SessionFlag &
 interface ServiceInfoContextEntry {
   serviceInfo: ServiceInfo | null
   reloadServiceInfo: ({ signal }: { signal: AbortSignal }) => Promise<ServiceInfo>
-  dispatchServiceInfo: React.Dispatch<Partial<ServiceInfo>>
+  dispatchServiceInfo: Dispatch<Partial<ServiceInfo>>
   connectionError?: Error
 }
 
 const ServiceInfoContext = createContext<ServiceInfoContextEntry | undefined>(undefined)
 
-const ServiceInfoProvider = ({ children }: React.PropsWithChildren<{}>) => {
+const ServiceInfoProvider = ({ children }: PropsWithChildren<{}>) => {
   const currentWallet = useCurrentWallet()
   const setCurrentWallet = useSetCurrentWallet()
   const websocket = useWebsocket()

--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -18,8 +18,8 @@ import { toSemVer, UNKNOWN_VERSION } from '../utils'
 
 import * as Api from '../libs/JmWalletApi'
 
-// interval in milliseconds for periodic session requests
-const SESSION_REQUEST_INTERVAL = 10_000
+// interval for periodic session requests
+const SESSION_REQUEST_INTERVAL: Milliseconds = 10_000
 
 type AmountFraction = number
 type AmountCounterparties = number

--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -81,17 +81,11 @@ type ServiceInfo = SessionFlag &
   RescanBlockchainInProgressFlag &
   SessionInfo &
   ServerInfo
-type ServiceInfoUpdate =
-  | ServiceInfo
-  | MakerRunningFlag
-  | CoinjoinInProgressFlag
-  | RescanBlockchainInProgressFlag
-  | ServerInfo
 
 interface ServiceInfoContextEntry {
   serviceInfo: ServiceInfo | null
   reloadServiceInfo: ({ signal }: { signal: AbortSignal }) => Promise<ServiceInfo>
-  dispatchServiceInfo: React.Dispatch<ServiceInfoUpdate>
+  dispatchServiceInfo: React.Dispatch<Partial<ServiceInfo>>
   connectionError?: Error
 }
 
@@ -105,7 +99,7 @@ const ServiceInfoProvider = ({ children }: React.PropsWithChildren<{}>) => {
   const fetchSessionInProgress = useRef<Promise<ServiceInfo> | null>(null)
 
   const [serviceInfo, dispatchServiceInfo] = useReducer(
-    (state: ServiceInfo | null, obj: ServiceInfoUpdate) => ({ ...state, ...obj }) as ServiceInfo | null,
+    (state: ServiceInfo | null, obj: Partial<ServiceInfo>) => ({ ...state, ...obj }) as ServiceInfo | null,
     null,
   )
   const [connectionError, setConnectionError] = useState<Error>()

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -13,7 +13,7 @@ export interface CurrentWallet {
 }
 
 class CurrentWalletImpl implements CurrentWallet {
-  name: Api.WalletName
+  readonly name: Api.WalletName
   #token: Api.ApiToken
 
   constructor(name: Api.WalletName, token: Api.ApiToken) {
@@ -203,7 +203,7 @@ const toWalletInfo = (data: CombinedRawWalletData): WalletInfo => {
 const toCombinedRawData = (utxos: UtxosResponse, display: WalletDisplayResponse) => ({ utxos, display })
 
 const WalletProvider = ({ children }: PropsWithChildren<any>) => {
-  const [currentWallet, setCurrentWalletOrNull] = useState(restoreWalletFromSession())
+  const [currentWallet, setCurrentWalletOrNull] = useState(restoreWalletFromSession)
 
   const setCurrentWallet = useCallback(
     (wallet: CurrentWallet) => {

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -153,10 +153,10 @@ const WalletContext = createContext<WalletContextEntry | undefined>(undefined)
 
 const restoreWalletFromSession = (): CurrentWallet | null => {
   const session = getSession()
-  return session && session.name && session.token
+  return session && session.name && session.auth && session.auth.token
     ? {
         name: session.name,
-        token: session.token,
+        token: session.auth.token,
       }
     : null
 }

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -6,6 +6,11 @@ import * as Api from '../libs/JmWalletApi'
 
 import { WalletBalanceSummary, toBalanceSummary } from './BalanceSummary'
 import { JM_API_AUTH_TOKEN_EXPIRY } from '../constants/config'
+import { isDevMode } from '../constants/debugFeatures'
+
+const API_AUTH_TOKEN_RENEW_INTERVAL: Milliseconds = isDevMode()
+  ? 60 * 1_000
+  : Math.round(JM_API_AUTH_TOKEN_EXPIRY * 0.75)
 
 export interface CurrentWallet {
   name: Api.WalletName
@@ -337,7 +342,7 @@ const WalletProvider = ({ children }: PropsWithChildren<any>) => {
         .catch((err) => console.error(err))
     }
 
-    const interval = setInterval(renewToken, JM_API_AUTH_TOKEN_EXPIRY / 3)
+    const interval = setInterval(renewToken, API_AUTH_TOKEN_RENEW_INTERVAL)
     return () => {
       clearInterval(interval)
       abortCtrl.abort()

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -328,13 +328,8 @@ const WalletProvider = ({ children }: PropsWithChildren<any>) => {
       )
         .then((res) => (res.ok ? res.json() : Api.Helper.throwError(res)))
         .then((body) => {
-          const auth = {
-            token: body.token,
-            token_type: body.token_type,
-            expires_in: body.expires_in,
-            scope: body.scope,
-            refresh_token: body.refresh_token,
-          }
+          const auth = Api.Helper.parseAuthProps(body)
+
           setSession({ name: currentWallet.name, auth })
           currentWallet.updateToken(auth.token)
           console.debug('Successfully renewed auth token.')

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
+import { StrictMode } from 'react'
 import ReactDOM from 'react-dom'
-// @ts-ignore
+
 import App from './components/App'
-// @ts-ignore
 import { SettingsProvider } from './context/SettingsContext'
 // @ts-ignore
 import { WebsocketProvider } from './context/WebsocketContext'
@@ -15,7 +14,7 @@ import './index.css'
 import './i18n/config'
 
 ReactDOM.render(
-  <React.StrictMode>
+  <StrictMode>
     <SettingsProvider>
       <WalletProvider>
         <ServiceConfigProvider>
@@ -27,6 +26,6 @@ ReactDOM.render(
         </ServiceConfigProvider>
       </WalletProvider>
     </SettingsProvider>
-  </React.StrictMode>,
+  </StrictMode>,
   document.getElementById('root'),
 )

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -24,19 +24,19 @@ export type TxId = string
 export type UtxoId = `${TxId}:${Vout}`
 
 // for JM versions <0.9.11
-export type SingleApiTokenContext = {
+export type SingleTokenAuthContext = {
   token: ApiToken
 }
 
 // for JM versions >=0.9.11
-export type RefreshApiTokenContext = SingleApiTokenContext & {
+export type RefreshTokenAuthContext = SingleTokenAuthContext & {
   token_type: string // "bearer"
   expires_in: Seconds // 1800
   scope: string
   refresh_token: ApiToken
 }
 
-export type ApiTokenContext = SingleApiTokenContext | RefreshApiTokenContext
+export type ApiAuthContext = SingleTokenAuthContext | RefreshTokenAuthContext
 
 type WithWalletName = {
   walletName: WalletName

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -57,6 +57,11 @@ interface ApiError {
 
 type WalletType = 'sw-fb'
 
+interface TokenRequest {
+  grant_type: string
+  refresh_token: string
+}
+
 interface CreateWalletRequest {
   walletname: WalletName | string
   password: string
@@ -219,6 +224,15 @@ const getGetinfo = async ({ signal }: ApiRequestContext) => {
 const getSession = async ({ token, signal }: ApiRequestContext & { token?: ApiToken }) => {
   return await fetch(`${basePath()}/v1/session`, {
     headers: token ? { ...Helper.buildAuthHeader(token) } : undefined,
+    signal,
+  })
+}
+
+const postToken = async ({ signal, token }: AuthApiRequestContext, req: TokenRequest) => {
+  return await fetch(`${basePath()}/v1/token`, {
+    headers: { ...Helper.buildAuthHeader(token) },
+    method: 'POST',
+    body: JSON.stringify(req),
     signal,
   })
 }
@@ -472,6 +486,7 @@ export class JmApiError extends Error {
 
 export {
   getGetinfo,
+  postToken,
   postMakerStart,
   getMakerStop,
   getSession,

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -23,6 +23,21 @@ type Vout = number
 export type TxId = string
 export type UtxoId = `${TxId}:${Vout}`
 
+// for JM versions <0.9.11
+export type SingleApiTokenContext = {
+  token: ApiToken
+}
+
+// for JM versions >=0.9.11
+export type RefreshApiTokenContext = SingleApiTokenContext & {
+  token_type: string // "bearer"
+  expires_in: Seconds // 1800
+  scope: string
+  refresh_token: ApiToken
+}
+
+export type ApiTokenContext = SingleApiTokenContext | RefreshApiTokenContext
+
 type WithWalletName = {
   walletName: WalletName
 }

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -75,7 +75,7 @@ interface ApiError {
 type WalletType = 'sw-fb'
 
 interface TokenRequest {
-  grant_type: string
+  grant_type: 'refresh_token' | string
   refresh_token: string
 }
 
@@ -224,11 +224,25 @@ const Helper = (() => {
     return { 'x-jm-authorization': `Bearer ${token}` }
   }
 
+  // Simple helper method to parse auth properties.
+  // TODO: This can be removed when the API methods
+  // return typed responses (see #670)
+  const parseAuthProps = (body: any): ApiAuthContext => {
+    return {
+      token: body.token,
+      token_type: body.token_type,
+      expires_in: body.expires_in,
+      scope: body.scope,
+      refresh_token: body.refresh_token,
+    }
+  }
+
   return {
     throwError,
     throwResolved,
     extractErrorMessage,
     buildAuthHeader,
+    parseAuthProps,
   }
 })()
 

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -12,31 +12,33 @@
  */
 const basePath = () => `${window.JM.PUBLIC_PATH}/api`
 
-export type ApiToken = string
-export type WalletName = `${string}.jmdat`
+type ApiToken = string
+type WalletName = `${string}.jmdat`
 
-export type Mixdepth = number
-export type AmountSats = number // TODO: should be BigInt! Remove once every caller migrated to TypeScript.
-export type BitcoinAddress = string
+type Mixdepth = number
+type AmountSats = number // TODO: should be BigInt! Remove once every caller migrated to TypeScript.
+type BitcoinAddress = string
 
 type Vout = number
-export type TxId = string
-export type UtxoId = `${TxId}:${Vout}`
+type TxId = string
+type UtxoId = `${TxId}:${Vout}`
 
 // for JM versions <0.9.11
-export type SingleTokenAuthContext = {
+type SingleTokenAuthContext = {
   token: ApiToken
+  refresh_token: undefined
 }
 
 // for JM versions >=0.9.11
-export type RefreshTokenAuthContext = SingleTokenAuthContext & {
+type RefreshTokenAuthContext = {
+  token: ApiToken
   token_type: string // "bearer"
   expires_in: Seconds // 1800
   scope: string
   refresh_token: ApiToken
 }
 
-export type ApiAuthContext = SingleTokenAuthContext | RefreshTokenAuthContext
+type ApiAuthContext = SingleTokenAuthContext | RefreshTokenAuthContext
 
 type WithWalletName = {
   walletName: WalletName
@@ -48,7 +50,7 @@ type WithMixdepth = {
 type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
 type YYYY = `2${Digit}${Digit}${Digit}`
 type MM = '01' | '02' | '03' | '04' | '05' | '06' | '07' | '08' | '09' | '10' | '11' | '12'
-export type Lockdate = `${YYYY}-${MM}`
+type Lockdate = `${YYYY}-${MM}`
 type WithLockdate = {
   lockdate: Lockdate
 }
@@ -64,7 +66,7 @@ interface AuthApiRequestContext extends ApiRequestContext {
   token: ApiToken
 }
 
-export type WalletRequestContext = AuthApiRequestContext & WithWalletName
+type WalletRequestContext = AuthApiRequestContext & WithWalletName
 
 interface ApiError {
   message: string
@@ -135,12 +137,12 @@ interface ConfigGetRequest {
   field: string
 }
 
-export interface StartSchedulerRequest {
+interface StartSchedulerRequest {
   destination_addresses: BitcoinAddress[]
   tumbler_options?: TumblerOptions
 }
 
-export interface TumblerOptions {
+interface TumblerOptions {
   restart?: boolean
   schedulefile?: string
   addrcount?: number
@@ -490,7 +492,7 @@ const getRescanBlockchain = async ({
   })
 }
 
-export class JmApiError extends Error {
+class JmApiError extends Error {
   public response: Response
 
   constructor(response: Response, message: string) {
@@ -526,4 +528,16 @@ export {
   getSchedule,
   getRescanBlockchain,
   Helper,
+  JmApiError,
+  ApiAuthContext,
+  StartSchedulerRequest,
+  WalletRequestContext,
+  ApiToken,
+  WalletName,
+  Lockdate,
+  TxId,
+  UtxoId,
+  Mixdepth,
+  AmountSats,
+  BitcoinAddress,
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,19 +1,19 @@
-import { WalletName, ApiToken } from './libs/JmWalletApi'
+import { WalletName, ApiAuthContext } from './libs/JmWalletApi'
 
 const SESSION_KEY = 'joinmarket'
 
 export interface SessionItem {
   name: WalletName
-  token: ApiToken
+  auth: ApiAuthContext
 }
 
 export const setSession = (session: SessionItem) => sessionStorage.setItem(SESSION_KEY, JSON.stringify(session))
 
 export const getSession = (): SessionItem | null => {
   const json = sessionStorage.getItem(SESSION_KEY)
-  const { name, token }: any = (json && JSON.parse(json)) || {}
-  if (name && token) {
-    return { name, token }
+  const { name, auth }: any = (json && JSON.parse(json)) || {}
+  if (name && auth?.token) {
+    return { name, auth }
   } else {
     clearSession()
     return null

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -1,18 +1,17 @@
-import React from 'react'
+import { StrictMode, ReactElement } from 'react'
 import { render, RenderOptions } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
 import { WalletProvider } from './context/WalletContext'
 import { ServiceInfoProvider } from './context/ServiceInfoContext'
 import { ServiceConfigProvider } from './context/ServiceConfigContext'
-// @ts-ignore
 import { SettingsProvider } from './context/SettingsContext'
 // @ts-ignore
 import { WebsocketProvider } from './context/WebsocketContext'
 import i18n from './i18n/testConfig'
 
-const AllTheProviders = ({ children }: { children: React.ReactElement }) => {
+const AllTheProviders = ({ children }: { children: ReactElement }) => {
   return (
-    <React.StrictMode>
+    <StrictMode>
       <I18nextProvider i18n={i18n}>
         <SettingsProvider>
           <WalletProvider>
@@ -24,12 +23,11 @@ const AllTheProviders = ({ children }: { children: React.ReactElement }) => {
           </WalletProvider>
         </SettingsProvider>
       </I18nextProvider>
-    </React.StrictMode>
+    </StrictMode>
   )
 }
 
-const customRender = (ui: React.ReactElement, options?: RenderOptions) =>
-  render(ui, { wrapper: AllTheProviders, ...options })
+const customRender = (ui: ReactElement, options?: RenderOptions) => render(ui, { wrapper: AllTheProviders, ...options })
 
 // re-export everything
 export * from '@testing-library/react'


### PR DESCRIPTION
Resolves #663.

This PR adds handling for the new JWT auth mechanism.

From [JSON-RPC-API-using-jmwalletd.md#rules-about-making-requests](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/JSON-RPC-API-using-jmwalletd.md#rules-about-making-requests):

> On initially creating, unlocking or recovering a wallet, a new access and refresh token will be sent in response, the former is valid for only 30 minutes and must be used for any authenticated call, the former is valid for 4 hours and can be used to request a new access token, ideally before access token expiration to avoid unauthorized response from authenticated endpoint and in any case, before refresh token expiration.

The token is refreshed every 22.5 minutes (30min * 0.75). In dev mode more often (every 60 seconds).

There is currently a problem upstream with handling wallets that contain spaces in their filename, should be fixed with https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1562. Nonetheless, the code can already be reviewed and should not be affected by the changes.

### How to test
Rebuild the dev docker environment `npm run regtest:rebuild` and verify:
- Create wallet still works
- Import wallet still works
- Lock/Unlock still works
- Token can be refreshed
- Requests to RPC api are still successful after token refresh
- Websocket communication still functioning after token refresh (e.g. start/stop a maker and watch the websocket data)

### Misc
- Method `Api.Helper.parseAuthProps` is temporary and can be removed in #670.
- Changes backend version in regtest env to `master` again.
