### PR TITLE
fix(Earn): validate offer minsize

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -19,3 +19,7 @@ export const CJ_STATE_MAKER_RUNNING = 1
 export const CJ_STATE_NONE_RUNNING = 2
 
 export const JM_API_AUTH_TOKEN_EXPIRY: Milliseconds = Math.round(0.5 * 60 * 60 * 1_000)
+
+// cap of dusty offer minsizes ("has dusty minsize, capping at 27300")
+// See: https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.9.11/src/jmclient/configure.py#L70 (last check on 2024-04-22 of v0.9.11)
+export const JM_DUST_THRESHOLD = 27_300

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -394,6 +394,8 @@
     "label_min_amount_input": "Minimum amount",
     "placeholder_min_amount_input": "Enter a minimum amount in sats or BTC...",
     "feedback_invalid_min_amount": "Please provide a minimum amount.",
+    "feedback_invalid_min_amount_range": "Please provide a minimum amount in sats between {{ minAmountMin }} and {{ minAmountMax }}.",
+    "feedback_invalid_min_amount_insufficient_funds": "Invalid minimum amount: Insufficient funds available.",
     "button_start": "Start Earning!",
     "button_stop": "Stop",
     "text_starting": "Starting",


### PR DESCRIPTION
Fixes #740.
However, this is a temporary fix to prevent the backend from dying.

There should be a follow-up PR that adds better explanation more prominently.
e.g. similar to the  `CoinjoinRequirementSummary`/`CoinjoinRequirementViolation` alerts on "Jam" and "Send".

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/3f7335c0-42d0-41e5-bf6f-0b379a3b0454" width=350 />
<img src="https://github.com/joinmarket-webui/jam/assets/3358649/28d0ee94-9064-4582-8610-574519f9a900" width=350 />
