### PR TITLE
feat: renew fidelity bond

### DIFF
--- a/src/components/Earn.tsx
+++ b/src/components/Earn.tsx
@@ -14,7 +14,7 @@ import PageTitle from './PageTitle'
 import SegmentedTabs from './SegmentedTabs'
 import { CreateFidelityBond } from './fb/CreateFidelityBond'
 import { ExistingFidelityBond } from './fb/ExistingFidelityBond'
-import { SpendFidelityBondModal } from './fb/SpendFidelityBondModal'
+import { RenewFidelityBondModal, SpendFidelityBondModal } from './fb/SpendFidelityBondModal'
 import { EarnReportOverlay } from './EarnReport'
 import { OrderbookOverlay } from './Orderbook'
 import Balance from './Balance'
@@ -614,6 +614,20 @@ export default function Earn({ wallet }: EarnProps) {
                     destinationJarIndex={0}
                     onClose={({ mustReload }) => {
                       setMoveToJarFidelityBondId(undefined)
+                      if (mustReload) {
+                        reloadFidelityBonds({ delay: 0 })
+                      }
+                    }}
+                  />
+                )}
+                {currentWalletInfo && renewFidelityBondId && (
+                  <RenewFidelityBondModal
+                    show={true}
+                    fidelityBondId={renewFidelityBondId}
+                    wallet={wallet}
+                    walletInfo={currentWalletInfo}
+                    onClose={({ mustReload }) => {
+                      setRenewFidelityBondId(undefined)
                       if (mustReload) {
                         reloadFidelityBonds({ delay: 0 })
                       }

--- a/src/components/Earn.tsx
+++ b/src/components/Earn.tsx
@@ -424,6 +424,7 @@ export default function Earn({ wallet }: EarnProps) {
   }, [currentWalletInfo])
 
   const [moveToJarFidelityBondId, setMoveToJarFidelityBondId] = useState<Api.UtxoId>()
+  const [renewFidelityBondId, setRenewFidelityBondId] = useState<Api.UtxoId>()
 
   const startMakerService = useCallback(
     (values: EarnFormValues) => {
@@ -633,18 +634,25 @@ export default function Earn({ wallet }: EarnProps) {
                   return (
                     <ExistingFidelityBond key={index} fidelityBond={fidelityBond}>
                       {actionsEnabled && (
-                        <div className="mt-4">
-                          <div className="">
-                            <rb.Button
-                              variant={settings.theme === 'dark' ? 'light' : 'dark'}
-                              className="w-50 d-flex justify-content-center align-items-center"
-                              disabled={moveToJarFidelityBondId !== undefined}
-                              onClick={() => setMoveToJarFidelityBondId(fidelityBond.utxo)}
-                            >
-                              <Sprite className="me-1 mb-1" symbol="unlock" width="24" height="24" />
-                              {t('earn.fidelity_bond.existing.button_spend')}
-                            </rb.Button>
-                          </div>
+                        <div className="mt-4 d-flex gap-2">
+                          <rb.Button
+                            variant={settings.theme === 'dark' ? 'light' : 'dark'}
+                            className="w-100 d-flex justify-content-center align-items-center"
+                            disabled={moveToJarFidelityBondId !== undefined}
+                            onClick={() => setMoveToJarFidelityBondId(fidelityBond.utxo)}
+                          >
+                            <Sprite className="me-1 mb-1" symbol="unlock" width="24" height="24" />
+                            {t('earn.fidelity_bond.existing.button_spend')}
+                          </rb.Button>
+                          <rb.Button
+                            variant={settings.theme === 'dark' ? 'light' : 'dark'}
+                            className="w-100 d-flex justify-content-center align-items-center"
+                            disabled={renewFidelityBondId !== undefined}
+                            onClick={() => setRenewFidelityBondId(fidelityBond.utxo)}
+                          >
+                            <Sprite className="me-1" symbol="refresh" width="24" height="24" />
+                            {t('earn.fidelity_bond.existing.button_renew')}
+                          </rb.Button>
                         </div>
                       )}
                     </ExistingFidelityBond>

--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -6,7 +6,7 @@ import Balance from './Balance'
 import { useSettings } from '../context/SettingsContext'
 import { FeeValues, TxFee, useEstimatedMaxCollaboratorFee } from '../hooks/Fees'
 import { ConfirmModal, ConfirmModalProps } from './Modal'
-import { AmountSats } from '../libs/JmWalletApi'
+import { AmountSats, BitcoinAddress } from '../libs/JmWalletApi'
 import { jarInitial } from './jars/Jar'
 import { isValidNumber } from '../utils'
 import styles from './PaymentConfirmModal.module.css'
@@ -57,7 +57,7 @@ const useMiningFeeText = ({ tx_fees, tx_fees_factor }: Pick<FeeValues, 'tx_fees'
 
 interface PaymentDisplayInfo {
   sourceJarIndex?: JarIndex
-  destination: String
+  destination: BitcoinAddress | string
   amount: AmountSats
   isSweep: boolean
   isCoinjoin: boolean

--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { PropsWithChildren, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import * as rb from 'react-bootstrap'
 import Sprite from './Sprite'
@@ -6,10 +6,10 @@ import Balance from './Balance'
 import { useSettings } from '../context/SettingsContext'
 import { FeeValues, TxFee, useEstimatedMaxCollaboratorFee } from '../hooks/Fees'
 import { ConfirmModal, ConfirmModalProps } from './Modal'
-import styles from './PaymentConfirmModal.module.css'
 import { AmountSats } from '../libs/JmWalletApi'
 import { jarInitial } from './jars/Jar'
 import { isValidNumber } from '../utils'
+import styles from './PaymentConfirmModal.module.css'
 
 const feeRange: (txFee: TxFee, txFeeFactor: number) => [number, number] = (txFee, txFeeFactor) => {
   if (txFee.unit !== 'sats/kilo-vbyte') {
@@ -81,8 +81,9 @@ export function PaymentConfirmModal({
     feeConfigValues,
     showPrivacyInfo = true,
   },
+  children,
   ...confirmModalProps
-}: PaymentConfirmModalProps) {
+}: PropsWithChildren<PaymentConfirmModalProps>) {
   const { t } = useTranslation()
   const settings = useSettings()
 
@@ -204,6 +205,11 @@ export function PaymentConfirmModal({
             <rb.Col xs={8} md={9} className="text-start">
               {miningFeeText}
             </rb.Col>
+          </rb.Row>
+        )}
+        {children && (
+          <rb.Row>
+            <rb.Col xs={12}>{children}</rb.Col>
           </rb.Row>
         )}
       </rb.Container>

--- a/src/components/fb/CreateFidelityBond.tsx
+++ b/src/components/fb/CreateFidelityBond.tsx
@@ -597,6 +597,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
       {lockDate && timelockedAddress && selectedJar !== undefined && (
         <PaymentConfirmModal
           isShown={showConfirmInputsModal}
+          size="lg"
           title={t('earn.fidelity_bond.confirm_modal.title')}
           onCancel={() => setShowConfirmInputsModal(false)}
           onConfirm={() => {

--- a/src/components/fb/CreateFidelityBond.tsx
+++ b/src/components/fb/CreateFidelityBond.tsx
@@ -5,7 +5,6 @@ import { Trans, useTranslation } from 'react-i18next'
 import { CurrentWallet, Utxo, Utxos, WalletInfo, useReloadCurrentWalletInfo } from '../../context/WalletContext'
 import Alert from '../Alert'
 import Sprite from '../Sprite'
-import { ConfirmModal } from '../Modal'
 import {
   SelectJar,
   SelectUtxos,
@@ -18,8 +17,32 @@ import {
 import * as fb from './utils'
 import { isDebugFeatureEnabled } from '../../constants/debugFeatures'
 import styles from './CreateFidelityBond.module.css'
+import { PaymentConfirmModal } from '../PaymentConfirmModal'
+import { useFeeConfigValues } from '../../hooks/Fees'
 
 const TIMEOUT_RELOAD_UTXOS_AFTER_FB_CREATE_MS = 2_500
+
+export const LockInfoAlert = ({ lockDate, className }: { lockDate: Api.Lockdate; className?: string }) => {
+  const { t, i18n } = useTranslation()
+
+  return (
+    <Alert
+      className={className}
+      variant="warning"
+      message={
+        <>
+          {t('earn.fidelity_bond.confirm_modal.body', {
+            date: new Date(fb.lockdate.toTimestamp(lockDate)).toUTCString(),
+            humanReadableDuration: fb.time.humanReadableDuration({
+              to: fb.lockdate.toTimestamp(lockDate),
+              locale: i18n.resolvedLanguage || i18n.language,
+            }),
+          })}
+        </>
+      }
+    />
+  )
+}
 
 const steps = {
   selectDate: 0,
@@ -41,8 +64,9 @@ interface CreateFidelityBondProps {
 }
 
 const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDone }: CreateFidelityBondProps) => {
+  const { t } = useTranslation()
   const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
-  const { t, i18n } = useTranslation()
+  const feeConfigValues = useFeeConfigValues()[0]
 
   const [isExpanded, setIsExpanded] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
@@ -53,17 +77,19 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
   const [lockDate, setLockDate] = useState<Api.Lockdate | null>(null)
   const [selectedJar, setSelectedJar] = useState<JarIndex>()
   const [selectedUtxos, setSelectedUtxos] = useState<Utxos>([])
-  const [timelockedAddress, setTimelockedAddress] = useState(null)
+  const [timelockedAddress, setTimelockedAddress] = useState<Api.BitcoinAddress>()
   const [utxoIdsToBeSpent, setUtxoIdsToBeSpent] = useState([])
   const [createdFidelityBondUtxo, setCreatedFidelityBondUtxo] = useState<Utxo>()
   const [frozenUtxos, setFrozenUtxos] = useState<Utxos>([])
 
-  const allUtxosSelected = useMemo(() => {
-    return (
-      walletInfo.balanceSummary.calculatedTotalBalanceInSats ===
-      selectedUtxos.map((it) => it.value).reduce((prev, curr) => prev + curr, 0)
-    )
-  }, [walletInfo, selectedUtxos])
+  const selectedUtxosTotalValue = useMemo(
+    () => selectedUtxos.map((it) => it.value).reduce((prev, curr) => prev + curr, 0),
+    [selectedUtxos],
+  )
+  const allUtxosSelected = useMemo(
+    () => walletInfo.balanceSummary.calculatedTotalBalanceInSats === selectedUtxosTotalValue,
+    [walletInfo, selectedUtxosTotalValue],
+  )
 
   const yearsRange = useMemo(() => {
     if (isDebugFeatureEnabled('allowCreatingExpiredFidelityBond')) {
@@ -79,7 +105,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
     setSelectedJar(undefined)
     setSelectedUtxos([])
     setLockDate(null)
-    setTimelockedAddress(null)
+    setTimelockedAddress(undefined)
     setAlert(undefined)
     setCreatedFidelityBondUtxo(undefined)
     setFrozenUtxos([])
@@ -307,7 +333,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
           )
         }
 
-        if (timelockedAddress === null) {
+        if (!timelockedAddress) {
           return <div>{t('earn.fidelity_bond.error_loading_address')}</div>
         }
 
@@ -386,7 +412,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
 
         return t('earn.fidelity_bond.freeze_utxos.text_primary_button')
       case steps.reviewInputs:
-        if (timelockedAddress === null) return t('earn.fidelity_bond.review_inputs.text_primary_button_error')
+        if (!timelockedAddress) return t('earn.fidelity_bond.review_inputs.text_primary_button_error')
 
         if (!onlyCjOutOrFbUtxosSelected()) {
           return t('earn.fidelity_bond.review_inputs.text_primary_button_unsafe')
@@ -522,7 +548,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
       loadTimeLockedAddress(lockDate!)
     }
 
-    if (step === steps.reviewInputs && timelockedAddress === null) {
+    if (step === steps.reviewInputs && !timelockedAddress) {
       loadTimeLockedAddress(lockDate!)
       return
     }
@@ -568,26 +594,31 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
   return (
     <div className={styles.container}>
       {alert && <Alert {...alert} className="mt-0" onClose={() => setAlert(undefined)} />}
-      {lockDate && (
-        <ConfirmModal
+      {lockDate && timelockedAddress && selectedJar !== undefined && (
+        <PaymentConfirmModal
           isShown={showConfirmInputsModal}
           title={t('earn.fidelity_bond.confirm_modal.title')}
           onCancel={() => setShowConfirmInputsModal(false)}
           onConfirm={() => {
             setStep(steps.createFidelityBond)
             setShowConfirmInputsModal(false)
-            directSweepToFidelityBond(selectedJar!, timelockedAddress!)
+            directSweepToFidelityBond(selectedJar, timelockedAddress)
+          }}
+          data={{
+            sourceJarIndex: undefined, // dont show a source jar - might be confusing in this context
+            destination: timelockedAddress,
+            amount: selectedUtxosTotalValue,
+            isSweep: true,
+            isCoinjoin: false, // not sent as collaborative transaction
+            numCollaborators: undefined,
+            feeConfigValues,
+            showPrivacyInfo: false,
           }}
         >
-          {t('earn.fidelity_bond.confirm_modal.body', {
-            date: new Date(fb.lockdate.toTimestamp(lockDate)).toUTCString(),
-            humanReadableDuration: fb.time.humanReadableDuration({
-              to: fb.lockdate.toTimestamp(lockDate),
-              locale: i18n.resolvedLanguage || i18n.language,
-            }),
-          })}
-        </ConfirmModal>
+          <LockInfoAlert className="text-start mt-4" lockDate={lockDate} />
+        </PaymentConfirmModal>
       )}
+
       <div className={styles.header} onClick={() => setIsExpanded(!isExpanded)}>
         <div className="d-flex justify-content-between align-items-center">
           <div className={styles.title}>

--- a/src/components/fb/CreateFidelityBond.tsx
+++ b/src/components/fb/CreateFidelityBond.tsx
@@ -254,8 +254,8 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
         return (
           <SelectDate
             description={t('earn.fidelity_bond.select_date.description')}
-            selectableYearsRange={yearsRange}
-            onDateSelected={(date) => setLockDate(date)}
+            yearsRange={yearsRange}
+            onChange={(date) => setLockDate(date)}
           />
         )
       case steps.selectJar:

--- a/src/components/fb/FidelityBondSteps.tsx
+++ b/src/components/fb/FidelityBondSteps.tsx
@@ -60,7 +60,7 @@ interface ReviewInputsProps {
   jar: JarIndex
   utxos: Array<Utxo>
   selectedUtxos: Array<Utxo>
-  timelockedAddress: string
+  timelockedAddress: Api.BitcoinAddress
 }
 
 interface CreatedFidelityBondProps {

--- a/src/components/fb/FidelityBondSteps.tsx
+++ b/src/components/fb/FidelityBondSteps.tsx
@@ -10,17 +10,15 @@ import { SelectableJar, jarInitial, jarFillLevel } from '../jars/Jar'
 import Sprite from '../Sprite'
 import Balance from '../Balance'
 import { CopyButton } from '../CopyButton'
-import LockdateForm from './LockdateForm'
+import LockdateForm, { LockdateFormProps } from './LockdateForm'
 import * as fb from './utils'
 import styles from './FidelityBondSteps.module.css'
 
 const cx = classnamesBind.bind(styles)
 
-interface SelectDateProps {
+type SelectDateProps = {
   description: string
-  selectableYearsRange: fb.YearsRange
-  onDateSelected: (lockdate: Api.Lockdate | null) => void
-}
+} & LockdateFormProps
 
 interface SelectJarProps {
   description: string
@@ -70,11 +68,11 @@ interface CreatedFidelityBondProps {
   frozenUtxos: Array<Utxo>
 }
 
-const SelectDate = ({ description, selectableYearsRange, onDateSelected }: SelectDateProps) => {
+const SelectDate = ({ description, yearsRange, disabled, onChange }: SelectDateProps) => {
   return (
     <div className="d-flex flex-column gap-4">
       <div className={styles.stepDescription}>{description}</div>
-      <LockdateForm onChange={(date) => onDateSelected(date)} yearsRange={selectableYearsRange} />
+      <LockdateForm yearsRange={yearsRange} onChange={onChange} disabled={disabled} />
     </div>
   )
 }

--- a/src/components/fb/LockdateForm.tsx
+++ b/src/components/fb/LockdateForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import * as rb from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 
@@ -58,13 +58,14 @@ export const _selectableYears = (yearsRange: fb.YearsRange, now = new Date()): n
     .map((_, index) => index + now.getUTCFullYear() + extra)
 }
 
-interface LockdateFormProps {
+export interface LockdateFormProps {
   onChange: (lockdate: Api.Lockdate | null) => void
   yearsRange?: fb.YearsRange
   now?: Date
+  disabled?: boolean
 }
 
-const LockdateForm = ({ onChange, now, yearsRange }: LockdateFormProps) => {
+const LockdateForm = ({ onChange, now, yearsRange, disabled }: LockdateFormProps) => {
   const { i18n } = useTranslation()
   const _now = useMemo<Date>(() => now || new Date(), [now])
   const _yearsRange = useMemo<fb.YearsRange>(() => yearsRange || fb.DEFAULT_TIMELOCK_YEARS_RANGE, [yearsRange])
@@ -115,6 +116,7 @@ const LockdateForm = ({ onChange, now, yearsRange }: LockdateFormProps) => {
               onChange={(e) => setLockdateYear(parseInt(e.target.value, 10))}
               required
               isInvalid={!isLockdateYearValid}
+              disabled={disabled}
               data-testid="select-lockdate-year"
             >
               {selectableYears.map((year) => (
@@ -135,6 +137,7 @@ const LockdateForm = ({ onChange, now, yearsRange }: LockdateFormProps) => {
               onChange={(e) => setLockdateMonth(parseInt(e.target.value, 10) as Month)}
               required
               isInvalid={!isLockdateMonthValid}
+              disabled={disabled}
               data-testid="select-lockdate-month"
             >
               {selectableMonths.map((it) => (

--- a/src/components/fb/SpendFidelityBondModal.tsx
+++ b/src/components/fb/SpendFidelityBondModal.tsx
@@ -484,14 +484,16 @@ const RenewFidelityBondModal = ({
         </rb.Modal.Body>
         <rb.Modal.Footer>
           <div className="w-100 d-flex gap-4 justify-content-center align-items-center">
-            <rb.Button
-              variant="light"
-              disabled={isLoading}
-              onClick={() => onClose({ txInfo, mustReload: parentMustReload })}
-              className="flex-1 d-flex justify-content-center align-items-center"
-            >
-              {t('global.cancel')}
-            </rb.Button>
+            {!txInfo && (
+              <rb.Button
+                variant="light"
+                disabled={isLoading}
+                onClick={() => onClose({ txInfo, mustReload: parentMustReload })}
+                className="flex-1 d-flex justify-content-center align-items-center"
+              >
+                {t('global.cancel')}
+              </rb.Button>
+            )}
             <rb.Button
               ref={submitButtonRef}
               variant="dark"
@@ -506,6 +508,7 @@ const RenewFidelityBondModal = ({
       </rb.Modal>
       {lockDate && fidelityBond && timelockedAddress !== undefined && (
         <PaymentConfirmModal
+          size="lg"
           isShown={showConfirmSendModal}
           title={t('earn.fidelity_bond.renew.confirm_send_modal.title')}
           onCancel={() => {

--- a/src/components/fb/SpendFidelityBondModal.tsx
+++ b/src/components/fb/SpendFidelityBondModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as rb from 'react-bootstrap'
 import { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
@@ -7,12 +7,14 @@ import * as Api from '../../libs/JmWalletApi'
 import * as fb from './utils'
 import Alert from '../Alert'
 import Sprite from '../Sprite'
-import { SelectJar } from './FidelityBondSteps'
+import { SelectDate, SelectJar } from './FidelityBondSteps'
 import { PaymentConfirmModal } from '../PaymentConfirmModal'
 import { jarInitial } from '../jars/Jar'
 import { useFeeConfigValues } from '../../hooks/Fees'
 
 import styles from './SpendFidelityBondModal.module.css'
+import { isDebugFeatureEnabled } from '../../constants/debugFeatures'
+import { CopyButton } from '../CopyButton'
 
 type Input = {
   outpoint: Api.UtxoId
@@ -138,6 +140,394 @@ const spendUtxosWithDirectSend = async (
   }
 }
 
+type SendFidelityBondToAddressProps = {
+  fidelityBond: Utxo | undefined
+  destination: Api.BitcoinAddress
+  wallet: CurrentWallet
+  t: TFunction
+}
+
+const sendFidelityBondToAddress = async ({ fidelityBond, destination, wallet, t }: SendFidelityBondToAddressProps) => {
+  if (!fidelityBond || fb.utxo.isLocked(fidelityBond)) {
+    throw new Error(t('earn.fidelity_bond.move.error_fidelity_bond_still_locked'))
+  }
+
+  const abortCtrl = new AbortController()
+  const requestContext = { ...wallet, signal: abortCtrl.signal }
+
+  return await spendUtxosWithDirectSend(
+    requestContext,
+    {
+      destination,
+      sourceJarIndex: fidelityBond.mixdepth,
+      utxos: [fidelityBond],
+    },
+    {
+      onReloadWalletError: (res) =>
+        Api.Helper.throwResolved(res, errorResolver(t, 'global.errors.error_reloading_wallet_failed')),
+      onFreezeUtxosError: (res) =>
+        Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_freezing_utxos')),
+      onUnfreezeUtxosError: (res) =>
+        Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_unfreezing_fidelity_bond')),
+      onSendError: (res) =>
+        Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_spending_fidelity_bond')),
+    },
+  )
+}
+
+type SendFidelityBondToJarProps = {
+  fidelityBond: Utxo | undefined
+  targetJarIndex: JarIndex
+  wallet: CurrentWallet
+  t: TFunction
+}
+
+const sendFidelityBondToJar = async ({ fidelityBond, targetJarIndex, wallet, t }: SendFidelityBondToJarProps) => {
+  if (!fidelityBond || fb.utxo.isLocked(fidelityBond)) {
+    throw new Error(t('earn.fidelity_bond.move.error_fidelity_bond_still_locked'))
+  }
+
+  const abortCtrl = new AbortController()
+  const requestContext = { ...wallet, signal: abortCtrl.signal }
+
+  const destination = await Api.getAddressNew({ ...requestContext, mixdepth: targetJarIndex })
+    .then((res) => {
+      if (res.ok) return res.json()
+      return Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_loading_address'))
+    })
+    .then((data) => data.address as Api.BitcoinAddress)
+
+  return await sendFidelityBondToAddress({ destination, fidelityBond, wallet, t })
+}
+
+const Done = ({ text }: { text: string }) => {
+  return (
+    <div className="d-flex flex-column justify-content-center align-items-center gap-1">
+      <div className={styles.successCheckmark}>
+        <Sprite symbol="checkmark" width="24" height="30" />
+      </div>
+      <div className={styles.successSummaryTitle}>{text}</div>
+    </div>
+  )
+}
+
+type RenewFidelityBondModalProps = {
+  fidelityBondId: Api.UtxoId
+  wallet: CurrentWallet
+  walletInfo: WalletInfo
+  onClose: (result: Result) => void
+} & Omit<rb.ModalProps, 'onHide'>
+
+const RenewFidelityBondModal = ({
+  fidelityBondId,
+  wallet,
+  walletInfo,
+  onClose,
+  ...modalProps
+}: RenewFidelityBondModalProps) => {
+  const { t } = useTranslation()
+  const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
+  const feeConfigValues = useFeeConfigValues()[0]
+
+  const [alert, setAlert] = useState<SimpleAlert>()
+
+  const [txInfo, setTxInfo] = useState<TxInfo>()
+  const [waitForUtxosToBeSpent, setWaitForUtxosToBeSpent] = useState<Api.UtxoId[]>([])
+
+  const [lockDate, setLockDate] = useState<Api.Lockdate>()
+  const [timelockedAddress, setTimelockedAddress] = useState<Api.BitcoinAddress>()
+
+  const [parentMustReload, setParentMustReload] = useState(false)
+  const [isSending, setIsSending] = useState(false)
+  const [isLoadingTimelockedAddress, setIsLoadingTimelockAddress] = useState(false)
+  const isLoading = useMemo(() => isSending || waitForUtxosToBeSpent.length > 0, [isSending, waitForUtxosToBeSpent])
+
+  const [showConfirmSendModal, setShowConfirmSendModal] = useState(false)
+
+  const submitButtonRef = useRef<HTMLButtonElement>(null)
+
+  const fidelityBond = useMemo(() => {
+    return walletInfo.data.utxos.utxos.find((utxo) => utxo.utxo === fidelityBondId)
+  }, [walletInfo, fidelityBondId])
+
+  // This callback is responsible for updating the loading state when the
+  // the payment is made. The wallet needs some time after a tx is sent
+  // to reflect the changes internally. All outputs in
+  // `waitForUtxosToBeSpent` must have been removed from the wallet
+  // for the payment to be considered done.
+  useEffect(() => {
+    if (waitForUtxosToBeSpent.length === 0) return
+
+    const abortCtrl = new AbortController()
+
+    // Delaying the poll requests gives the wallet some time to synchronize
+    // the utxo set and reduces amount of http requests
+    const initialDelayInMs = 250
+    const timer = setTimeout(() => {
+      if (abortCtrl.signal.aborted) return
+
+      reloadCurrentWalletInfo
+        .reloadUtxos({ signal: abortCtrl.signal })
+        .then((res) => {
+          if (abortCtrl.signal.aborted) return
+
+          const outputs = res.utxos.map((it) => it.utxo)
+          const utxosStillPresent = waitForUtxosToBeSpent.filter((it) => outputs.includes(it))
+          setWaitForUtxosToBeSpent([...utxosStillPresent])
+        })
+        .catch((err) => {
+          if (abortCtrl.signal.aborted) return
+
+          // Stop waiting for wallet synchronization on errors, but inform
+          // the user that loading the wallet info failed
+          setWaitForUtxosToBeSpent([])
+
+          const message = t('global.errors.error_reloading_wallet_failed', {
+            reason: err.message || t('global.errors.reason_unknown'),
+          })
+          setAlert({ variant: 'danger', message })
+        })
+    }, initialDelayInMs)
+
+    return () => {
+      abortCtrl.abort()
+      clearTimeout(timer)
+    }
+  }, [waitForUtxosToBeSpent, reloadCurrentWalletInfo, t])
+
+  const yearsRange = useMemo(() => {
+    if (isDebugFeatureEnabled('allowCreatingExpiredFidelityBond')) {
+      return fb.toYearsRange(-1, fb.DEFAULT_MAX_TIMELOCK_YEARS)
+    }
+    return fb.toYearsRange(0, fb.DEFAULT_MAX_TIMELOCK_YEARS)
+  }, [])
+
+  const loadTimeLockedAddress = useCallback(
+    (lockdate: Api.Lockdate, signal: AbortSignal) => {
+      setIsLoadingTimelockAddress(true)
+      setAlert(undefined)
+
+      return (
+        Api.getAddressTimelockNew({
+          ...wallet,
+          lockdate,
+          signal,
+        })
+          .then((res) => {
+            return res.ok ? res.json() : Api.Helper.throwError(res, t('earn.fidelity_bond.error_loading_address'))
+          })
+          // show the loader a little longer to avoid flickering
+          .then((result) => new Promise((r) => setTimeout(() => r(result), 221)))
+          .then((data: any) => {
+            if (signal.aborted) return
+            setTimelockedAddress(data.address)
+            setIsLoadingTimelockAddress(false)
+          })
+          .catch((err) => {
+            if (signal.aborted) return
+            setAlert({ variant: 'danger', message: err.message })
+            setIsLoadingTimelockAddress(false)
+          })
+      )
+    },
+    [wallet, t],
+  )
+
+  useEffect(() => {
+    if (!lockDate) return
+    const abortCtrl = new AbortController()
+    loadTimeLockedAddress(lockDate, abortCtrl.signal)
+    return () => abortCtrl.abort()
+  }, [loadTimeLockedAddress, lockDate])
+
+  const primaryButtonContent = useMemo(() => {
+    if (isSending) {
+      return (
+        <>
+          <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+          {t('earn.fidelity_bond.renew.text_sending')}
+        </>
+      )
+    } else if (txInfo) {
+      return <>{t('global.done')}</>
+    }
+    return <>{t('earn.fidelity_bond.renew.text_button_submit')}</>
+  }, [isSending, txInfo, t])
+
+  const onSelectedDateChanged = useCallback((date) => {
+    setTimelockedAddress(undefined)
+    setLockDate(date ?? undefined)
+  }, [])
+
+  const modalBodyContent = useMemo(() => {
+    if (isLoading) {
+      return (
+        <div className="d-flex justify-content-center align-items-center my-5">
+          <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="me-2" />
+          <div>{t(`earn.fidelity_bond.renew.${isSending ? 'text_sending' : 'text_loading'}`)}</div>
+        </div>
+      )
+    }
+
+    if (txInfo) {
+      return (
+        <div className="my-4">
+          <Done text={t('earn.fidelity_bond.renew.success_text')} />
+        </div>
+      )
+    }
+
+    return (
+      <div className="my-2 d-flex flex-column gap-4">
+        <SelectDate
+          description={t('earn.fidelity_bond.select_date.description')}
+          yearsRange={yearsRange}
+          disabled={isLoading || isLoadingTimelockedAddress}
+          onChange={onSelectedDateChanged}
+        />
+        {timelockedAddress && (
+          <>
+            <div className="d-flex flex-column gap-3">
+              <div className="d-flex align-items-center gap-2">
+                <CopyButton
+                  text={<Sprite symbol="copy" width="18" height="18" />}
+                  successText={<Sprite symbol="checkmark" width="18" height="18" />}
+                  value={timelockedAddress}
+                />
+                <div className="d-flex flex-column">
+                  <div>{t('earn.fidelity_bond.review_inputs.label_address')}</div>
+                  <div>
+                    <code>{timelockedAddress}</code>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    )
+  }, [
+    isLoading,
+    isSending,
+    yearsRange,
+    timelockedAddress,
+    isLoadingTimelockedAddress,
+    txInfo,
+    onSelectedDateChanged,
+    t,
+  ])
+
+  const onPrimaryButtonClicked = async () => {
+    if (isLoading) return
+    if (isLoadingTimelockedAddress) return
+    if (timelockedAddress === undefined) return
+    if (waitForUtxosToBeSpent.length > 0) return
+
+    if (txInfo) {
+      onClose({ txInfo, mustReload: parentMustReload })
+    } else if (!showConfirmSendModal) {
+      setShowConfirmSendModal(true)
+    } else {
+      if (!fidelityBond || fb.utxo.isLocked(fidelityBond)) {
+        throw new Error(t('earn.fidelity_bond.move.error_fidelity_bond_still_locked'))
+      }
+      setShowConfirmSendModal(false)
+      setParentMustReload(true)
+
+      setAlert(undefined)
+      setIsSending(true)
+
+      return sendFidelityBondToAddress({
+        destination: timelockedAddress,
+        fidelityBond,
+        wallet,
+        t,
+      })
+        .then((data) => data.txinfo as TxInfo)
+        .then((txinfo) => {
+          setTxInfo(txinfo)
+
+          setWaitForUtxosToBeSpent(txinfo.inputs.map((it) => it.outpoint))
+
+          setIsSending(false)
+        })
+        .catch((e) => {
+          setIsSending(false)
+
+          const message = e instanceof Error ? e.message : t('global.errors.reason_unknown')
+          setAlert({ variant: 'danger', message })
+        })
+    }
+  }
+
+  return (
+    <>
+      <rb.Modal
+        animation={true}
+        backdrop="static"
+        centered={true}
+        keyboard={false}
+        size="lg"
+        {...modalProps}
+        onHide={() => onClose({ txInfo, mustReload: parentMustReload })}
+        dialogClassName={showConfirmSendModal ? 'invisible' : ''}
+      >
+        <rb.Modal.Header closeButton>
+          <rb.Modal.Title>{t('earn.fidelity_bond.renew.title')}</rb.Modal.Title>
+        </rb.Modal.Header>
+        <rb.Modal.Body>
+          {alert && <Alert {...alert} className="mt-0" onClose={() => setAlert(undefined)} />}
+          {modalBodyContent}
+        </rb.Modal.Body>
+        <rb.Modal.Footer>
+          <div className="w-100 d-flex gap-4 justify-content-center align-items-center">
+            <rb.Button
+              variant="light"
+              disabled={isLoading}
+              onClick={() => onClose({ txInfo, mustReload: parentMustReload })}
+              className="flex-1 d-flex justify-content-center align-items-center"
+            >
+              {t('global.cancel')}
+            </rb.Button>
+            <rb.Button
+              ref={submitButtonRef}
+              variant="dark"
+              className="flex-1 d-flex justify-content-center align-items-center"
+              disabled={isLoading || timelockedAddress === undefined}
+              onClick={onPrimaryButtonClicked}
+            >
+              {primaryButtonContent}
+            </rb.Button>
+          </div>
+        </rb.Modal.Footer>
+      </rb.Modal>
+      {showConfirmSendModal && fidelityBond && timelockedAddress !== undefined && (
+        <PaymentConfirmModal
+          isShown={true}
+          title={t(`earn.fidelity_bond.renew.${timelockedAddress ? 'confirm_send_modal.title' : 'title'}`)}
+          onCancel={() => {
+            setShowConfirmSendModal(false)
+            onClose({ txInfo, mustReload: parentMustReload })
+          }}
+          onConfirm={() => {
+            submitButtonRef.current?.click()
+          }}
+          data={{
+            sourceJarIndex: undefined, // dont show a source jar - might be confusing in this context
+            destination: timelockedAddress,
+            amount: fidelityBond.value,
+            isSweep: true,
+            isCoinjoin: false, // not sent as collaborative transaction
+            numCollaborators: undefined,
+            feeConfigValues,
+            showPrivacyInfo: false,
+          }}
+        />
+      )}
+    </>
+  )
+}
+
 type SpendFidelityBondModalProps = {
   fidelityBondId: Api.UtxoId
   wallet: CurrentWallet
@@ -240,7 +630,12 @@ const SpendFidelityBondModal = ({
       setAlert(undefined)
       setIsSending(true)
 
-      sendFidelityBondToJar(fidelityBond, selectedDestinationJarIndex)
+      sendFidelityBondToJar({
+        fidelityBond,
+        targetJarIndex: selectedDestinationJarIndex,
+        wallet,
+        t,
+      })
         .then((data) => data.txinfo as TxInfo)
         .then((txinfo) => {
           setTxInfo(txinfo)
@@ -258,42 +653,7 @@ const SpendFidelityBondModal = ({
     }
   }
 
-  const sendFidelityBondToJar = async (fidelityBond: Utxo | undefined, targetJarIndex: JarIndex) => {
-    if (!fidelityBond || fb.utxo.isLocked(fidelityBond)) {
-      throw new Error(t('earn.fidelity_bond.move.error_fidelity_bond_still_locked'))
-    }
-
-    const abortCtrl = new AbortController()
-    const requestContext = { ...wallet, signal: abortCtrl.signal }
-
-    const destination = await Api.getAddressNew({ ...requestContext, mixdepth: targetJarIndex })
-      .then((res) => {
-        if (res.ok) return res.json()
-        return Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_loading_address'))
-      })
-      .then((data) => data.address as Api.BitcoinAddress)
-
-    return await spendUtxosWithDirectSend(
-      requestContext,
-      {
-        destination,
-        sourceJarIndex: fidelityBond.mixdepth,
-        utxos: [fidelityBond],
-      },
-      {
-        onReloadWalletError: (res) =>
-          Api.Helper.throwResolved(res, errorResolver(t, 'global.errors.error_reloading_wallet_failed')),
-        onFreezeUtxosError: (res) =>
-          Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_freezing_utxos')),
-        onUnfreezeUtxosError: (res) =>
-          Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_unfreezing_fidelity_bond')),
-        onSendError: (res) =>
-          Api.Helper.throwResolved(res, errorResolver(t, 'earn.fidelity_bond.move.error_spending_fidelity_bond')),
-      },
-    )
-  }
-
-  const PrimaryButtonContent = () => {
+  const primaryButtonContent = useMemo(() => {
     if (isSending) {
       return (
         <>
@@ -305,18 +665,7 @@ const SpendFidelityBondModal = ({
       return <>{t('earn.fidelity_bond.move.text_button_done')}</>
     }
     return <>{t('earn.fidelity_bond.move.text_button_submit')}</>
-  }
-
-  const Done = ({ text }: { text: string }) => {
-    return (
-      <div className="d-flex flex-column justify-content-center align-items-center gap-1">
-        <div className={styles.successCheckmark}>
-          <Sprite symbol="checkmark" width="24" height="30" />
-        </div>
-        <div className={styles.successSummaryTitle}>{text}</div>
-      </div>
-    )
-  }
+  }, [isSending, txInfo, t])
 
   const ModalBodyContent = () => {
     if (isLoading) {
@@ -384,7 +733,7 @@ const SpendFidelityBondModal = ({
               disabled={isLoading || selectedDestinationJarIndex === undefined}
               onClick={onPrimaryButtonClicked}
             >
-              {PrimaryButtonContent()}
+              {primaryButtonContent}
             </rb.Button>
           </div>
         </rb.Modal.Footer>
@@ -421,4 +770,4 @@ const SpendFidelityBondModal = ({
   )
 }
 
-export { SpendFidelityBondModal }
+export { RenewFidelityBondModal, SpendFidelityBondModal }

--- a/src/components/fb/SpendFidelityBondModal.tsx
+++ b/src/components/fb/SpendFidelityBondModal.tsx
@@ -15,6 +15,7 @@ import { useFeeConfigValues } from '../../hooks/Fees'
 import styles from './SpendFidelityBondModal.module.css'
 import { isDebugFeatureEnabled } from '../../constants/debugFeatures'
 import { CopyButton } from '../CopyButton'
+import { LockInfoAlert } from './CreateFidelityBond'
 
 type Input = {
   outpoint: Api.UtxoId
@@ -501,9 +502,9 @@ const RenewFidelityBondModal = ({
           </div>
         </rb.Modal.Footer>
       </rb.Modal>
-      {showConfirmSendModal && fidelityBond && timelockedAddress !== undefined && (
+      {lockDate && fidelityBond && timelockedAddress !== undefined && (
         <PaymentConfirmModal
-          isShown={true}
+          isShown={showConfirmSendModal}
           title={t(`earn.fidelity_bond.renew.${timelockedAddress ? 'confirm_send_modal.title' : 'title'}`)}
           onCancel={() => {
             setShowConfirmSendModal(false)
@@ -522,7 +523,9 @@ const RenewFidelityBondModal = ({
             feeConfigValues,
             showPrivacyInfo: false,
           }}
-        />
+        >
+          <LockInfoAlert className="text-start mt-4" lockDate={lockDate} />
+        </PaymentConfirmModal>
       )}
     </>
   )

--- a/src/components/fb/SpendFidelityBondModal.tsx
+++ b/src/components/fb/SpendFidelityBondModal.tsx
@@ -392,7 +392,7 @@ const RenewFidelityBondModal = ({
                   successText={<Sprite symbol="checkmark" width="18" height="18" />}
                   value={timelockedAddress || ''}
                 />
-                <div className="d-flex flex-column flex-grow-1">
+                <div className="d-flex flex-column flex-grow-1 overflow-scroll">
                   <div>{t('earn.fidelity_bond.review_inputs.label_address')}</div>
                   {!isLoading && !isLoadingTimelockedAddress ? (
                     <div className="font-monospace text-small pt-1">{timelockedAddress || '...'}</div>

--- a/src/hooks/WaitForUtxosToBeSpent.ts
+++ b/src/hooks/WaitForUtxosToBeSpent.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react'
+import { useReloadCurrentWalletInfo } from '../context/WalletContext'
+import { UtxoId } from '../libs/JmWalletApi'
+
+// Delaying the poll requests gives the wallet some time to synchronize
+// the utxo set and reduces amount of http requests
+const DEFAUL_DELAY: Milliseconds = 1_000
+
+interface WaitForUtxosToBeSpentArgs {
+  waitForUtxosToBeSpent: UtxoId[]
+  setWaitForUtxosToBeSpent: (utxos: UtxoId[]) => void
+  onError: (error: any) => void
+  delay?: Milliseconds
+  resetOnErrors?: boolean
+}
+
+// This callback is responsible for updating the utxo array when a
+// payment is made. The wallet needs some time after a tx is sent
+// to reflect the changes internally. All outputs given in
+// `waitForUtxosToBeSpent` must have been removed from the wallet
+// for a payment to be considered done.
+export const useWaitForUtxosToBeSpent = ({
+  waitForUtxosToBeSpent,
+  setWaitForUtxosToBeSpent,
+  onError,
+  delay = DEFAUL_DELAY,
+  resetOnErrors = true,
+}: WaitForUtxosToBeSpentArgs): void => {
+  const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
+  return useEffect(() => {
+    if (waitForUtxosToBeSpent.length === 0) return
+
+    const abortCtrl = new AbortController()
+
+    const timer = setTimeout(() => {
+      if (abortCtrl.signal.aborted) return
+
+      reloadCurrentWalletInfo
+        .reloadUtxos({ signal: abortCtrl.signal })
+        .then((res) => {
+          if (abortCtrl.signal.aborted) return
+
+          const outputs = res.utxos.map((it) => it.utxo)
+          const utxosStillPresent = waitForUtxosToBeSpent.filter((it) => outputs.includes(it))
+
+          // updating the utxos array will trigger a recursive call
+          setWaitForUtxosToBeSpent([...utxosStillPresent])
+        })
+        .catch((error: any) => {
+          if (abortCtrl.signal.aborted) return
+          if (resetOnErrors) {
+            // Stop waiting for wallet synchronization on errors
+            setWaitForUtxosToBeSpent([])
+          }
+          onError(error)
+        })
+    }, delay)
+
+    return () => {
+      abortCtrl.abort()
+      clearTimeout(timer)
+    }
+  }, [waitForUtxosToBeSpent, setWaitForUtxosToBeSpent, resetOnErrors, onError, delay, reloadCurrentWalletInfo])
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -515,7 +515,8 @@
         "label_locked_until": "Locked until",
         "label_expired_on": "Expired on",
         "label_address": "Timelocked address",
-        "button_spend": "Unlock Funds"
+        "button_spend": "Unlock Funds",
+        "button_renew": "Renew Bond"
       },
       "move": {
         "title": "Unlock Funds",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -8,6 +8,7 @@
     "close": "Close",
     "abort": "Abort",
     "cancel": "Cancel",
+    "done": "Done",
     "table": {
       "pagination": {
         "items_per_page": {
@@ -517,6 +518,17 @@
         "label_address": "Timelocked address",
         "button_spend": "Unlock Funds",
         "button_renew": "Renew Bond"
+      },
+      "renew": {
+        "title": "Renew Bond",
+        "text_loading": "Loading...",
+        "text_sending": "Renewing...",
+        "text_button_submit": "Renew Bond",
+        "success_text": "Fidelity Bond renewed successfully!",
+        "error_renewing_fidelity_bond": "Error while renewing expired fidelity bond.",
+        "confirm_send_modal": {
+          "title": "Confirm renewing expired Fidelity Bond"
+        }
       },
       "move": {
         "title": "Unlock Funds",

--- a/src/index.css
+++ b/src/index.css
@@ -532,6 +532,10 @@ h2 {
   color: inherit;
 }
 
+.modal {
+  --bs-modal-width: 800px;
+}
+
 .modal-header {
   background-color: var(--bs-gray-800);
   color: var(--bs-white);


### PR DESCRIPTION
Resolves #610 

Adds the ability to renew an expired fidelity bond.

This will be done with a direct-send creating a "single input, single output transaction" (this might not be what more advanced users want - e.g. CPFP is not possible afterwards). Feedback welcome.

In addition, the "Create FB" confirm dialog will now display the fee settings for the user to review before actually creating the bond.

## :camera_flash: 

### Expired fidelity bond (Before/After)
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/273686c7-5429-49e0-a6d9-046dbca3fe7f" width=300 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/ce42ea24-bb35-442a-9cb8-95615811e752" width=300 />


### Renew fidelity bond flow

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/80cf1d30-3f9a-41e0-bbc1-8a981942a4d8" width=300 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/5b4faf8b-ac2c-42e0-8f73-a6d5f6cd7b10" width=300 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/1fd9c6e8-6f55-4225-a408-861bd4190b3a" width=300 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/c32b734a-d825-415b-967e-3e9fea649584" width=300 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/8c66933d-6132-48e0-8f1e-38a36fd51787" width=300 />

#### On Error
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/e6cc0724-29cd-4872-9c78-e97899bd04c8" width=300 />

### "Create fidelity bond" Confirm Modal (Before/After)

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/5a67ea7a-3add-4972-aa13-0a26c667bb6b" width=300 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/04a3314d-720b-4fb4-ac96-6d7d0253a89a" width=300 />


## How to test

- Create an expired fidelity bond (only possible in dev mode with `npm run dev:start`)
- Renew expired fidelity bond (also, possibly with lockdate in the past)
- Rinse and repeat!