### PR TITLE
chore(ui): scroll to page top after successful payment

### DIFF
--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -25,7 +25,7 @@ import { buildCoinjoinRequirementSummary } from '../../hooks/CoinjoinRequirement
 
 import { routes } from '../../constants/routes'
 import { JM_MINIMUM_MAKERS_DEFAULT } from '../../constants/config'
-import { SATS, formatSats, isValidNumber } from '../../utils'
+import { SATS, formatSats, isValidNumber, scrollToTop } from '../../utils'
 
 import {
   enhanceDirectPaymentErrorMessageIfNecessary,
@@ -477,6 +477,8 @@ export default function Send({ wallet }: SendProps) {
         setIsSweep(false)
 
         form.reset()
+
+        scrollToTop()
       }
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,3 +92,5 @@ export const toSemVer = (raw?: string): SemVer => {
     raw,
   }
 }
+
+export const scrollToTop = () => window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })


### PR DESCRIPTION
Nothing fancy: Scroll above the fold after a successful payment to focus the "payment successful" or "collaborative transaction in progress" message.

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/a6fe3734-6d96-4010-9b55-d2913533305a" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/90e1d384-c209-4bad-ab37-254ac9f958f7" width=350 />

