### PR TITLE
fixed amount input field to properly interpret BTC

### DIFF
--- a/src/components/BitcoinAmountInput.test.tsx
+++ b/src/components/BitcoinAmountInput.test.tsx
@@ -102,19 +102,16 @@ describe('<BitcoinAmountInput />', () => {
     })
     const inputElement = screen.getByLabelText('test-label')
 
-    await act(async () => {
-      fireEvent.change(inputElement, { target: { value: '1.0' } })
-      fireEvent.focus(inputElement)
-    })
+    await user.type(inputElement, '1.0')
 
+    expect(inputElement).toHaveFocus()
     expect(inputElement.dataset.value).toBe('100000000')
     expect(inputElement.dataset.displayUnit).toBe('BTC')
     expect(inputElement.dataset.displayValue).toBe(`1.0`)
 
-    await act(async () => {
-      fireEvent.blur(inputElement)
-    })
+    await user.tab()
 
+    expect(inputElement).not.toHaveFocus()
     expect(inputElement.dataset.value).toBe('100000000')
     expect(inputElement.dataset.displayUnit).toBe('BTC')
     expect(inputElement.dataset.displayValue).toBe(`1.00 000 000`)

--- a/src/components/BitcoinAmountInput.test.tsx
+++ b/src/components/BitcoinAmountInput.test.tsx
@@ -1,5 +1,5 @@
 import user from '@testing-library/user-event'
-import { act, fireEvent, render, screen } from '../testUtils'
+import { render, screen } from '../testUtils'
 
 import { noop } from '../utils'
 

--- a/src/components/BitcoinAmountInput.test.tsx
+++ b/src/components/BitcoinAmountInput.test.tsx
@@ -1,5 +1,5 @@
 import user from '@testing-library/user-event'
-import { render, screen } from '../testUtils'
+import { act, fireEvent, render, screen } from '../testUtils'
 
 import { noop } from '../utils'
 
@@ -94,5 +94,29 @@ describe('<BitcoinAmountInput />', () => {
     expect(inputElement.dataset.value).toBe(undefined)
     expect(inputElement.dataset.displayUnit).toBe(undefined)
     expect(inputElement.dataset.displayValue).toBe('')
+  })
+
+  it('amount 1.0 should be interpreted as 1 BTC', async () => {
+    setup({
+      label: 'test-label',
+    })
+    const inputElement = screen.getByLabelText('test-label')
+
+    await act(async () => {
+      fireEvent.change(inputElement, { target: { value: '1.0' } })
+      fireEvent.focus(inputElement)
+    })
+
+    expect(inputElement.dataset.value).toBe('100000000')
+    expect(inputElement.dataset.displayUnit).toBe('BTC')
+    expect(inputElement.dataset.displayValue).toBe(`1.0`)
+
+    await act(async () => {
+      fireEvent.blur(inputElement)
+    })
+
+    expect(inputElement.dataset.value).toBe('100000000')
+    expect(inputElement.dataset.displayUnit).toBe('BTC')
+    expect(inputElement.dataset.displayValue).toBe(`1.00 000 000`)
   })
 })

--- a/src/components/BitcoinAmountInput.tsx
+++ b/src/components/BitcoinAmountInput.tsx
@@ -114,9 +114,9 @@ const BitcoinAmountInput = forwardRef(
               field.onBlur(e)
             }}
             onChange={(e) => {
-              const valueOrNan = parseFloat(e.target.value ?? '')
-
-              if (!isValidNumber(valueOrNan)) {
+              const valueOrNan = e.target.value ?? ''
+              const floatValueOrNan = parseFloat(valueOrNan)
+              if (!isValidNumber(floatValueOrNan)) {
                 form.setFieldValue(
                   field.name,
                   {
@@ -129,10 +129,12 @@ const BitcoinAmountInput = forwardRef(
                 )
                 return
               } else {
-                const value: number = valueOrNan
-
+                const value: number = floatValueOrNan
                 let numberValues: string | undefined
-                const unit = unitFromValue(String(value))
+                const unit =
+                  valueOrNan.includes('.') && parseFloat(valueOrNan)
+                    ? unitFromValue(String(valueOrNan))
+                    : unitFromValue(String(value))
                 if (unit === 'BTC') {
                   const splitted = String(value).split('.')
                   const [integerPart, fractionalPart = ''] = splitted

--- a/src/components/BitcoinAmountInput.tsx
+++ b/src/components/BitcoinAmountInput.tsx
@@ -77,7 +77,6 @@ const BitcoinAmountInput = forwardRef(
             data-display-value={field.value?.displayValue}
             name={field.name}
             autoComplete="off"
-            type={inputType.type}
             inputMode={inputType.inputMode}
             className={classNames('slashed-zeroes', className)}
             value={
@@ -115,6 +114,10 @@ const BitcoinAmountInput = forwardRef(
             }}
             onChange={(e) => {
               const rawUserInputOrEmpty = e.target.value ?? ''
+              const validNumberRegex = /^-?\d*\.?\d*$/
+              if (!validNumberRegex.test(rawUserInputOrEmpty)) {
+                return
+              }
               const floatValueOrNan = parseFloat(rawUserInputOrEmpty)
               if (!isValidNumber(floatValueOrNan)) {
                 form.setFieldValue(

--- a/src/components/BitcoinAmountInput.tsx
+++ b/src/components/BitcoinAmountInput.tsx
@@ -114,8 +114,8 @@ const BitcoinAmountInput = forwardRef(
               field.onBlur(e)
             }}
             onChange={(e) => {
-              const valueOrNan = e.target.value ?? ''
-              const floatValueOrNan = parseFloat(valueOrNan)
+              const rawUserInputOrEmpty = e.target.value ?? ''
+              const floatValueOrNan = parseFloat(rawUserInputOrEmpty)
               if (!isValidNumber(floatValueOrNan)) {
                 form.setFieldValue(
                   field.name,
@@ -132,8 +132,8 @@ const BitcoinAmountInput = forwardRef(
                 const value: number = floatValueOrNan
                 let numberValues: string | undefined
                 const unit =
-                  valueOrNan.includes('.') && parseFloat(valueOrNan)
-                    ? unitFromValue(String(valueOrNan))
+                  rawUserInputOrEmpty.includes('.') && parseFloat(rawUserInputOrEmpty)
+                    ? unitFromValue(String(rawUserInputOrEmpty))
                     : unitFromValue(String(value))
                 if (unit === 'BTC') {
                   const splitted = String(value).split('.')


### PR DESCRIPTION
This PR fixes #799 
Fixed the amount input field to correctly interpret `1.0` as `1 BTC`. Previously, it was incorrectly treated as a much smaller value; for example, entering `0.1` was considered `0.00000001 BTC`.