### PR TITLE
616: (feat) prevent multiple fidelity bonds with same expiry date

### DIFF
--- a/src/components/fb/FidelityBondSteps.tsx
+++ b/src/components/fb/FidelityBondSteps.tsx
@@ -68,11 +68,11 @@ interface CreatedFidelityBondProps {
   frozenUtxos: Array<Utxo>
 }
 
-const SelectDate = ({ description, yearsRange, disabled, onChange }: SelectDateProps) => {
+const SelectDate = ({ description, yearsRange, disabled, lockDateExists, onChange }: SelectDateProps) => {
   return (
     <div className="d-flex flex-column gap-4">
       <div className={styles.stepDescription}>{description}</div>
-      <LockdateForm yearsRange={yearsRange} onChange={onChange} disabled={disabled} />
+      <LockdateForm yearsRange={yearsRange} lockDateExists={lockDateExists} onChange={onChange} disabled={disabled} />
     </div>
   )
 }

--- a/src/components/fb/FidelityBondSteps.tsx
+++ b/src/components/fb/FidelityBondSteps.tsx
@@ -68,11 +68,11 @@ interface CreatedFidelityBondProps {
   frozenUtxos: Array<Utxo>
 }
 
-const SelectDate = ({ description, yearsRange, disabled, lockDateExists, onChange }: SelectDateProps) => {
+const SelectDate = ({ description, yearsRange, disabled, onChange }: SelectDateProps) => {
   return (
     <div className="d-flex flex-column gap-4">
       <div className={styles.stepDescription}>{description}</div>
-      <LockdateForm yearsRange={yearsRange} lockDateExists={lockDateExists} onChange={onChange} disabled={disabled} />
+      <LockdateForm yearsRange={yearsRange} onChange={onChange} disabled={disabled} />
     </div>
   )
 }

--- a/src/components/fb/LockdateForm.tsx
+++ b/src/components/fb/LockdateForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import * as rb from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
-
+import { useCurrentWalletInfo, Utxos } from '../../context/WalletContext'
 import * as Api from '../../libs/JmWalletApi'
 import * as fb from './utils'
 
@@ -77,12 +77,29 @@ const LockdateForm = ({ onChange, now, yearsRange, disabled }: LockdateFormProps
 
   const [lockdateYear, setLockdateYear] = useState(initialYear)
   const [lockdateMonth, setLockdateMonth] = useState(initialMonth)
+  const [timestamp, setTimestamp] = useState(Date.UTC(lockdateYear, lockdateMonth - 1, 1))
+  const [lockdateExists, setLockdateExists] = useState(false)
 
   const selectableYears = useMemo(() => _selectableYears(_yearsRange, _now), [_yearsRange, _now])
   const selectableMonths = useMemo(
     () => _selectableMonths(lockdateYear, _yearsRange, _now, i18n.resolvedLanguage || i18n.language),
     [lockdateYear, _yearsRange, _now, i18n],
   )
+  const currentWalletInfo = useCurrentWalletInfo()
+  const fidelityBonds = useMemo(() => {
+    return currentWalletInfo?.fidelityBondSummary.fbOutputs || []
+  }, [currentWalletInfo])
+
+  const ifLockTimeExists = (fidelityBonds: Utxos, timestamp: Milliseconds): void => {
+    setLockdateExists(false)
+    // eslint-disable-next-line array-callback-return
+    fidelityBonds.map((fidelityBond) => {
+      const locktime = fb.utxo.getLocktime(fidelityBond)
+      if (locktime === timestamp) {
+        setLockdateExists(true)
+      }
+    })
+  }
 
   const isLockdateYearValid = useMemo(() => selectableYears.includes(lockdateYear), [lockdateYear, selectableYears])
   const isLockdateMonthValid = useMemo(
@@ -96,12 +113,13 @@ const LockdateForm = ({ onChange, now, yearsRange, disabled }: LockdateFormProps
 
   useEffect(() => {
     if (isLockdateYearValid && isLockdateMonthValid) {
-      const timestamp = Date.UTC(lockdateYear, lockdateMonth - 1, 1)
+      setTimestamp(Date.UTC(lockdateYear, lockdateMonth - 1, 1))
+      ifLockTimeExists(fidelityBonds, timestamp)
       onChange(fb.lockdate.fromTimestamp(timestamp))
     } else {
       onChange(null)
     }
-  }, [lockdateYear, lockdateMonth, isLockdateYearValid, isLockdateMonthValid, onChange])
+  }, [lockdateYear, lockdateMonth, isLockdateYearValid, isLockdateMonthValid, timestamp, fidelityBonds, onChange])
 
   return (
     <rb.Container>
@@ -148,6 +166,7 @@ const LockdateForm = ({ onChange, now, yearsRange, disabled }: LockdateFormProps
             </rb.Form.Select>
           </rb.Form.Group>
         </rb.Col>
+        {lockdateExists && <rb.Button>hello</rb.Button>}
       </rb.Row>
     </rb.Container>
   )

--- a/src/components/fb/LockdateForm.tsx
+++ b/src/components/fb/LockdateForm.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useCurrentWalletInfo, Utxos } from '../../context/WalletContext'
 import * as Api from '../../libs/JmWalletApi'
 import * as fb from './utils'
+import Alert from '../Alert'
 
 const monthFormatter = (locales: string) => new Intl.DateTimeFormat(locales, { month: 'long' })
 
@@ -166,7 +167,13 @@ const LockdateForm = ({ onChange, now, yearsRange, disabled }: LockdateFormProps
             </rb.Form.Select>
           </rb.Form.Group>
         </rb.Col>
-        {lockdateExists && <rb.Button>hello</rb.Button>}
+        {lockdateExists && (
+          <Alert
+            className="text-start mt-4"
+            variant="warning"
+            message={<Trans i18nKey="earn.fidelity_bond.select_date.warning_fb_with_same_expiry" />}
+          />
+        )}
       </rb.Row>
     </rb.Container>
   )

--- a/src/components/fb/LockdateForm.tsx
+++ b/src/components/fb/LockdateForm.tsx
@@ -3,7 +3,6 @@ import * as rb from 'react-bootstrap'
 import { Trans, useTranslation } from 'react-i18next'
 import * as Api from '../../libs/JmWalletApi'
 import * as fb from './utils'
-import Alert from '../Alert'
 
 const monthFormatter = (locales: string) => new Intl.DateTimeFormat(locales, { month: 'long' })
 
@@ -61,12 +60,11 @@ export const _selectableYears = (yearsRange: fb.YearsRange, now = new Date()): n
 export interface LockdateFormProps {
   onChange: (lockdate: Api.Lockdate | null) => void
   yearsRange?: fb.YearsRange
-  lockDateExists?: boolean
   now?: Date
   disabled?: boolean
 }
 
-const LockdateForm = ({ onChange, now, yearsRange, lockDateExists, disabled }: LockdateFormProps) => {
+const LockdateForm = ({ onChange, now, yearsRange, disabled }: LockdateFormProps) => {
   const { i18n } = useTranslation()
   const _now = useMemo<Date>(() => now || new Date(), [now])
   const _yearsRange = useMemo<fb.YearsRange>(() => yearsRange || fb.DEFAULT_TIMELOCK_YEARS_RANGE, [yearsRange])
@@ -78,7 +76,6 @@ const LockdateForm = ({ onChange, now, yearsRange, lockDateExists, disabled }: L
 
   const [lockdateYear, setLockdateYear] = useState(initialYear)
   const [lockdateMonth, setLockdateMonth] = useState(initialMonth)
-  const [timestamp, setTimestamp] = useState(Date.UTC(lockdateYear, lockdateMonth - 1, 1))
 
   const selectableYears = useMemo(() => _selectableYears(_yearsRange, _now), [_yearsRange, _now])
   const selectableMonths = useMemo(
@@ -98,12 +95,12 @@ const LockdateForm = ({ onChange, now, yearsRange, lockDateExists, disabled }: L
 
   useEffect(() => {
     if (isLockdateYearValid && isLockdateMonthValid) {
-      setTimestamp(Date.UTC(lockdateYear, lockdateMonth - 1, 1))
+      const timestamp = Date.UTC(lockdateYear, lockdateMonth - 1, 1)
       onChange(fb.lockdate.fromTimestamp(timestamp))
     } else {
       onChange(null)
     }
-  }, [lockdateYear, lockdateMonth, isLockdateYearValid, isLockdateMonthValid, timestamp, onChange])
+  }, [lockdateYear, lockdateMonth, isLockdateYearValid, isLockdateMonthValid, onChange])
 
   return (
     <rb.Container>
@@ -150,13 +147,6 @@ const LockdateForm = ({ onChange, now, yearsRange, lockDateExists, disabled }: L
             </rb.Form.Select>
           </rb.Form.Group>
         </rb.Col>
-        {lockDateExists && (
-          <Alert
-            className="text-start mt-4"
-            variant="warning"
-            message={<Trans i18nKey="earn.fidelity_bond.select_date.warning_fb_with_same_expiry" />}
-          />
-        )}
       </rb.Row>
     </rb.Container>
   )

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -449,7 +449,7 @@
         "form_label_year": "Year",
         "form_label_month": "Month",
         "description": "Fidelity bond expiration date:",
-        "warning_fb_with_same_expiry": "<strong>Warning</strong>: You already have a fidelity bond with same expiry date. We advice you to create a bond with different expiry date as this can create same address as previous one for better privacy. (You can still choose to go with this.)"
+        "warning_fb_with_same_expiry": "<strong>Warning</strong>: You already have a fidelity bond with same expiry date. We advice you to create a bond with different expiry date for better privacy as this can create same address as previous one. (You can still choose to go with this.)"
       },
       "select_jar": {
         "text_primary_button": "Next",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -448,7 +448,8 @@
         "text_secondary_button": "Cancel",
         "form_label_year": "Year",
         "form_label_month": "Month",
-        "description": "Fidelity bond expiration date:"
+        "description": "Fidelity bond expiration date:",
+        "warning_fb_with_same_expiry": "<strong>Warning</strong>: You already have a fidelity bond with same expiry date. We advice you to create a bond with different expiry date as this can create same address as previous one for better privacy. (You can still choose to go with this.)"
       },
       "select_jar": {
         "text_primary_button": "Next",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -449,7 +449,7 @@
         "form_label_year": "Year",
         "form_label_month": "Month",
         "description": "Fidelity bond expiration date:",
-        "warning_fb_with_same_expiry": "<strong>Warning</strong>: You already have a fidelity bond with same expiry date. We advice you to create a bond with different expiry date for better privacy as this can create same address as previous one. (You can still choose to go with this.)"
+        "warning_fb_with_same_expiry": "<strong>Warning</strong>: A fidelity bond with the same expiry date already exists."
       },
       "select_jar": {
         "text_primary_button": "Next",


### PR DESCRIPTION
This PR fixes #616 
Implementation is done in lockdateForm.js component, that shows a warning message while selecting expiry date whenever a user creates a new fidelity bond.
When is warning message displayed? if there already exists fidelity bonds, and a user create a new one. But he selects an expiry date same as in any of the previous bonds. Then the message is displayed warning the user.
