### PR TITLE
chore: do not preselect jar on send page

### DIFF
--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -112,22 +112,6 @@ export default function Send({ wallet }: SendProps) {
     )
   }, [walletInfo])
 
-  useEffect(
-    function preSelectSourceJarIfPossible() {
-      if (isLoading) return
-
-      const jarsWithBalance = sortedAccountBalances.filter((it) => it.calculatedAvailableBalanceInSats > 0)
-      setSourceJarIndex((current) => {
-        if (jarsWithBalance.length === 0) return null
-
-        const currentJarHasBalance = current !== null && jarsWithBalance.some((it) => it.accountIndex === current)
-        if (currentJarHasBalance) return current
-        return jarsWithBalance[0].accountIndex
-      })
-    },
-    [isLoading, sourceJarIndex, sortedAccountBalances],
-  )
-
   const accountBalance = useMemo(() => {
     if (sourceJarIndex === null) return null
     return sortedAccountBalances[sourceJarIndex]
@@ -469,6 +453,7 @@ export default function Send({ wallet }: SendProps) {
         : await sendPayment(sourceJarIndex, destination, amount)
 
       if (success) {
+        setSourceJarIndex(INITIAL_SOURCE_JAR_INDEX)
         setDestination(INITIAL_DESTINATION)
         setDestinationJar(null)
         setAmount(INITIAL_AMOUNT)
@@ -477,9 +462,9 @@ export default function Send({ wallet }: SendProps) {
         setIsSweep(false)
 
         form.reset()
-
-        scrollToTop()
       }
+
+      scrollToTop()
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,4 +93,13 @@ export const toSemVer = (raw?: string): SemVer => {
   }
 }
 
-export const scrollToTop = () => window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
+/**
+ * Scrolls to the top of the page.
+ *
+ * Hint: There is a small delay before the scrolling is initiated,
+ * in order to mitigate some weird browser behaviour, where it
+ * did not properly work without a timeout.
+ */
+export const scrollToTop = (options?: ScrollOptions) => {
+  setTimeout(() => window.scrollTo({ behavior: 'smooth', ...options, top: 0, left: 0 }), 21)
+}


### PR DESCRIPTION
Before this commit, the first funded jar has been preselected as source jar.
After this commit, no jar will be preselected.

This was a request by @editwentyone.

Additionally, it fixes a strange bug: Scrolling to the top of the page did not work properly in all browsers.
