### PR TITLE
chore: debounce polling of session info

### DIFF
--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -1,6 +1,8 @@
-import React, { createContext, useEffect, useState, useContext } from 'react'
+import { createContext, useEffect, useState, useContext } from 'react'
 
 import { useCurrentWallet } from './WalletContext'
+import { noop } from '../utils'
+import { isDevMode } from '../constants/debugFeatures'
 
 const WEBSOCKET_RECONNECT_DELAY_STEP = 1_000
 const WEBSOCKET_RECONNECT_MAX_DELAY = 10_000
@@ -23,8 +25,7 @@ const connectionRetryDelayLinear = (attempt = 0) => {
 // path that will be proxied to the backend server
 const WEBSOCKET_ENDPOINT_PATH = `${window.JM.PUBLIC_PATH}/jmws`
 
-const NOOP = () => {}
-const logToDebugConsoleInDevMode = process.env.NODE_ENV === 'development' ? console.debug : NOOP
+const logToDebugConsoleInDevMode = isDevMode() ? console.debug : noop
 
 const createWebSocket = () => {
   const { protocol, host } = window.location

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,3 +94,20 @@ export const toSemVer = (raw?: string): SemVer => {
 }
 
 export const scrollToTop = () => window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
+
+export const noop = () => {}
+
+export const setIntervalDebounced = (
+  callback: () => Promise<void>,
+  delay: Milliseconds,
+  onTimerIdChanged: (timerId: NodeJS.Timer) => void,
+) => {
+  ;(function loop() {
+    onTimerIdChanged(
+      setTimeout(async () => {
+        await callback()
+        loop()
+      }, delay),
+    )
+  })()
+}


### PR DESCRIPTION
Before these changes, the `/session` endpoint has been polled with `setInterval` - i.e. rescheduled to run every 10 seconds, regardless of the response duration. On slow connection, e.g. over Tor, this can lead to requests queuing up.

After this commit, a new request is made 10 seconds _after_ the previous response arrived, which mitigates the behaviour described above.