### PR TITLE
dev: ability to reset fee values in dev mode

### DIFF
--- a/src/components/Jam.tsx
+++ b/src/components/Jam.tsx
@@ -464,7 +464,6 @@ export default function Jam({ wallet }: JamProps) {
                       setFieldValue,
                       validateForm,
                       isValid,
-                      dirty,
                       touched,
                       errors,
                     }) => (
@@ -474,7 +473,12 @@ export default function Jam({ wallet }: JamProps) {
                           {isDebugFeatureEnabled('insecureScheduleTesting') && (
                             <rb.Form.Group className="mb-4" controlId="offertype">
                               <ToggleSwitch
-                                label={'Use insecure testing settings'}
+                                label={
+                                  <>
+                                    Use insecure testing settings
+                                    <span className="ms-2 badge rounded-pill bg-warning">dev</span>
+                                  </>
+                                }
                                 subtitle={
                                   "This is completely insecure but makes testing the schedule much faster. This option won't be available in production."
                                 }

--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -1,8 +1,8 @@
-import { ChangeEvent } from 'react'
+import { ReactNode, ChangeEvent } from 'react'
 import styles from './ToggleSwitch.module.css'
 
 interface ToggleSwitchProps {
-  label: string
+  label: string | ReactNode
   subtitle?: string
   onToggle: (isToggled: boolean) => void
   toggledOn: boolean

--- a/src/constants/debugFeatures.ts
+++ b/src/constants/debugFeatures.ts
@@ -6,6 +6,7 @@ interface DebugFeatures {
   devSetupPage: boolean
   importDummyMnemonicPhrase: boolean
   rescanChainPage: boolean
+  allowFeeValuesReset: boolean
   fastThemeToggle: boolean
 }
 
@@ -19,6 +20,7 @@ const debugFeatures: DebugFeatures = {
   devSetupPage: devMode,
   importDummyMnemonicPhrase: devMode,
   rescanChainPage: devMode,
+  allowFeeValuesReset: devMode,
   fastThemeToggle: devMode,
 }
 


### PR DESCRIPTION
Ability to reset fee values in dev mode.

Some fee properties (`max_cj_fee_abs` and `max_cj_fee_rel`) do not have default values if JM is installed from scratch.
You can now reset those fee values if you want to test what the UI looks like, when a user does not have these values configured.

Misc:
- also added the "dev" badge to the test toggle on the scheduler page

## How to test
- Start the app in dev mode with `npm run dev:start`
- Go to settings -> Click "Adjust fee limits"
- Click the "Reset form values" button (notice how the form becomes invalid)
- Click "Save" - form should not be able to be submitted
- Toggle (disable) "Enable form validation"
- Now click "Save" again - config will be updated
- Visit "Send" or "Sweep" page and verify the alert message saying fee config values are missing

## :camera_flash: 
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/3e945414-f91b-496e-818c-19b7b5359e0c" width=450 />
<br />
<br />
<br />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/38f2a6c3-11c6-4fb5-8d82-72b0c681f979" width=450 />

(This message was there all along.. as dev you just never really saw it)




