### PR TITLE
chore: do not display xpubs

### DIFF
--- a/src/components/jar_details/DisplayBranch.tsx
+++ b/src/components/jar_details/DisplayBranch.tsx
@@ -63,27 +63,13 @@ export function DisplayBranchHeader({ branch }: DisplayBranchProps) {
 }
 
 export function DisplayBranchBody({ branch }: DisplayBranchProps) {
-  const { branch: detailsString, entries } = branch
-  const xpub: string | undefined = detailsString.split('\t')[2]
   return (
     <rb.Container className="mb-2" fluid>
-      <rb.Row>
-        <rb.Col>
-          {xpub && (
-            <div className="p-3 mb-1">
-              <div>Extended public key</div>
-              <code className="text-secondary text-break">{xpub}</code>
-            </div>
-          )}
-        </rb.Col>
-      </rb.Row>
-      {entries.map((entry, index) => (
+      {branch.entries.map((entry) => (
         <DisplayBranchEntry
           key={entry.address}
           entry={entry}
-          className={`bg-transparent rounded-0 border-start-0 border-end-0 ${
-            index === 0 ? 'border-top-1 mt-2' : 'border-top-0'
-          }`}
+          className="bg-transparent rounded-0 border-start-0 border-end-0 border-bottom-0"
         />
       ))}
     </rb.Container>

--- a/src/components/jar_details/DisplayBranch.tsx
+++ b/src/components/jar_details/DisplayBranch.tsx
@@ -4,9 +4,9 @@ import { useTranslation } from 'react-i18next'
 import Balance from '../Balance'
 import { useSettings } from '../../context/SettingsContext'
 import { Branch, BranchEntry } from '../../context/WalletContext'
-import styles from './DisplayBranch.module.css'
 import { CopyButton } from '../CopyButton'
 import Sprite from '../Sprite'
+import styles from './DisplayBranch.module.css'
 
 const toHdPathIndex = (hdPath: string) => {
   const indexOfLastSeparator = hdPath.lastIndexOf('/')
@@ -73,15 +73,6 @@ export function DisplayBranchBody({ branch }: DisplayBranchProps) {
         />
       ))}
     </rb.Container>
-  )
-}
-
-export default function DisplayBranch({ branch }: DisplayBranchProps) {
-  return (
-    <article>
-      <DisplayBranchHeader branch={branch} />
-      <DisplayBranchBody branch={branch} />
-    </article>
   )
 }
 

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -414,16 +414,18 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                   </>
                 ) : (
                   <rb.Accordion flush className="p-3 p-lg-0">
-                    {jar.branches.map((branch, index) => (
-                      <rb.Accordion.Item className={styles.jarItem} key={branch.branch} eventKey={`${index}`}>
-                        <rb.Accordion.Header>
-                          <DisplayBranchHeader branch={branch} />
-                        </rb.Accordion.Header>
-                        <rb.Accordion.Body>
-                          <DisplayBranchBody branch={branch} />
-                        </rb.Accordion.Body>
-                      </rb.Accordion.Item>
-                    ))}
+                    {jar.branches
+                      .filter((it) => it.entries.length > 0)
+                      .map((branch, index) => (
+                        <rb.Accordion.Item className={styles.jarItem} key={branch.branch} eventKey={`${index}`}>
+                          <rb.Accordion.Header>
+                            <DisplayBranchHeader branch={branch} />
+                          </rb.Accordion.Header>
+                          <rb.Accordion.Body>
+                            <DisplayBranchBody branch={branch} />
+                          </rb.Accordion.Body>
+                        </rb.Accordion.Item>
+                      ))}
                   </rb.Accordion>
                 )}
               </div>

--- a/src/context/ServiceInfoContext.tsx
+++ b/src/context/ServiceInfoContext.tsx
@@ -208,7 +208,7 @@ const ServiceInfoProvider = ({ children }: PropsWithChildren<{}>) => {
         })
         .catch((err) => {
           if (!signal.aborted) {
-            const isUnauthorized = err instanceof Api.JmApiError && err.response.status === 401
+            const isUnauthorized = err instanceof Api.JmApiError && err.response?.status === 401
             if (isUnauthorized) {
               resetWalletAndClearSession()
             } else {


### PR DESCRIPTION
..as those derive public keys from an unexpected derivation depth.

See upstream issue https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1586

So, best thing for now is to temporarily do not display any xpub, instead of a "wrong" one. What do you think?
