### PR TITLE
chore: remove create wallet button from settings page

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -217,23 +217,6 @@ export default function Settings({ wallet, stopWallet }: SettingsProps) {
             <Sprite symbol="wallet" width="24" height="24" />
             {t('settings.button_switch_wallet')}
           </Link>
-          <rb.Button
-            variant="outline-dark"
-            className={styles['settings-btn']}
-            onClick={() => lockWallet({ force: false, navigateTo: routes.createWallet })}
-          >
-            {lockingWallet ? (
-              <>
-                <rb.Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" className="mx-1" />
-                {t('settings.button_locking_wallet')}
-              </>
-            ) : (
-              <>
-                <Sprite symbol="plus" width="24" height="24" />
-                {t('settings.button_create_wallet')}
-              </>
-            )}
-          </rb.Button>
 
           {serviceInfo && isFeatureEnabled('rescanChain', serviceInfo) && isDebugFeatureEnabled('rescanChainPage') && (
             <Link

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -214,7 +214,6 @@
     "button_lock_wallet": "Lock wallet",
     "button_locking_wallet": "Locking...",
     "button_switch_wallet": "Switch wallet",
-    "button_create_wallet": "Create new wallet",
     "error_loading_seed_failed": "Could not retrieve seed phrase.",
     "seed_modal_info_text": "Please write down your seed phrase and password! Without this information you will not be able to access and recover your wallet!",
     "documentation": "Documentation",


### PR DESCRIPTION
This is just a proposal, feel free to close it, if you think it is not a good idea.

I do not quite  see the use of a "create wallet" button from the settings page.
A wallet can already be created from the main view when no wallet is active.
This PR will remove the button from the settings page.

What do you think?

##  :camera_flash: Before/After

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/8ca4ca66-c7c5-4c52-aa6d-3738c11d17ad" width=250 /> 
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/198f15ca-347d-470a-a26d-3b2fb2ac9725" width=250 />
