### PR TITLE
fix(fb): display error alert in modal

### DIFF
--- a/src/components/fb/CreateFidelityBond.tsx
+++ b/src/components/fb/CreateFidelityBond.tsx
@@ -618,7 +618,6 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
 
   return (
     <div className={styles.container}>
-      {alert && <Alert {...alert} className="mt-0" onClose={() => setAlert(undefined)} />}
       {lockDate && timelockedAddress && selectedJar !== undefined && (
         <PaymentConfirmModal
           isShown={showConfirmInputsModal}
@@ -685,6 +684,7 @@ const CreateFidelityBond = ({ otherFidelityBondExists, wallet, walletInfo, onDon
           <rb.Modal.Title>{t('earn.fidelity_bond.create_fidelity_bond.title')}</rb.Modal.Title>
         </rb.Modal.Header>
         <rb.Modal.Body>
+          {alert && <Alert {...alert} className="mt-0" onClose={() => setAlert(undefined)} />}
           <div className="mb-5">{stepComponent(step)}</div>
           <div className="d-flex flex-column gap-2">
             {!isLoading && primaryButtonText(step) !== null && (


### PR DESCRIPTION
fixes #775 
The alert message has been shifted inside modal.
However I was not able to produce the error locally, so its requested to produce the error locally while reviewing it. and please let know if it works fine.
PS: If anyone gets to know how to produce error, I would love to learn it as well. 