### PR TITLE
ui(orderbook): add delay hint to highlighted offer toggle

### DIFF
--- a/src/components/Orderbook.tsx
+++ b/src/components/Orderbook.tsx
@@ -449,7 +449,7 @@ export function Orderbook({ entries, refresh, nickname }: OrderbookProps) {
                     subtitle={ownOffers.length === 0 ? t('orderbook.text_highlight_own_orders_subtitle') : undefined}
                     toggledOn={isHighlightOwnOffers}
                     onToggle={(isToggled) => setIsHighlightOwnOffers(isToggled)}
-                    disabled={isLoadingRefresh}
+                    disabled={isLoadingRefresh || ownOffers.length === 0}
                   />
                   {ownOffers.length > 0 && (
                     <ToggleSwitch

--- a/src/components/Orderbook.tsx
+++ b/src/components/Orderbook.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
 import { Table, Header, HeaderRow, HeaderCell, Body, Row, Cell } from '@table-library/react-table-library/table'
 import { usePagination } from '@table-library/react-table-library/pagination'
 import { useSort, HeaderCellSort, SortToggleType } from '@table-library/react-table-library/sort'
@@ -16,6 +16,7 @@ import TablePagination from './TablePagination'
 import { factorToPercentage, isAbsoluteOffer, isRelativeOffer } from '../utils'
 import { isDevMode } from '../constants/debugFeatures'
 import styles from './Orderbook.module.css'
+import ToggleSwitch from './ToggleSwitch'
 
 const TABLE_THEME = {
   Table: `
@@ -352,13 +353,13 @@ export function Orderbook({ entries, refresh, nickname }: OrderbookProps) {
     [tableData],
   )
 
+  const ownOffers = useMemo(() => {
+    return nickname ? entries.filter((it) => it.counterparty === nickname) : []
+  }, [nickname, entries])
+
   useEffect(() => {
-    if (!nickname || !isHighlightOwnOffers) {
-      setHighlightedOrders([])
-    } else {
-      setHighlightedOrders(entries.filter((it) => it.counterparty === nickname))
-    }
-  }, [entries, nickname, isHighlightOwnOffers])
+    setHighlightedOrders(isHighlightOwnOffers ? ownOffers : [])
+  }, [ownOffers, isHighlightOwnOffers])
 
   return (
     <div className={styles.orderbookContainer}>
@@ -424,13 +425,12 @@ export function Orderbook({ entries, refresh, nickname }: OrderbookProps) {
           <>
             {nickname && (
               <div className="mb-3 ps-3 ps-md-0 pt-3 pt-lg-0">
-                <rb.Form.Check
-                  type="checkbox"
-                  id="highlight-own-offers"
+                <ToggleSwitch
                   label={t('orderbook.label_highlight_own_orders')}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                    setIsHighlightOwnOffers(e.target.checked)
-                  }}
+                  subtitle={ownOffers.length === 0 ? t('orderbook.text_highlight_own_orders_subtitle') : undefined}
+                  toggledOn={isHighlightOwnOffers}
+                  onToggle={(isToggled) => setIsHighlightOwnOffers(isToggled)}
+                  disabled={isLoadingRefresh}
                 />
               </div>
             )}

--- a/src/constants/debugFeatures.ts
+++ b/src/constants/debugFeatures.ts
@@ -9,6 +9,7 @@ interface DebugFeatures {
   allowFeeValuesReset: boolean
   fastThemeToggle: boolean
   enableDemoEarnReport: boolean
+  enableDemoOrderbook: boolean
 }
 
 const devMode = process.env.NODE_ENV === 'development' && process.env.REACT_APP_JAM_DEV_MODE === 'true'
@@ -24,6 +25,7 @@ const debugFeatures: DebugFeatures = {
   allowFeeValuesReset: devMode,
   fastThemeToggle: devMode,
   enableDemoEarnReport: devMode,
+  enableDemoOrderbook: devMode,
 }
 
 type DebugFeature = keyof DebugFeatures

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -607,6 +607,8 @@
     "text_orderbook_filter_count": "{{ filterCount }} entries match given search criteria",
     "label_highlight_own_orders": "Highlight my offers",
     "text_highlight_own_orders_subtitle": "It might take some time for your offer and your bond to appear in your local orderbook.",
+    "label_pin_to_top_own_orders": "Pin my offers",
+    "text_pin_to_top_own_orders_subtitle": "Displays your offers at the top of the table",
     "table": {
       "heading_type": "Type",
       "heading_counterparty": "Counterparty",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -606,6 +606,7 @@
     "placeholder_search": "Search",
     "text_orderbook_filter_count": "{{ filterCount }} entries match given search criteria",
     "label_highlight_own_orders": "Highlight my offers",
+    "text_highlight_own_orders_subtitle": "It might take some time for your offer and your bond to appear in your local orderbook.",
     "table": {
       "heading_type": "Type",
       "heading_counterparty": "Counterparty",


### PR DESCRIPTION
Adds a small hint that it might take some time for an offer to appear in the local order book, e.g. when the maker has just been started recently. This hint will disappear if the current nickname is present in the offer list.



Edit: Screenshots outdated - see below :pray: 

## :camera_flash: 

### Before

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/8658a5b5-45f2-4539-8117-acc43de464d5" width=350 />


### After
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/e4b265dd-da84-48b9-91e5-b4c762373c0d" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/62785104-70a7-4360-9fc4-2bf613d5d26c" width=350 />