### PR TITLE
ui: fluid container with wider layout

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -94,7 +94,7 @@ export default function App() {
         element={
           <>
             <Navbar />
-            <rb.Container as="main" className="py-4 py-sm-5">
+            <rb.Container as="main" className="py-4 py-sm-5" fluid>
               <Outlet />
             </rb.Container>
             <Footer />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -94,7 +94,7 @@ export default function App() {
         element={
           <>
             <Navbar />
-            <rb.Container as="main" className="py-4 py-sm-5" fluid>
+            <rb.Container as="main" className="py-4 py-lg-5" fluid="xl">
               <Outlet />
             </rb.Container>
             <Footer />

--- a/src/components/Jars.module.css
+++ b/src/components/Jars.module.css
@@ -16,8 +16,9 @@
 .jarsContainer {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: flex-start;
+  justify-content: space-around;
+  align-items: center;
+  width: 100%;
   gap: 2rem;
   color: var(--bs-body-color);
 }
@@ -25,7 +26,6 @@
 .jarsContainer :global .jar-container-hook {
   flex-direction: row;
   gap: 1rem;
-  min-width: 11rem;
 }
 
 .jarsContainer :global .jar-info-container-hook {
@@ -38,6 +38,7 @@
 @media only screen and (min-width: 768px) {
   .jarsContainer {
     flex-direction: row;
+    align-items: flex-start;
     gap: 1.5rem;
   }
 

--- a/src/components/Jars.tsx
+++ b/src/components/Jars.tsx
@@ -3,18 +3,18 @@ import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { AccountBalances } from '../context/BalanceSummary'
 import { AmountSats } from '../libs/JmWalletApi'
-import { OpenableJar, jarFillLevel } from './jars/Jar'
+import { JarProps, OpenableJar, jarFillLevel } from './jars/Jar'
 import Sprite from './Sprite'
 
 import styles from './Jars.module.css'
 
-interface JarsProps {
+type JarsProps = Pick<JarProps, 'size'> & {
   accountBalances: AccountBalances
   totalBalance: AmountSats
   onClick: (jarIndex: JarIndex) => void
 }
 
-const Jars = ({ accountBalances, totalBalance, onClick }: JarsProps) => {
+const Jars = ({ size, accountBalances, totalBalance, onClick }: JarsProps) => {
   const { t } = useTranslation()
   const sortedAccountBalances = useMemo(() => {
     if (!accountBalances) return []
@@ -43,6 +43,7 @@ const Jars = ({ accountBalances, totalBalance, onClick }: JarsProps) => {
           return (
             <OpenableJar
               key={account.accountIndex}
+              size={size}
               index={account.accountIndex}
               balance={account.calculatedAvailableBalanceInSats}
               frozenBalance={account.calculatedFrozenOrLockedBalanceInSats}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,7 +13,7 @@ const Col = ({ variant, children }: PropsWithChildren<ColProps>) => {
   }
 
   return (
-    <rb.Col md={10} lg={8} xl={6}>
+    <rb.Col md={12} lg={10} xl={8} xxl={6}>
       {children}
     </rb.Col>
   )

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,7 +13,7 @@ const Col = ({ variant, children }: PropsWithChildren<ColProps>) => {
   }
 
   return (
-    <rb.Col md={12} lg={10} xl={8} xxl={6}>
+    <rb.Col lg={10} xl={10} xxl={8}>
       {children}
     </rb.Col>
   )

--- a/src/components/MainWalletView.module.css
+++ b/src/components/MainWalletView.module.css
@@ -60,12 +60,3 @@
 .jarsDividerContainer .dividerButton:disabled {
   cursor: not-allowed;
 }
-
-.sendReceiveButton {
-  font-weight: 500;
-  border-color: var(--bs-border-color) !important;
-}
-
-.sendReceiveButton:hover {
-  border-color: transparent !important;
-}

--- a/src/components/MainWalletView.tsx
+++ b/src/components/MainWalletView.tsx
@@ -171,24 +171,24 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
                 <ExtendedLink
                   to={routes.receive}
                   state={{ account: 0 }}
-                  className={`${styles.sendReceiveButton} btn btn-outline-dark w-100`}
+                  className={`${styles.sendReceiveButton} btn btn-lg btn-outline-dark w-100`}
                   disabled={isLoading || serviceInfo?.rescanning}
                 >
                   <div className="d-flex justify-content-center align-items-center">
-                    <Sprite symbol="receive" width="24" height="24" />
-                    <div className="ps-1">{t('current_wallet.button_deposit')}</div>
+                    <Sprite symbol="receive" width="24" height="24" className="me-1" />
+                    {t('current_wallet.button_deposit')}
                   </div>
                 </ExtendedLink>
               </rb.Col>
               <rb.Col>
                 <ExtendedLink
                   to={routes.send}
-                  className={`${styles.sendReceiveButton} btn btn-outline-dark w-100`}
+                  className={`${styles.sendReceiveButton} btn btn-lg btn-outline-dark w-100`}
                   disabled={isLoading || serviceInfo?.rescanning}
                 >
                   <div className="d-flex justify-content-center align-items-center">
-                    <Sprite symbol="send" width="24" height="24" />
-                    <div className="ps-1">{t('current_wallet.button_withdraw')}</div>
+                    <Sprite symbol="send" width="24" height="24" className="me-1" />
+                    {t('current_wallet.button_withdraw')}
                   </div>
                 </ExtendedLink>
               </rb.Col>

--- a/src/components/MainWalletView.tsx
+++ b/src/components/MainWalletView.tsx
@@ -205,6 +205,7 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
                   </rb.Placeholder>
                 ) : (
                   <Jars
+                    size="lg"
                     accountBalances={currentWalletInfo.balanceSummary.accountBalances}
                     totalBalance={currentWalletInfo.balanceSummary.calculatedTotalBalanceInSats}
                     onClick={onJarClicked}

--- a/src/components/Receive.module.css
+++ b/src/components/Receive.module.css
@@ -69,7 +69,7 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
-  justify-content: center;
+  justify-content: space-evenly;
   align-items: center;
   gap: 2rem;
   color: var(--bs-body-color);
@@ -90,6 +90,5 @@
   .jarsContainer {
     gap: 1.5rem;
     flex-wrap: nowrap;
-    justify-content: space-between;
   }
 }

--- a/src/components/Send/SourceJarSelector.module.css
+++ b/src/components/Send/SourceJarSelector.module.css
@@ -2,9 +2,9 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
-  justify-content: center;
-  align-items: flex-start;
-  gap: 2rem;
+  justify-content: space-evenly;
+  align-items: center;
+  gap: 1rem;
   color: var(--bs-body-color);
   margin-bottom: 1.5rem;
 }

--- a/src/components/jars/Jar.module.css
+++ b/src/components/jars/Jar.module.css
@@ -51,9 +51,9 @@
   /* min width should approximately match width of value "(symbol) 0.00 000 000":
     - 1ch for the symbol
     - 9ch chars for all zeros
-    - 1.5ch for the dot and spaces
+    - 2ch for the dot and spaces
   */
-  min-width: 11.5ch;
+  min-width: 12ch;
   min-height: 1rem;
   font-size: 0.8rem;
 }

--- a/src/components/jars/Jar.tsx
+++ b/src/components/jars/Jar.tsx
@@ -11,22 +11,23 @@ const classNames = classnamesBind.bind(styles)
 
 type JarFillLevel = 0 | 1 | 2 | 3
 
-interface JarProps {
+export type JarProps = {
   index: JarIndex
   balance: AmountSats
   frozenBalance: AmountSats
   fillLevel: JarFillLevel
   isOpen?: boolean
+  size?: 'sm' | 'lg'
 }
 
-interface SelectableJarProps {
+export type SelectableJarProps = JarProps & {
   isSelectable: boolean
   isSelected: boolean
   variant?: 'default' | 'warning'
   onClick: (index: JarIndex) => void
 }
 
-interface TooltipJarProps {
+export type OpenableJarProps = Omit<JarProps, 'isOpen'> & {
   tooltipText: string
   onClick: () => void
 }
@@ -85,7 +86,7 @@ const jarInitial = (index: JarIndex) => {
 /**
  * A jar with index and balance.
  */
-const Jar = ({ index, balance, frozenBalance, fillLevel, isOpen = false }: JarProps) => {
+const Jar = ({ index, balance, frozenBalance, fillLevel, isOpen = false, size }: JarProps) => {
   const settings = useSettings()
 
   const jarSymbol = useMemo(() => {
@@ -122,7 +123,12 @@ const Jar = ({ index, balance, frozenBalance, fillLevel, isOpen = false }: JarPr
 
   return (
     <div className={`${styles.jarContainer} jar-container-hook`}>
-      <Sprite className={`${styles.jarSprite} ${flavorStyle}`} symbol={jarSymbol} width="32px" height="48px" />
+      <Sprite
+        className={`${styles.jarSprite} ${flavorStyle}`}
+        symbol={jarSymbol}
+        width={size === 'lg' ? '48px' : '32px'}
+        height={size === 'lg' ? '72px' : '48px'}
+      />
       <div className={`${styles.jarInfoContainer} jar-info-container-hook`}>
         <div className={styles.jarIndex}>{flavorName}</div>
         <div className={`${styles.jarBalance} jar-balance-container-hook`}>
@@ -148,15 +154,13 @@ const Jar = ({ index, balance, frozenBalance, fillLevel, isOpen = false }: JarPr
  * A jar with index, balance, and a radio-style selection button.
  */
 const SelectableJar = ({
-  index,
-  balance,
-  frozenBalance,
-  fillLevel,
   isSelectable,
   isSelected,
   onClick,
+  index,
   variant = 'default',
-}: JarProps & SelectableJarProps) => {
+  ...jarProps
+}: SelectableJarProps) => {
   return (
     <div
       className={classNames('selectableJarContainer', {
@@ -165,7 +169,7 @@ const SelectableJar = ({
       })}
       onClick={() => isSelectable && onClick(index)}
     >
-      <Jar index={index} balance={balance} frozenBalance={frozenBalance} fillLevel={fillLevel} />
+      <Jar index={index} {...jarProps} />
       <div className="d-flex justify-content-center align-items-center gap-1 mt-2 position-relative">
         <div className={styles.selectionCircle} />
         {variant === 'warning' && (
@@ -182,14 +186,7 @@ const SelectableJar = ({
  * A jar with index, balance, and a tooltip.
  * The jar symbol opens on hover.
  */
-const OpenableJar = ({
-  index,
-  balance,
-  frozenBalance,
-  fillLevel,
-  tooltipText,
-  onClick,
-}: JarProps & TooltipJarProps) => {
+const OpenableJar = ({ tooltipText, onClick, ...jarProps }: OpenableJarProps) => {
   const [jarIsOpen, setJarIsOpen] = useState(false)
   const onMouseOver = () => setJarIsOpen(true)
   const onMouseOut = () => setJarIsOpen(false)
@@ -210,7 +207,7 @@ const OpenableJar = ({
         overlay={(props) => <rb.Tooltip {...props}>{tooltipText}</rb.Tooltip>}
       >
         <div className={styles.tooltipJarContainer} onClick={onClick}>
-          <Jar index={index} balance={balance} frozenBalance={frozenBalance} fillLevel={fillLevel} isOpen={jarIsOpen} />
+          <Jar {...jarProps} isOpen={jarIsOpen} />
         </div>
       </rb.OverlayTrigger>
     </div>


### PR DESCRIPTION
- larger jars and buttons on main wallet view
- use fluid container (container-xl) and switch column sizes from
  ```
  md={10} lg={8} xl={6}
  ```
  to
  ```
  lg={10} xl={10} xxl={8}
  ```

## :camera_flash: Before / After


<img src="https://github.com/joinmarket-webui/jam/assets/3358649/d5ccbb08-834f-4a71-a09d-ffeacae1338c" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/5af11bc3-d61e-464f-b82d-e7a5ac732b57" width=350 />
<br />

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/6d934141-6dc1-4969-b035-5896c909578a" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/e1b2125c-7bdf-4030-a56f-792ac973672c" width=350 />
<br />

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/88773aca-9efb-4ed7-880e-1bfa633f95ae" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/b248ef5e-9b02-4fb7-9f6a-693c7aa84787" width=350 />
<br />

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/10c77422-340c-45ec-929a-898c99974280" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/48fc2e38-a25e-4d28-86c2-52e77d036e9a" width=350 />
<br />

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/150201aa-a868-44aa-9bfa-489c25d36284" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/9b3f4ba8-1e8e-4016-8a8c-36722790cd10" width=350 />
<br />

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/e76259cf-54f2-41fe-9e89-3ae8fd5b097b" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/a4621907-8a49-4f26-90b1-f868aee69b14" width=350 />
<br />

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/2a5c1559-18ce-4ae7-ac99-01a45be5aed2" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/fd8d5915-6d47-4091-bb1d-897d9fda0208" width=350 />