### PR TITLE
chore(ui): disable lock button while locking wallet

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -194,6 +194,7 @@ export default function Settings({ wallet, stopWallet }: SettingsProps) {
             variant="outline-dark"
             className={styles['settings-btn']}
             onClick={() => lockWallet({ force: false, navigateTo: routes.walletList })}
+            disabled={lockingWallet}
           >
             {lockingWallet ? (
               <>


### PR DESCRIPTION
Locking the wallet can take some time (sometimes a few seconds, e.g. via Tor). This avoids additional requests being made if the button is clicked while a request is in-flight.

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/28660cf5-b982-4f2d-8b6a-e87c90baa9e5" width=250 />

(It is not totally obvious in the screenshot, but the button is disabled)