### PR TITLE
ui(wallet): rephrase wallet label from 'unlocked' to 'active'

### DIFF
--- a/src/components/Wallet.test.tsx
+++ b/src/components/Wallet.test.tsx
@@ -90,7 +90,7 @@ describe('<Wallet />', () => {
     )
 
     expect(screen.getByText(walletDisplayName(dummyWalletFileName))).toBeInTheDocument()
-    expect(screen.getByText('wallets.wallet_preview.wallet_unlocked')).toBeInTheDocument()
+    expect(screen.getByText('wallets.wallet_preview.wallet_active')).toBeInTheDocument()
     expect(screen.queryByPlaceholderText('wallets.wallet_preview.placeholder_password')).toBeInTheDocument()
     expect(screen.queryByText('wallets.wallet_preview.button_unlock')).toBeInTheDocument()
     expect(screen.queryByText('wallets.wallet_preview.button_open')).not.toBeInTheDocument()
@@ -107,7 +107,7 @@ describe('<Wallet />', () => {
     )
 
     expect(screen.getByText(walletDisplayName(dummyWalletFileName))).toBeInTheDocument()
-    expect(screen.getByText('wallets.wallet_preview.wallet_unlocked')).toBeInTheDocument()
+    expect(screen.getByText('wallets.wallet_preview.wallet_active')).toBeInTheDocument()
     expect(screen.getByText('wallets.wallet_preview.button_open')).toBeInTheDocument()
     expect(screen.getByText('wallets.wallet_preview.button_lock')).toBeInTheDocument()
     expect(screen.queryByPlaceholderText('wallets.wallet_preview.placeholder_password')).not.toBeInTheDocument()
@@ -123,7 +123,7 @@ describe('<Wallet />', () => {
       }),
     )
 
-    expect(screen.getByText('wallets.wallet_preview.wallet_unlocked')).toBeInTheDocument()
+    expect(screen.getByText('wallets.wallet_preview.wallet_active')).toBeInTheDocument()
     expect(screen.getByText('wallets.wallet_preview.button_lock')).toBeInTheDocument()
 
     const lockWalletButton = screen.getByText('wallets.wallet_preview.button_lock')

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -189,7 +189,7 @@ export default function Wallet({
               </rb.Card.Title>
 
               {isActive ? (
-                <span className="text-success">{t('wallets.wallet_preview.wallet_unlocked')}</span>
+                <span className="text-success">{t('wallets.wallet_preview.wallet_active')}</span>
               ) : (
                 <span className="text-muted">{t('wallets.wallet_preview.wallet_locked')}</span>
               )}

--- a/src/components/Wallets.test.tsx
+++ b/src/components/Wallets.test.tsx
@@ -344,7 +344,7 @@ describe('<Wallets />', () => {
         }),
       )
 
-      expect(screen.getByText('wallets.wallet_preview.wallet_unlocked')).toBeInTheDocument()
+      expect(screen.getByText('wallets.wallet_preview.wallet_active')).toBeInTheDocument()
       expect(screen.getByText('wallets.wallet_preview.button_lock')).toBeInTheDocument()
 
       const lockWalletButton = screen.getByText('wallets.wallet_preview.button_lock')
@@ -393,7 +393,7 @@ describe('<Wallets />', () => {
         }),
       )
 
-      expect(screen.getByText('wallets.wallet_preview.wallet_unlocked')).toBeInTheDocument()
+      expect(screen.getByText('wallets.wallet_preview.wallet_active')).toBeInTheDocument()
       expect(screen.getByText('wallets.wallet_preview.button_lock')).toBeInTheDocument()
 
       const lockWalletButton = screen.getByText('wallets.wallet_preview.button_lock')


### PR DESCRIPTION
This partly reverts a previous change and rephrases the label on wallets that are currently loaded from "unlocked" to "active".

Mainly tries to avoid confusion as mentioned in #774.

## Before

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/7ce06c3b-b6fa-412d-a667-ceb45aa553ca" width=350 />

## After

<img src="https://github.com/joinmarket-webui/jam/assets/3358649/21a44950-5028-43cd-99eb-4bb998dedf3d" width=350 />
