### PR TITLE
fix: use orderbook.json instead of parsing html table

### DIFF
--- a/src/components/Earn.tsx
+++ b/src/components/Earn.tsx
@@ -2,10 +2,11 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Formik, FormikErrors } from 'formik'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
+import { TFunction } from 'i18next'
 import { useSettings } from '../context/SettingsContext'
 import { CurrentWallet, useCurrentWalletInfo, useReloadCurrentWalletInfo } from '../context/WalletContext'
 import { useServiceInfo, useReloadServiceInfo, Offer } from '../context/ServiceInfoContext'
-import { factorToPercentage, isValidNumber, percentageToFactor } from '../utils'
+import { factorToPercentage, isAbsoluteOffer, isRelativeOffer, isValidNumber, percentageToFactor } from '../utils'
 import * as Api from '../libs/JmWalletApi'
 import * as fb from './fb/utils'
 import Sprite from './Sprite'
@@ -19,7 +20,6 @@ import { OrderbookOverlay } from './Orderbook'
 import Balance from './Balance'
 import styles from './Earn.module.css'
 import Accordion from './Accordion'
-import { TFunction } from 'i18next'
 
 // In order to prevent state mismatch, the 'maker stop' response is delayed shortly.
 // Even though the API response suggests that the maker has started or stopped immediately, it seems that this is not always the case.
@@ -31,14 +31,8 @@ const MAKER_STOP_RESPONSE_DELAY_MS = 2_000
 // that the UTXO corresponding to the fidelity bond is correctly marked as such.
 const RELOAD_FIDELITY_BONDS_DELAY_MS = 2_000
 
-const OFFERTYPE_REL = 'sw0reloffer'
-const OFFERTYPE_ABS = 'sw0absoffer'
-
-// can be any of ['sw0reloffer', 'swreloffer', 'reloffer']
-const isRelativeOffer = (offertype: string) => offertype.includes('reloffer')
-
-// can be any of ['sw0absoffer', 'swabsoffer', 'absoffer']
-const isAbsoluteOffer = (offertype: string) => offertype.includes('absoffer')
+const OFFERTYPE_REL: Api.OfferType = 'sw0reloffer'
+const OFFERTYPE_ABS: Api.OfferType = 'sw0absoffer'
 
 const FORM_INPUT_LOCAL_STORAGE_KEYS = {
   offertype: 'jm-offertype',

--- a/src/components/Orderbook.tsx
+++ b/src/components/Orderbook.tsx
@@ -19,7 +19,7 @@ import styles from './Orderbook.module.css'
 
 const TABLE_THEME = {
   Table: `
-    --data-table-library_grid-template-columns: 1fr 5rem 1fr 1fr 2fr 2fr 2fr 2fr;
+    --data-table-library_grid-template-columns: 1fr 5rem 1fr 2fr 2fr 2fr 2fr;
     font-size: 0.9rem;
   `,
   BaseCell: `
@@ -203,6 +203,7 @@ const OrderbookTable = ({ data }: OrderbookTableProps) => {
         [SORT_KEYS.maximumSize]: (array) => array.sort((a, b) => a.maximumSize - b.maximumSize),
         [SORT_KEYS.minerFeeContribution]: (array) =>
           array.sort((a, b) => a.minerFeeContribution - b.minerFeeContribution),
+
         [SORT_KEYS.counterparty]: (array) =>
           array.sort((a, b) => {
             const val = a.counterparty.localeCompare(b.counterparty)
@@ -239,7 +240,7 @@ const OrderbookTable = ({ data }: OrderbookTableProps) => {
                 <HeaderCellSort sortKey={SORT_KEYS.maximumSize}>
                   {t('orderbook.table.heading_maximum_size')}
                 </HeaderCellSort>
-                <HeaderCellSort sortKey={SORT_KEYS.minerFeeContribution}>
+                <HeaderCellSort hide={true} sortKey={SORT_KEYS.minerFeeContribution}>
                   {t('orderbook.table.heading_miner_fee_contribution')}
                 </HeaderCellSort>
                 <HeaderCellSort sortKey={SORT_KEYS.bondValue}>{t('orderbook.table.heading_bond_value')}</HeaderCellSort>
@@ -250,7 +251,7 @@ const OrderbookTable = ({ data }: OrderbookTableProps) => {
                 const order = asOrderTableEntry(item)
                 return (
                   <Row key={item.id} item={item} className={item._highlighted ? styles.highlighted : ''}>
-                    <Cell className="slashed-zeroes">{order.counterparty}</Cell>
+                    <Cell className="font-monospace">{order.counterparty}</Cell>
                     <Cell>{order.orderId}</Cell>
                     <Cell>{renderOrderType(order.type)}</Cell>
                     <Cell>{renderOrderFee(order.fee.displayValue, settings)}</Cell>
@@ -260,7 +261,7 @@ const OrderbookTable = ({ data }: OrderbookTableProps) => {
                     <Cell>
                       <Balance valueString={order.maximumSize} convertToUnit={settings.unit} showBalance={true} />
                     </Cell>
-                    <Cell>
+                    <Cell hide={true}>
                       <Balance
                         valueString={order.minerFeeContribution}
                         convertToUnit={settings.unit}
@@ -476,7 +477,7 @@ export function OrderbookOverlay({ nickname, show, onHide }: OrderbookOverlayPro
           setOffers(orderbook.offers || [])
 
           if (isDevMode()) {
-            console.table(offers)
+            console.table(orderbook.offers)
           }
         })
         .catch((e) => {

--- a/src/components/Orderbook.tsx
+++ b/src/components/Orderbook.tsx
@@ -245,7 +245,7 @@ const OrderbookTable = ({ data }: OrderbookTableProps) => {
                 const order = asOrderTableEntry(item)
                 return (
                   <Row key={item.id} item={item} className={item._highlighted ? styles.highlighted : ''}>
-                    <Cell>{order.counterparty}</Cell>
+                    <Cell className="slashed-zeroes">{order.counterparty}</Cell>
                     <Cell>{order.orderId}</Cell>
                     <Cell>{renderOrderType(order.type)}</Cell>
                     <Cell>{renderOrderFee(order.fee.displayValue, settings)}</Cell>
@@ -262,7 +262,7 @@ const OrderbookTable = ({ data }: OrderbookTableProps) => {
                         showBalance={true}
                       />
                     </Cell>
-                    <Cell>{order.bondValue}</Cell>
+                    <Cell className="font-monospace">{order.bondValue}</Cell>
                   </Row>
                 )
               })}

--- a/src/libs/JmObwatchApi.ts
+++ b/src/libs/JmObwatchApi.ts
@@ -10,7 +10,11 @@ export interface Offer {
   maxsize: AmountSats // example: 237499972700
   txfee: AmountSats // example: 0
   cjfee: AmountSats | string // example: 250 (abs offers) or "0.00017" (rel offers)
-  fidelity_bond_value: number // example: 0 (no fb) or 0.0000052877962973
+  fidelity_bond_value: number // example: 0 (no fb) or 114557102085.28133
+}
+
+export interface OrderbookJson {
+  offers?: Offer[]
 }
 
 const orderbookJson = async ({ signal }: { signal: AbortSignal }) => {
@@ -19,17 +23,15 @@ const orderbookJson = async ({ signal }: { signal: AbortSignal }) => {
   })
 }
 
-const fetchOffers = async (options: { signal: AbortSignal }) => {
-  return orderbookJson(options)
-    .then((res) => (res.ok ? res.json() : ApiHelper.throwError(res)))
-    .then((res) => (res.offers || []) as Offer[])
+const fetchOrderbook = async (options: { signal: AbortSignal }): Promise<OrderbookJson> => {
+  return orderbookJson(options).then((res) => (res.ok ? res.json() : ApiHelper.throwError(res)))
 }
 
-const refreshOffers = async ({ signal }: { signal: AbortSignal }) => {
+const refreshOrderbook = async ({ signal }: { signal: AbortSignal }) => {
   return await fetch(`${basePath()}/refreshorderbook`, {
     method: 'POST',
     signal,
   })
 }
 
-export { fetchOffers, refreshOffers }
+export { fetchOrderbook, refreshOrderbook }

--- a/src/libs/JmObwatchApi.ts
+++ b/src/libs/JmObwatchApi.ts
@@ -1,83 +1,35 @@
-import { Helper as ApiHelper } from '../libs/JmWalletApi'
+import { AmountSats, Helper as ApiHelper } from '../libs/JmWalletApi'
 
 const basePath = () => `${window.JM.PUBLIC_PATH}/obwatch`
 
-export const ABSOLUTE_ORDER_TYPE_VAL = 'Native SW Absolute Fee'
-export const RELATIVE_ORDER_TYPE_VAL = 'Native SW Relative Fee'
-
-export interface Order {
-  type: string // example: "Native SW Absolute Fee" or "Native SW Relative Fee"
+export interface Offer {
   counterparty: string // example: "J5Bv3JSxPFWm2Yjb"
-  orderId: string // example: "0" (not unique!)
-  fee: string // example: "0.00000250" (abs offers) or "0.000100%" (rel offers)
-  minerFeeContribution: string // example: "0.00000000"
-  minimumSize: string // example: "0.00027300"
-  maximumSize: string // example: "2374.99972700"
-  bondValue: string // example: "0" (no fb) or "0.0000052877962973"
+  oid: number // example: 0 (not unique!)
+  ordertype: string // example: "sw0absoffer" or "sw0reloffer"
+  minsize: AmountSats // example: 27300
+  maxsize: AmountSats // example: 237499972700
+  txfee: AmountSats // example: 0
+  cjfee: AmountSats | string // example: 250 (abs offers) or "0.00017" (rel offers)
+  fidelity_bond_value: number // example: 0 (no fb) or 0.0000052877962973
 }
 
-const ORDER_KEYS: (keyof Order)[] = [
-  'type',
-  'counterparty',
-  'orderId',
-  'fee',
-  'minerFeeContribution',
-  'minimumSize',
-  'maximumSize',
-  'bondValue',
-]
-
-const parseOrderbook = (res: Response): Promise<Order[]> => {
-  if (!res.ok) {
-    // e.g. error is raised if ob-watcher is not running
-    return ApiHelper.throwError(res)
-  }
-
-  return res.text().then((html) => {
-    var parser = new DOMParser()
-    var doc = parser.parseFromString(html, 'text/html')
-
-    const tables = doc.getElementsByTagName('table')
-    if (tables.length !== 1) {
-      throw new Error('Cannot find orderbook table')
-    }
-    const orderbookTable = tables[0]
-    const tbodies = [...orderbookTable.children].filter((child) => child.tagName.toLowerCase() === 'tbody')
-    if (tbodies.length !== 1) {
-      throw new Error('Cannot find orderbook table body')
-    }
-
-    const tbody = tbodies[0]
-
-    const orders: Order[] = [...tbody.children]
-      .filter((row) => row.tagName.toLowerCase() === 'tr')
-      .filter((row) => row.children.length > 0)
-      .map((row) => [...row.children].filter((child) => child.tagName.toLowerCase() === 'td'))
-      .filter((cols) => cols.length === ORDER_KEYS.length)
-      .map((cols) => {
-        const data: unknown = ORDER_KEYS.map((key, index) => ({ [key]: cols[index].innerHTML })).reduce(
-          (acc, curr) => ({ ...acc, ...curr }),
-          {},
-        )
-        return data as Order
-      })
-
-    return orders
+const orderbookJson = async ({ signal }: { signal: AbortSignal }) => {
+  return await fetch(`${basePath()}/orderbook.json`, {
+    signal,
   })
 }
 
-// TODO: why is "orderbook.json" always empty? -> Parse HTML in the meantime.. ¯\_(ツ)_/¯
-const fetchOrderbook = async ({ signal }: { signal: AbortSignal }) => {
-  return await fetch(`${basePath()}/`, {
-    signal,
-  }).then((res) => parseOrderbook(res))
+const fetchOffers = async (options: { signal: AbortSignal }) => {
+  return orderbookJson(options)
+    .then((res) => (res.ok ? res.json() : ApiHelper.throwError(res)))
+    .then((res) => (res.offers || []) as Offer[])
 }
 
-const refreshOrderbook = async ({ signal }: { signal: AbortSignal }) => {
+const refreshOffers = async ({ signal }: { signal: AbortSignal }) => {
   return await fetch(`${basePath()}/refreshorderbook`, {
     method: 'POST',
     signal,
   })
 }
 
-export { fetchOrderbook, refreshOrderbook }
+export { fetchOffers, refreshOffers }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { WalletFileName } from './libs/JmWalletApi'
+import { OfferType, WalletFileName } from './libs/JmWalletApi'
 
 const BTC_FORMATTER = new Intl.NumberFormat('en-US', {
   minimumIntegerDigits: 1,
@@ -73,6 +73,12 @@ export const factorToPercentage = (val: number, precision = 6) => {
   // but: ✓ Number((0.000027 * 100).toFixed(6)) = 0.0027
   return Number((val * 100).toFixed(precision))
 }
+
+// can be any of ['sw0reloffer', 'swreloffer', 'reloffer']
+export const isRelativeOffer = (offertype: OfferType) => offertype.includes('reloffer')
+
+// can be any of ['sw0absoffer', 'swabsoffer', 'absoffer']
+export const isAbsoluteOffer = (offertype: OfferType) => offertype.includes('absoffer')
 
 export const isValidNumber = (val: number | undefined) => typeof val === 'number' && !isNaN(val)
 


### PR DESCRIPTION
Closes https://github.com/joinmarket-webui/jam/issues/454.
Closes https://github.com/joinmarket-webui/jam/issues/561.


- Fetches `orderbook.json` instead of parsing the html table to get data.
- Uses normalized fidelity bond value
- Removes column "Miner Fee Contribution"

### :camera_flash: Before/After
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/da046b8a-e374-4e0b-b5b6-4e629f130154" width=550 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/bd4a54c8-dc15-4f7f-be58-a5c37e8eb16a" width=550 />

