### PR TITLE
feat: custom tx fee on direct and collaborative send

### DIFF
--- a/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
@@ -7,12 +7,9 @@ RUN apt-get update \
        tor \
        && rm -rf /var/lib/apt/lists/*
 
-#ENV REPO https://github.com/JoinMarket-Org/joinmarket-clientserver
-#ENV REPO_BRANCH master
-#ENV REPO_REF master
-ENV REPO https://github.com/kristapsk/joinmarket-clientserver
-ENV REPO_BRANCH wallet_rpc-coinjoin-txfee
-ENV REPO_REF wallet_rpc-coinjoin-txfee
+ENV REPO https://github.com/JoinMarket-Org/joinmarket-clientserver
+ENV REPO_BRANCH master
+ENV REPO_REF master
 
 WORKDIR /src
 RUN git clone "$REPO" . --depth=10 --branch "$REPO_BRANCH" && git checkout "$REPO_REF"

--- a/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
+++ b/docker/regtest/dockerfile-deps/joinmarket/latest/Dockerfile
@@ -7,9 +7,12 @@ RUN apt-get update \
        tor \
        && rm -rf /var/lib/apt/lists/*
 
-ENV REPO https://github.com/JoinMarket-Org/joinmarket-clientserver
-ENV REPO_BRANCH master
-ENV REPO_REF master
+#ENV REPO https://github.com/JoinMarket-Org/joinmarket-clientserver
+#ENV REPO_BRANCH master
+#ENV REPO_REF master
+ENV REPO https://github.com/kristapsk/joinmarket-clientserver
+ENV REPO_BRANCH wallet_rpc-coinjoin-txfee
+ENV REPO_REF wallet_rpc-coinjoin-txfee
 
 WORKDIR /src
 RUN git clone "$REPO" . --depth=10 --branch "$REPO_BRANCH" && git checkout "$REPO_REF"

--- a/src/components/Earn.tsx
+++ b/src/components/Earn.tsx
@@ -295,9 +295,7 @@ const EarnForm = ({
                         value: OFFERTYPE_REL,
                       },
                     ]}
-                    onChange={(tab, checked) => {
-                      checked && setFieldValue('offertype', tab.value, true)
-                    }}
+                    onChange={(tab) => setFieldValue('offertype', tab.value, true)}
                     value={values.offertype}
                     disabled={isLoading || isSubmitting}
                   />

--- a/src/components/Earn.tsx
+++ b/src/components/Earn.tsx
@@ -247,7 +247,6 @@ const EarnForm = ({
 
   return (
     <Formik initialValues={initialValues} validate={validate} onSubmit={onSubmit}>
-<<<<<<< HEAD
       {(props) => {
         const { handleSubmit, setFieldValue, handleBlur, values, touched, errors, isSubmitting } = props
         const minsizeField = props.getFieldProps<AmountValue>('minsize')
@@ -270,74 +269,12 @@ const EarnForm = ({
                           value: OFFERTYPE_REL,
                         },
                       ]}
-                      onChange={(tab, checked) => {
-                        checked && setFieldValue('offertype', tab.value, true)
+                      value={values.offertype}
+                      onChange={(tab) => {
+                        setFieldValue('offertype', tab.value, true)
                       }}
-                      initialValue={values.offertype}
                       disabled={isLoading || isSubmitting}
                     />
-=======
-      {({ handleSubmit, setFieldValue, handleChange, handleBlur, values, touched, errors, isSubmitting }) => (
-        <>
-          <rb.Form onSubmit={handleSubmit} noValidate>
-            <Accordion title={t('earn.button_settings')}>
-              <>
-                <rb.Form.Group className="mb-4 d-flex justify-content-center" controlId="offertype">
-                  <SegmentedTabs
-                    name="offertype"
-                    tabs={[
-                      {
-                        label: t('earn.radio_abs_offer_label'),
-                        value: OFFERTYPE_ABS,
-                      },
-                      {
-                        label: t('earn.radio_rel_offer_label'),
-                        value: OFFERTYPE_REL,
-                      },
-                    ]}
-                    onChange={(tab) => setFieldValue('offertype', tab.value, true)}
-                    value={values.offertype}
-                    disabled={isLoading || isSubmitting}
-                  />
-                </rb.Form.Group>
-                {values.offertype === OFFERTYPE_REL ? (
-                  <rb.Form.Group className="mb-3" controlId="feeRel">
-                    <rb.Form.Label className="mb-0">
-                      {t('earn.label_rel_fee', {
-                        fee: typeof values.feeRel === 'number' ? `(${factorToPercentage(values.feeRel)}%)` : '',
-                      })}
-                    </rb.Form.Label>
-                    <rb.Form.Text className="d-block text-secondary mb-2">{t('earn.description_rel_fee')}</rb.Form.Text>
-                    {isLoading ? (
-                      <rb.Placeholder as="div" animation="wave">
-                        <rb.Placeholder xs={12} className={styles['input-loader']} />
-                      </rb.Placeholder>
-                    ) : (
-                      <rb.InputGroup hasValidation>
-                        <rb.InputGroup.Text id="feeRel-addon1" className={styles.inputGroupText}>
-                          %
-                        </rb.InputGroup.Text>
-                        <rb.Form.Control
-                          aria-label={t('earn.label_rel_fee', { fee: '' })}
-                          className="slashed-zeroes"
-                          type="number"
-                          name="feeRel"
-                          disabled={isSubmitting}
-                          onChange={(e) => {
-                            const value = e.target.value || ''
-                            setFieldValue('feeRel', value !== '' ? percentageToFactor(parseFloat(value)) : '', true)
-                          }}
-                          onBlur={handleBlur}
-                          value={typeof values.feeRel === 'number' ? factorToPercentage(values.feeRel) : ''}
-                          isValid={touched.feeRel && !errors.feeRel}
-                          isInvalid={touched.feeRel && !!errors.feeRel}
-                          min={0}
-                          step={feeRelPercentageStep}
-                        />
-                        <rb.Form.Control.Feedback type="invalid">{errors.feeRel}</rb.Form.Control.Feedback>
-                      </rb.InputGroup>
-                    )}
->>>>>>> 6149e4a (chore: fix SegmentedTabs active state)
                   </rb.Form.Group>
                   {values.offertype === OFFERTYPE_REL ? (
                     <rb.Form.Group className="mb-3" controlId="feeRel">

--- a/src/components/Earn.tsx
+++ b/src/components/Earn.tsx
@@ -247,6 +247,7 @@ const EarnForm = ({
 
   return (
     <Formik initialValues={initialValues} validate={validate} onSubmit={onSubmit}>
+<<<<<<< HEAD
       {(props) => {
         const { handleSubmit, setFieldValue, handleBlur, values, touched, errors, isSubmitting } = props
         const minsizeField = props.getFieldProps<AmountValue>('minsize')
@@ -275,6 +276,70 @@ const EarnForm = ({
                       initialValue={values.offertype}
                       disabled={isLoading || isSubmitting}
                     />
+=======
+      {({ handleSubmit, setFieldValue, handleChange, handleBlur, values, touched, errors, isSubmitting }) => (
+        <>
+          <rb.Form onSubmit={handleSubmit} noValidate>
+            <Accordion title={t('earn.button_settings')}>
+              <>
+                <rb.Form.Group className="mb-4 d-flex justify-content-center" controlId="offertype">
+                  <SegmentedTabs
+                    name="offertype"
+                    tabs={[
+                      {
+                        label: t('earn.radio_abs_offer_label'),
+                        value: OFFERTYPE_ABS,
+                      },
+                      {
+                        label: t('earn.radio_rel_offer_label'),
+                        value: OFFERTYPE_REL,
+                      },
+                    ]}
+                    onChange={(tab, checked) => {
+                      checked && setFieldValue('offertype', tab.value, true)
+                    }}
+                    value={values.offertype}
+                    disabled={isLoading || isSubmitting}
+                  />
+                </rb.Form.Group>
+                {values.offertype === OFFERTYPE_REL ? (
+                  <rb.Form.Group className="mb-3" controlId="feeRel">
+                    <rb.Form.Label className="mb-0">
+                      {t('earn.label_rel_fee', {
+                        fee: typeof values.feeRel === 'number' ? `(${factorToPercentage(values.feeRel)}%)` : '',
+                      })}
+                    </rb.Form.Label>
+                    <rb.Form.Text className="d-block text-secondary mb-2">{t('earn.description_rel_fee')}</rb.Form.Text>
+                    {isLoading ? (
+                      <rb.Placeholder as="div" animation="wave">
+                        <rb.Placeholder xs={12} className={styles['input-loader']} />
+                      </rb.Placeholder>
+                    ) : (
+                      <rb.InputGroup hasValidation>
+                        <rb.InputGroup.Text id="feeRel-addon1" className={styles.inputGroupText}>
+                          %
+                        </rb.InputGroup.Text>
+                        <rb.Form.Control
+                          aria-label={t('earn.label_rel_fee', { fee: '' })}
+                          className="slashed-zeroes"
+                          type="number"
+                          name="feeRel"
+                          disabled={isSubmitting}
+                          onChange={(e) => {
+                            const value = e.target.value || ''
+                            setFieldValue('feeRel', value !== '' ? percentageToFactor(parseFloat(value)) : '', true)
+                          }}
+                          onBlur={handleBlur}
+                          value={typeof values.feeRel === 'number' ? factorToPercentage(values.feeRel) : ''}
+                          isValid={touched.feeRel && !errors.feeRel}
+                          isInvalid={touched.feeRel && !!errors.feeRel}
+                          min={0}
+                          step={feeRelPercentageStep}
+                        />
+                        <rb.Form.Control.Feedback type="invalid">{errors.feeRel}</rb.Form.Control.Feedback>
+                      </rb.InputGroup>
+                    )}
+>>>>>>> 6149e4a (chore: fix SegmentedTabs active state)
                   </rb.Form.Group>
                   {values.offertype === OFFERTYPE_REL ? (
                     <rb.Form.Group className="mb-3" controlId="feeRel">

--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -21,22 +21,18 @@ const feeRange: (txFee: TxFee, txFeeFactor: number) => [number, number] = (txFee
   return [minFeeSatsPerVByte, maxFeeSatsPerVByte]
 }
 
-const useMiningFeeText = ({ feeConfigValues }: { feeConfigValues?: FeeValues }) => {
+const useMiningFeeText = ({ tx_fees, tx_fees_factor }: Pick<FeeValues, 'tx_fees' | 'tx_fees_factor'>) => {
   const { t } = useTranslation()
 
-  const miningFeeText = useMemo(() => {
-    if (!feeConfigValues) return null
-    if (!isValidNumber(feeConfigValues.tx_fees?.value) || !isValidNumber(feeConfigValues.tx_fees_factor)) return null
+  return useMemo(() => {
+    if (!isValidNumber(tx_fees?.value) || !isValidNumber(tx_fees_factor)) return null
 
-    if (!feeConfigValues.tx_fees?.unit) {
+    if (!tx_fees?.unit) {
       return null
-    } else if (feeConfigValues.tx_fees.unit === 'blocks') {
-      return t('send.confirm_send_modal.text_miner_fee_in_targeted_blocks', { count: feeConfigValues.tx_fees.value })
+    } else if (tx_fees.unit === 'blocks') {
+      return t('send.confirm_send_modal.text_miner_fee_in_targeted_blocks', { count: tx_fees.value })
     } else {
-      const [minFeeSatsPerVByte, maxFeeSatsPerVByte] = feeRange(
-        feeConfigValues.tx_fees,
-        feeConfigValues.tx_fees_factor!,
-      )
+      const [minFeeSatsPerVByte, maxFeeSatsPerVByte] = feeRange(tx_fees, tx_fees_factor!)
       const fractionDigits = 2
 
       if (minFeeSatsPerVByte.toFixed(fractionDigits) === maxFeeSatsPerVByte.toFixed(fractionDigits)) {
@@ -56,9 +52,7 @@ const useMiningFeeText = ({ feeConfigValues }: { feeConfigValues?: FeeValues }) 
         }),
       })
     }
-  }, [t, feeConfigValues])
-
-  return miningFeeText
+  }, [t, tx_fees, tx_fees_factor])
 }
 
 interface PaymentDisplayInfo {
@@ -92,7 +86,7 @@ export function PaymentConfirmModal({
   const { t } = useTranslation()
   const settings = useSettings()
 
-  const miningFeeText = useMiningFeeText({ feeConfigValues })
+  const miningFeeText = useMiningFeeText({ ...feeConfigValues })
   const estimatedMaxCollaboratorFee = useEstimatedMaxCollaboratorFee({
     isCoinjoin,
     feeConfigValues,

--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -155,17 +155,6 @@ export function PaymentConfirmModal({
             )}
           </rb.Col>
         </rb.Row>
-
-        {miningFeeText && (
-          <rb.Row>
-            <rb.Col xs={4} md={3} className="text-end">
-              <strong>{t('send.confirm_send_modal.label_miner_fee')}</strong>
-            </rb.Col>
-            <rb.Col xs={8} md={9} className="text-start">
-              {miningFeeText}
-            </rb.Col>
-          </rb.Row>
-        )}
         {isCoinjoin && (
           <rb.Row>
             <rb.Col xs={4} md={3} className="text-end">
@@ -204,6 +193,16 @@ export function PaymentConfirmModal({
                   </div>
                 </rb.OverlayTrigger>
               </div>
+            </rb.Col>
+          </rb.Row>
+        )}
+        {miningFeeText && (
+          <rb.Row>
+            <rb.Col xs={4} md={3} className="text-end">
+              <strong>{t('send.confirm_send_modal.label_miner_fee')}</strong>
+            </rb.Col>
+            <rb.Col xs={8} md={9} className="text-start">
+              {miningFeeText}
             </rb.Col>
           </rb.Row>
         )}

--- a/src/components/SegmentedTabs.module.css
+++ b/src/components/SegmentedTabs.module.css
@@ -1,27 +1,27 @@
-.segmented-tabs {
+.segmentedTabs {
   background-color: var(--bs-gray-300);
   border-radius: 0.25rem;
   padding: 0.25rem;
   width: 100%;
 }
 
-.segmented-tab > label {
+.segmentedTab > label {
   height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
 }
 
-:root[data-theme='dark'] .segmented-tabs {
+:root[data-theme='dark'] .segmentedTabs {
   color: var(--bs-gray-100);
   background-color: var(--bs-gray-800);
 }
 
-.segmented-tab {
+.segmentedTab {
   flex: 1 1 0;
 }
 
-.segmented-tab input[type='radio'] {
+.segmentedTab input[type='radio'] {
   appearance: none;
   margin: 0;
   position: absolute;
@@ -30,7 +30,7 @@
   width: 0;
 }
 
-.segmented-tab label {
+.segmentedTab label {
   background-color: white;
   padding: 0.25rem 1rem;
   border-radius: 0.1rem;
@@ -39,33 +39,33 @@
   text-align: center;
 }
 
-.segmented-tab input[type='radio']:disabled ~ label {
+.segmentedTab input[type='radio']:disabled ~ label {
   background-color: transparent;
   color: var(--bs-gray-600);
   opacity: 0.5;
 }
 
-:root[data-theme='dark'] .segmented-tab input[type='radio']:disabled ~ label {
+:root[data-theme='dark'] .segmentedTab input[type='radio']:disabled ~ label {
   color: var(--bs-gray-600);
   opacity: 0.5;
 }
 
-.segmented-tab input[type='radio']:not(:checked):not(:disabled) ~ label {
+.segmentedTab input[type='radio']:not(:checked):not(:disabled) ~ label {
   background-color: transparent;
 }
 
-.segmented-tab input[type='radio']:not(:disabled) ~ label {
+.segmentedTab input[type='radio']:not(:disabled) ~ label {
   cursor: pointer;
 }
-.segmented-tab input[type='radio']:checked:not(:disabled) ~ label {
+.segmentedTab input[type='radio']:checked:not(:disabled) ~ label {
   background-color: var(--bs-gray-100);
   box-shadow: 1px 1px 3px 1px rgba(0, 0, 0, 0.1);
 }
 
-:root[data-theme='dark'] .segmented-tab input[type='radio']:checked:not(:disabled) ~ label {
+:root[data-theme='dark'] .segmentedTab input[type='radio']:checked:not(:disabled) ~ label {
   background-color: var(--bs-gray-600);
 }
 
-.segmented-tab input[type='radio']:focus ~ label {
+.segmentedTab input[type='radio']:focus ~ label {
   box-shadow: 0 0 0 0.25rem var(--bs-focus-ring-color) !important;
 }

--- a/src/components/SegmentedTabs.tsx
+++ b/src/components/SegmentedTabs.tsx
@@ -2,20 +2,26 @@ import React from 'react'
 import * as rb from 'react-bootstrap'
 import styles from './SegmentedTabs.module.css'
 
+type SegmentedTabValue = string
 interface SegmentedTab {
   label: string
-  value: string
+  value: SegmentedTabValue
   disabled?: boolean
 }
 
+<<<<<<< HEAD
 function SegmentedTabFormCheck({ id, name, value, label, disabled, checked, onChange }: rb.FormCheckProps) {
+=======
+function SegmentedTabFormCheck(props: rb.FormCheckProps) {
+>>>>>>> 6149e4a (chore: fix SegmentedTabs active state)
   const _onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation()
-    onChange && onChange(e)
+    props.onChange && props.onChange(e)
   }
 
   return (
     <>
+<<<<<<< HEAD
       <div className={styles['segmented-tab']}>
         <input
           id={id}
@@ -28,6 +34,9 @@ function SegmentedTabFormCheck({ id, name, value, label, disabled, checked, onCh
         />
         <label htmlFor={id}>{label}</label>
       </div>
+=======
+      <rb.Form.Check {...props} bsPrefix={styles['segmented-tab']} type="radio" onChange={_onChange} />
+>>>>>>> 6149e4a (chore: fix SegmentedTabs active state)
     </>
   )
 }
@@ -36,11 +45,11 @@ interface SegmentedTabsProps {
   name: string
   tabs: SegmentedTab[]
   onChange: (tab: SegmentedTab, checked: boolean) => void
-  initialValue?: string
+  value?: SegmentedTabValue
   disabled?: boolean
 }
 
-export default function SegmentedTabs({ name, tabs, onChange, initialValue, disabled = false }: SegmentedTabsProps) {
+export default function SegmentedTabs({ name, tabs, onChange, value, disabled = false }: SegmentedTabsProps) {
   const _onChange = (e: React.ChangeEvent<HTMLInputElement>, tab: SegmentedTab) => {
     e.stopPropagation()
     onChange(tab, e.currentTarget.checked)
@@ -56,9 +65,14 @@ export default function SegmentedTabs({ name, tabs, onChange, initialValue, disa
               id={`${name}-${index}`}
               name={name}
               label={tab.label}
+              value={tab.value}
               disabled={disabled || tab.disabled}
+              checked={value === tab.value}
               inline={true}
+<<<<<<< HEAD
               checked={initialValue === tab.value}
+=======
+>>>>>>> 6149e4a (chore: fix SegmentedTabs active state)
               onChange={(e) => _onChange(e, tab)}
             />
           )

--- a/src/components/SegmentedTabs.tsx
+++ b/src/components/SegmentedTabs.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { ChangeEvent } from 'react'
 import * as rb from 'react-bootstrap'
 import styles from './SegmentedTabs.module.css'
 
@@ -9,54 +9,37 @@ interface SegmentedTab {
   disabled?: boolean
 }
 
-<<<<<<< HEAD
-function SegmentedTabFormCheck({ id, name, value, label, disabled, checked, onChange }: rb.FormCheckProps) {
-=======
-function SegmentedTabFormCheck(props: rb.FormCheckProps) {
->>>>>>> 6149e4a (chore: fix SegmentedTabs active state)
-  const _onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation()
-    props.onChange && props.onChange(e)
-  }
-
-  return (
-    <>
-<<<<<<< HEAD
-      <div className={styles['segmented-tab']}>
-        <input
-          id={id}
-          name={name}
-          type="radio"
-          value={value}
-          checked={checked}
-          onChange={_onChange}
-          disabled={disabled}
-        />
-        <label htmlFor={id}>{label}</label>
-      </div>
-=======
-      <rb.Form.Check {...props} bsPrefix={styles['segmented-tab']} type="radio" onChange={_onChange} />
->>>>>>> 6149e4a (chore: fix SegmentedTabs active state)
-    </>
-  )
-}
+const SegmentedTabFormCheck = ({ id, name, value, label, disabled, checked, onChange }: rb.FormCheckProps) => (
+  <div className={styles.segmentedTab}>
+    <input
+      id={id}
+      name={name}
+      type="radio"
+      value={value}
+      checked={checked}
+      onChange={onChange}
+      disabled={disabled}
+    />
+    <label htmlFor={id}>{label}</label>
+  </div>
+)
 
 interface SegmentedTabsProps {
   name: string
   tabs: SegmentedTab[]
-  onChange: (tab: SegmentedTab, checked: boolean) => void
+  onChange: (tab: SegmentedTab) => void
   value?: SegmentedTabValue
   disabled?: boolean
 }
 
 export default function SegmentedTabs({ name, tabs, onChange, value, disabled = false }: SegmentedTabsProps) {
-  const _onChange = (e: React.ChangeEvent<HTMLInputElement>, tab: SegmentedTab) => {
+  const _onChange = (e: ChangeEvent<HTMLInputElement>, tab: SegmentedTab) => {
     e.stopPropagation()
-    onChange(tab, e.currentTarget.checked)
+    onChange(tab)
   }
 
   return (
-    <div className={['segmented-tabs-hook', styles['segmented-tabs']].join(' ')}>
+    <div className={`segmented-tabs-hook ${styles.segmentedTabs}`}>
       <div className="d-flex gap-1">
         {tabs.map((tab, index) => {
           return (
@@ -69,10 +52,6 @@ export default function SegmentedTabs({ name, tabs, onChange, value, disabled = 
               disabled={disabled || tab.disabled}
               checked={value === tab.value}
               inline={true}
-<<<<<<< HEAD
-              checked={initialValue === tab.value}
-=======
->>>>>>> 6149e4a (chore: fix SegmentedTabs active state)
               onChange={(e) => _onChange(e, tab)}
             />
           )

--- a/src/components/SegmentedTabs.tsx
+++ b/src/components/SegmentedTabs.tsx
@@ -11,15 +11,7 @@ interface SegmentedTab {
 
 const SegmentedTabFormCheck = ({ id, name, value, label, disabled, checked, onChange }: rb.FormCheckProps) => (
   <div className={styles.segmentedTab}>
-    <input
-      id={id}
-      name={name}
-      type="radio"
-      value={value}
-      checked={checked}
-      onChange={onChange}
-      disabled={disabled}
-    />
+    <input id={id} name={name} type="radio" value={value} checked={checked} onChange={onChange} disabled={disabled} />
     <label htmlFor={id}>{label}</label>
   </div>
 )

--- a/src/components/Send/AmountInputField.module.css
+++ b/src/components/Send/AmountInputField.module.css
@@ -1,13 +1,3 @@
-.inputLoader {
-  height: 3.5rem;
-  border-radius: 0.25rem;
-}
-
-.input {
-  height: 3.5rem;
-  width: 100%;
-}
-
 .button {
   font-size: 0.875rem !important;
 }

--- a/src/components/Send/AmountInputField.tsx
+++ b/src/components/Send/AmountInputField.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import * as rb from 'react-bootstrap'
 import { useField, useFormikContext } from 'formik'
+import classNames from 'classnames'
 import Sprite from '../Sprite'
 import { AccountBalanceSummary } from '../../context/BalanceSummary'
 import { formatBtcDisplayValue } from '../../utils'
@@ -11,6 +12,7 @@ import styles from './AmountInputField.module.css'
 export type AmountInputFieldProps = {
   name: string
   label: string
+  className?: string
   placeholder?: string
   isLoading: boolean
   disabled?: boolean
@@ -21,6 +23,7 @@ export type AmountInputFieldProps = {
 export const AmountInputField = ({
   name,
   label,
+  className,
   placeholder,
   isLoading,
   disabled = false,
@@ -39,13 +42,13 @@ export const AmountInputField = ({
 
         {isLoading ? (
           <rb.Placeholder as="div" animation="wave">
-            <rb.Placeholder xs={12} className={className} />
+            <rb.Placeholder xs={12} className={styles.className} />
           </rb.Placeholder>
         ) : (
           <div className={form.touched[field.name] && !!form.errors[field.name] ? 'is-invalid' : ''}>
             <BitcoinAmountInput
               ref={ref}
-              className={styles.input}
+              className={classNames('slashed-zeroes', className)}
               inputGroupTextClassName={styles.inputGroupText}
               label={label}
               placeholder={placeholder}

--- a/src/components/Send/AmountInputField.tsx
+++ b/src/components/Send/AmountInputField.tsx
@@ -39,7 +39,7 @@ export const AmountInputField = ({
 
         {isLoading ? (
           <rb.Placeholder as="div" animation="wave">
-            <rb.Placeholder xs={12} className={styles.inputLoader} />
+            <rb.Placeholder xs={12} className={className} />
           </rb.Placeholder>
         ) : (
           <div className={form.touched[field.name] && !!form.errors[field.name] ? 'is-invalid' : ''}>

--- a/src/components/Send/AmountInputField.tsx
+++ b/src/components/Send/AmountInputField.tsx
@@ -42,7 +42,7 @@ export const AmountInputField = ({
 
         {isLoading ? (
           <rb.Placeholder as="div" animation="wave">
-            <rb.Placeholder xs={12} className={styles.className} />
+            <rb.Placeholder xs={12} className={className} />
           </rb.Placeholder>
         ) : (
           <div className={form.touched[field.name] && !!form.errors[field.name] ? 'is-invalid' : ''}>

--- a/src/components/Send/DestinationInputField.module.css
+++ b/src/components/Send/DestinationInputField.module.css
@@ -1,9 +1,0 @@
-.inputLoader {
-  height: 3.5rem;
-  border-radius: 0.25rem;
-}
-
-.input {
-  height: 3.5rem;
-  width: 100%;
-}

--- a/src/components/Send/DestinationInputField.tsx
+++ b/src/components/Send/DestinationInputField.tsx
@@ -7,10 +7,8 @@ import * as Api from '../../libs/JmWalletApi'
 import Sprite from '../Sprite'
 import { jarName } from '../jars/Jar'
 import JarSelectorModal from '../JarSelectorModal'
-
 import { WalletInfo } from '../../context/WalletContext'
 import { noop } from '../../utils'
-import styles from './DestinationInputField.module.css'
 
 export type DestinationValue = {
   value: Api.BitcoinAddress | null
@@ -88,14 +86,14 @@ export const DestinationInputField = ({
         <rb.Form.Label>{label}</rb.Form.Label>
         {isLoading ? (
           <rb.Placeholder as="div" animation="wave">
-            <rb.Placeholder xs={12} className={styles.inputLoader} />
+            <rb.Placeholder xs={12} className={className} />
           </rb.Placeholder>
         ) : (
           <>
             {field.value.fromJar !== null ? (
               <rb.InputGroup hasValidation={false}>
                 <rb.Form.Control
-                  className={classNames('slashed-zeroes', styles.input, className)}
+                  className={classNames('slashed-zeroes', className)}
                   value={`${jarName(field.value.fromJar)} (${field.value.value})`}
                   required
                   onChange={noop}
@@ -104,7 +102,6 @@ export const DestinationInputField = ({
                 />
                 <rb.Button
                   variant="dark"
-                  className={styles.button}
                   onClick={() => {
                     form.setFieldValue(field.name, form.initialValues[field.name], true)
                     setTimeout(() => ref.current?.focus(), 4)
@@ -124,7 +121,7 @@ export const DestinationInputField = ({
                     aria-label={label}
                     name={field.name}
                     placeholder={t('send.placeholder_recipient')}
-                    className={classNames('slashed-zeroes', styles.input, className)}
+                    className={classNames('slashed-zeroes', className)}
                     value={field.value.value || ''}
                     onBlur={field.onBlur}
                     required
@@ -144,7 +141,6 @@ export const DestinationInputField = ({
                   />
                   <rb.Button
                     variant="outline-dark"
-                    className={styles.button}
                     onClick={() => setDestinationJarPickerShown(true)}
                     disabled={disabled || !walletInfo}
                   >

--- a/src/components/Send/SendForm.module.css
+++ b/src/components/Send/SendForm.module.css
@@ -1,3 +1,9 @@
 .blurred {
   filter: blur(2px);
 }
+
+.input {
+  height: 3.5rem;
+  width: 100%;
+  border-radius: 0.25rem;
+}

--- a/src/components/Send/SendForm.tsx
+++ b/src/components/Send/SendForm.tsx
@@ -344,12 +344,7 @@ const InnerSendForm = ({
           </div>
 
           <div className="mb-4">
-            <Field
-              name="txFee"
-              label={t('settings.fees.label_tx_fees')}
-              className={styles.input}
-              component={TxFeeInputField}
-            />
+            <Field name="txFee" label={t('send.label_tx_fees')} className={styles.input} component={TxFeeInputField} />
           </div>
         </Accordion>
 

--- a/src/components/Send/SendForm.tsx
+++ b/src/components/Send/SendForm.tsx
@@ -296,6 +296,7 @@ const InnerSendForm = ({
         <AmountInputField
           name="amount"
           label={t('send.label_amount_input')}
+          className={styles.input}
           placeholder={t('send.placeholder_amount_input')}
           isLoading={isLoading}
           disabled={disabled}

--- a/src/components/Send/SendForm.tsx
+++ b/src/components/Send/SendForm.tsx
@@ -30,6 +30,8 @@ import { WalletInfo } from '../../context/WalletContext'
 import { useSettings } from '../../context/SettingsContext'
 import styles from './SendForm.module.css'
 import { TxFeeInputField, validateTxFee } from '../settings/TxFeeInputField'
+import { useServiceInfo } from '../../context/ServiceInfoContext'
+import { isFeatureEnabled } from '../../constants/features'
 
 type CollaborativeTransactionOptionsProps = {
   selectedAmount?: AmountValue
@@ -54,8 +56,8 @@ function CollaborativeTransactionOptions({
   feeConfigValues,
   reloadFeeConfigValues,
 }: CollaborativeTransactionOptionsProps) {
-  const settings = useSettings()
   const { t } = useTranslation()
+  const settings = useSettings()
 
   const [activeFeeConfigModalSection, setActiveFeeConfigModalSection] = useState<FeeConfigSectionKey>()
   const [showFeeConfigModal, setShowFeeConfigModal] = useState(false)
@@ -238,6 +240,7 @@ const InnerSendForm = ({
   disabled = false,
 }: InnerSendFormProps) => {
   const { t } = useTranslation()
+  const serviceInfo = useServiceInfo()
 
   const jarBalances = useMemo(() => {
     if (!walletInfo) return []
@@ -343,9 +346,16 @@ const InnerSendForm = ({
             />
           </div>
 
-          <div className="mb-4">
-            <Field name="txFee" label={t('send.label_tx_fees')} className={styles.input} component={TxFeeInputField} />
-          </div>
+          {serviceInfo && isFeatureEnabled('txFeeOnSend', serviceInfo) && (
+            <div className="mb-4">
+              <Field
+                name="txFee"
+                label={t('send.label_tx_fees')}
+                className={styles.input}
+                component={TxFeeInputField}
+              />
+            </div>
+          )}
         </Accordion>
 
         <SubmitButton

--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -379,10 +379,12 @@ export default function Send({ wallet }: SendProps) {
     setAlert(undefined)
 
     const abortCtrl = new AbortController()
-    return Api.getTakerStop({ ...wallet, signal: abortCtrl.signal }).catch((err) => {
-      if (abortCtrl.signal.aborted) return
-      setAlert({ variant: 'danger', message: err.message })
-    })
+    return Api.getTakerStop({ ...wallet, signal: abortCtrl.signal })
+      .then((res) => (res.ok ? true : Api.Helper.throwError(res)))
+      .catch((err) => {
+        if (abortCtrl.signal.aborted) return
+        setAlert({ variant: 'danger', message: err.message })
+      })
   }
 
   const onSubmit = async (values: SendFormValues) => {

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -325,7 +325,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                 name="jarDetailsTab"
                 tabs={tabs}
                 onChange={(tab, checked) => checked && setSelectedTab(tab.value)}
-                initialValue={selectedTab}
+                value={selectedTab}
               />
             </div>
           </div>

--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -324,7 +324,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
               <SegmentedTabs
                 name="jarDetailsTab"
                 tabs={tabs}
-                onChange={(tab, checked) => checked && setSelectedTab(tab.value)}
+                onChange={(tab) => setSelectedTab(tab.value)}
                 value={selectedTab}
               />
             </div>

--- a/src/components/settings/TxFeeInputField.tsx
+++ b/src/components/settings/TxFeeInputField.tsx
@@ -1,7 +1,7 @@
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { TFunction } from 'i18next'
-import { FieldProps, FormikErrors } from 'formik'
+import { FieldAttributes, FieldProps, FormikErrors } from 'formik'
 import { TxFeeValueUnit, TxFee } from '../../hooks/Fees'
 import { isValidNumber } from '../../utils'
 import Sprite from '../Sprite'
@@ -63,16 +63,16 @@ export const validateTxFee = (val: TxFee | undefined, t: TFunction): FormikError
 
 type TxFeeInputFieldProps = FieldProps<TxFee | undefined> & {
   label: string
+  className?: string
 }
 
-export const TxFeeInputField = ({ field, form, label }: TxFeeInputFieldProps) => {
+export const TxFeeInputField = ({ field, form, label, className }: TxFeeInputFieldProps) => {
   const { t } = useTranslation()
 
   return (
     <>
       <rb.Form.Label>{label}</rb.Form.Label>
-
-      <rb.Form.Group className="my-2 d-flex justify-content-center" controlId="offertype">
+      <rb.Form.Group className="mb-2 d-flex justify-content-center" controlId="txFeesUnit">
         <SegmentedTabs
           name="txFeesUnit"
           tabs={[
@@ -136,7 +136,7 @@ export const TxFeeInputField = ({ field, form, label }: TxFeeInputFieldProps) =>
           {field.value?.unit === 'sats/kilo-vbyte' ? (
             <rb.Form.Control
               aria-label={label}
-              className={`slashed-zeroes`}
+              className={`slashed-zeroes ${className || ''}`}
               name={field.name}
               type="number"
               placeholder="1"
@@ -163,7 +163,7 @@ export const TxFeeInputField = ({ field, form, label }: TxFeeInputFieldProps) =>
           ) : (
             <rb.Form.Control
               aria-label={label}
-              className={`slashed-zeroes`}
+              className={`slashed-zeroes ${className || ''}`}
               name={field.name}
               type="number"
               placeholder="1"

--- a/src/constants/features.ts
+++ b/src/constants/features.ts
@@ -3,13 +3,13 @@ import { ServiceInfo } from '../context/ServiceInfoContext'
 interface Features {
   importWallet: SemVer
   rescanChain: SemVer
-  directSendTxFee: SemVer
+  txFeeOnSend: SemVer
 }
 
 const features: Features = {
   importWallet: { major: 0, minor: 9, patch: 10 }, // added in https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1461
   rescanChain: { major: 0, minor: 9, patch: 10 }, // added in https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1461
-  directSendTxFee: { major: 0, minor: 9, patch: 10 }, // added in https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1597
+  txFeeOnSend: { major: 0, minor: 9, patch: 11 }, // added in https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1597
 }
 
 type Feature = keyof Features

--- a/src/hooks/Fees.ts
+++ b/src/hooks/Fees.ts
@@ -6,8 +6,8 @@ import { isValidNumber } from '../utils'
 export type TxFeeValueUnit = 'blocks' | 'sats/kilo-vbyte'
 export type TxFeeValue = number
 export type TxFee = {
-  value: TxFeeValue
-  unit: TxFeeValueUnit
+  value?: TxFeeValue
+  unit?: TxFeeValueUnit
 }
 
 export const toTxFeeValueUnit = (val?: TxFeeValue): TxFeeValueUnit | undefined => {
@@ -50,7 +50,7 @@ export const useLoadFeeConfigValues = () => {
         tx_fees: isValidNumber(parsedTxFees)
           ? {
               value: parsedTxFees,
-              unit: toTxFeeValueUnit(parsedTxFees) || 'blocks',
+              unit: toTxFeeValueUnit(parsedTxFees),
             }
           : undefined,
         tx_fees_factor: isValidNumber(parsedTxFeesFactor) ? parsedTxFeesFactor : undefined,

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -296,6 +296,7 @@
     "sending_options": "Sending options",
     "toggle_coinjoin": "Send as collaborative transaction",
     "toggle_coinjoin_subtitle": "Collaborative transactions improve the privacy of yourself and others.",
+    "label_tx_fees": "Mining fee",
     "button_send": "Send",
     "button_send_despite_warning": "Ignore warning & try send",
     "button_send_without_improved_privacy": "Send without privacy improvement",

--- a/src/libs/JmWalletApi.ts
+++ b/src/libs/JmWalletApi.ts
@@ -120,6 +120,7 @@ interface DoCoinjoinRequest {
   destination: BitcoinAddress
   amount_sats: AmountSats
   counterparties: number
+  txfee?: number
 }
 
 interface FreezeRequest {
@@ -391,10 +392,7 @@ const postDirectSend = async ({ token, signal, walletFileName }: WalletRequestCo
   return await fetch(`${basePath()}/v1/wallet/${encodeURIComponent(walletFileName)}/taker/direct-send`, {
     method: 'POST',
     headers: { ...Helper.buildAuthHeader(token) },
-    body: JSON.stringify({
-      ...req,
-      txfee: req.txfee ? String(req.txfee) : undefined,
-    }),
+    body: JSON.stringify(req),
     signal,
   })
 }


### PR DESCRIPTION
Resolves #696.

Enables specifing the tx fee on the send page for direct and collaborative sends.
Only possible with the newest (unreleased) JM version.

Direct send support is already merged (https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1597).
Collaborative send is still being reviewed (https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1612).

TODO:
- [x] revert to backend master branch in regtest setup


## :camera_flash: 

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/bd172461-c05e-4cda-893f-111887ee178c" width=350 />

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/306e8da3-1eee-4e31-b47a-2ce732347a56" width=350 />

