### PR TITLE
build(dev-deps): update http-proxy-middleware from v2.0.6 to v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@types/react": "^18.3.2",
         "@types/react-dom": "^18.3.0",
         "conventional-changelog": "^5.1.0",
-        "http-proxy-middleware": "^2.0.6",
+        "http-proxy-middleware": "^3.0.0",
         "husky": "^8.0.3",
         "jest-watch-typeahead": "^2.2.2",
         "jest-websocket-mock": "^2.5.0",
@@ -10885,27 +10885,20 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz",
+      "integrity": "sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==",
       "dev": true,
       "dependencies": {
-        "@types/http-proxy": "^1.17.8",
+        "@types/http-proxy": "^1.17.10",
+        "debug": "^4.3.4",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.5"
       },
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -23255,6 +23248,30 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -31984,16 +32001,17 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz",
+      "integrity": "sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==",
       "dev": true,
       "requires": {
-        "@types/http-proxy": "^1.17.8",
+        "@types/http-proxy": "^1.17.10",
+        "debug": "^4.3.4",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.5"
       }
     },
     "https-proxy-agent": {
@@ -41046,6 +41064,19 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3"
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+          "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+          "dev": true,
+          "requires": {
+            "@types/http-proxy": "^1.17.8",
+            "http-proxy": "^1.18.1",
+            "is-glob": "^4.0.1",
+            "is-plain-obj": "^3.0.0",
+            "micromatch": "^4.0.2"
           }
         },
         "json-schema-traverse": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/react": "^18.3.2",
     "@types/react-dom": "^18.3.0",
     "conventional-changelog": "^5.1.0",
-    "http-proxy-middleware": "^2.0.6",
+    "http-proxy-middleware": "^3.0.0",
     "husky": "^8.0.3",
     "jest-watch-typeahead": "^2.2.2",
     "jest-websocket-mock": "^2.5.0",

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -32,7 +32,8 @@ module.exports = (app) => {
      * - translate header "x-jm-authorization" to "Authorization"
      */
     app.use(
-      createProxyMiddleware(`${PUBLIC_URL}/jmws`, {
+      createProxyMiddleware({
+        pathFilter: `${PUBLIC_URL}/jmws`,
         target: `https://127.0.0.1:${JMWALLETD_WEBSOCKET_PORT}`,
         pathRewrite: { [`^${PUBLIC_URL}/jmws`]: '' },
         changeOrigin: true,
@@ -41,20 +42,24 @@ module.exports = (app) => {
       }),
     )
     app.use(
-      createProxyMiddleware(`${PUBLIC_URL}/api/`, {
+      createProxyMiddleware({
+        pathFilter: `${PUBLIC_URL}/api/`,
         target: `https://127.0.0.1:${JMWALLETD_API_PORT}`,
         pathRewrite: { [`^${PUBLIC_URL}`]: '' },
         changeOrigin: true,
         secure: false,
-        onProxyReq: (proxyReq, req, res) => {
-          if (req.headers['x-jm-authorization']) {
-            proxyReq.setHeader('Authorization', req.headers['x-jm-authorization'])
-          }
+        on: {
+          proxyReq: (proxyReq, req, res) => {
+            if (req.headers['x-jm-authorization']) {
+              proxyReq.setHeader('Authorization', req.headers['x-jm-authorization'])
+            }
+          },
         },
       }),
     )
     app.use(
-      createProxyMiddleware(`${PUBLIC_URL}/obwatch/`, {
+      createProxyMiddleware({
+        pathFilter: `${PUBLIC_URL}/obwatch/`,
         target: `http://127.0.0.1:${JMOBWATCH_PORT}`,
         pathRewrite: { [`^${PUBLIC_URL}/obwatch/`]: '' },
         changeOrigin: true,
@@ -69,7 +74,8 @@ module.exports = (app) => {
      * - proxy all API requests to "Jam API"
      */
     app.use(
-      createProxyMiddleware(`${PUBLIC_URL}/jmws`, {
+      createProxyMiddleware({
+        pathFilter: `${PUBLIC_URL}/jmws`,
         target: `http://127.0.0.1:${JAM_API_PORT}`,
         pathRewrite: { [`^${PUBLIC_URL}`]: '' },
         changeOrigin: true,
@@ -78,7 +84,8 @@ module.exports = (app) => {
       }),
     )
     app.use(
-      createProxyMiddleware(`${PUBLIC_URL}/api/`, {
+      createProxyMiddleware({
+        pathFilter: `${PUBLIC_URL}/api/`,
         target: `http://127.0.0.1:${JAM_API_PORT}`,
         pathRewrite: { [`^${PUBLIC_URL}`]: '' },
         changeOrigin: true,
@@ -86,7 +93,8 @@ module.exports = (app) => {
       }),
     )
     app.use(
-      createProxyMiddleware(`${PUBLIC_URL}/obwatch/`, {
+      createProxyMiddleware({
+        pathFilter: `${PUBLIC_URL}/obwatch/`,
         target: `http://127.0.0.1:${JAM_API_PORT}`,
         pathRewrite: { [`^${PUBLIC_URL}`]: '' },
         changeOrigin: true,
@@ -94,7 +102,8 @@ module.exports = (app) => {
       }),
     )
     app.use(
-      createProxyMiddleware(`${PUBLIC_URL}/jam/`, {
+      createProxyMiddleware({
+        pathFilter: `${PUBLIC_URL}/jam/`,
         target: `http://127.0.0.1:${JAM_API_PORT}`,
         pathRewrite: { [`^${PUBLIC_URL}`]: '' },
         changeOrigin: true,


### PR DESCRIPTION
Resolves #768.

Updates dev dependency `http-proxy-middleware` from `v2.0.6` to `v3.0.0`.
See the migration guide for more information: https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md

## How to test
- checkout branch
- run `npm install`
- run `npm run dev:start` and/or `npm run start`
- verify everything is running properly as before (e.g. create/import a wallet, attempt collaborative transaction, etc.)