### PR TITLE
follow-up(PR771): quick freeze/unfreeze

### DIFF
--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -364,7 +364,7 @@
     <symbol id="mixed" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M4 16.8c6.708.082 6.496-10.932 15.96-9.4M16.57 4L20 7.44l-3.432 3.44M16.57 13.2l3.39 3.6-3.39 3.2M4 7.2c6.887-.124 6.381 11.044 15.56 9.6"/>
     </symbol>
-    <symbol id="Unmixed" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <symbol id="unmixed" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M18 17.5H5M15.602 21L19 17.5 15.602 14M18 6.5H5M15.602 10L19 6.5 15.602 3"></path>
     </symbol>
 </svg>

--- a/src/components/Balance.module.css
+++ b/src/components/Balance.module.css
@@ -18,7 +18,7 @@
   --jam-balance-deemphasize-color: #1153b5;
 }
 
-.balance {
+.balanceColor {
   color: var(--jam-balance-color);
 }
 
@@ -53,32 +53,32 @@
   justify-content: center;
 }
 
-.bitcoinAmount .fractionalPart :nth-child(3)::before,
-.bitcoinAmount .fractionalPart :nth-child(6)::before {
+.bitcoinAmountSpacing .fractionalPart :nth-child(3)::before,
+.bitcoinAmountSpacing .fractionalPart :nth-child(6)::before {
   content: '\202F';
 }
 
 /** Integer Part **/
-.bitcoinAmount[data-integer-part-is-zero="true"] .integerPart,
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .integerPart,
 /** Decimal Point **/
-.bitcoinAmount[data-integer-part-is-zero="true"] .decimalPoint,
-.bitcoinAmount[data-fractional-part-starts-with-zero="true"] .decimalPoint,
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .decimalPoint,
+.bitcoinAmountColor[data-fractional-part-starts-with-zero="true"] .decimalPoint,
 /** Fractional Part **/
-.bitcoinAmount[data-integer-part-is-zero="false"] .fractionalPart,
-.bitcoinAmount[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]),
-.bitcoinAmount[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"],
-.bitcoinAmount[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"],
-.bitcoinAmount[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
-.bitcoinAmount[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
-.bitcoinAmount[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
-.bitcoinAmount[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
-.bitcoinAmount[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
+.bitcoinAmountColor[data-integer-part-is-zero="false"] .fractionalPart,
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]),
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"],
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"],
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
+.bitcoinAmountColor[data-integer-part-is-zero="true"] .fractionalPart :nth-child(1):is(span[data-digit="0"]) + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"] + span[data-digit="0"],
 /** Symbol */
-.bitcoinAmount[data-raw-value="0"] + .bitcoinSymbol {
+.bitcoinAmountColor[data-raw-value="0"] + .bitcoinSymbol {
   color: var(--jam-balance-deemphasize-color);
 }
 
-.satsAmount[data-raw-value='0'],
-.satsAmount[data-raw-value='0'] + .satsSymbol {
+.satsAmountColor[data-raw-value='0'],
+.satsAmountColor[data-raw-value='0'] + .satsSymbol {
   color: var(--jam-balance-deemphasize-color);
 }

--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -107,7 +107,7 @@ type SatsBalanceProps = Omit<BalanceComponentProps, 'symbol'> & { value: number 
 
 const SatsBalance = ({ value, colored = true, ...props }: SatsBalanceProps) => {
   return (
-    <BalanceComponent symbol={SAT_SYMBOL} {...props}>
+    <BalanceComponent symbol={SAT_SYMBOL} colored={colored} {...props}>
       <span
         className={classNames(`slashed-zeroes`, { [styles.satsAmountColor]: colored })}
         data-testid="sats-amount"

--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -39,7 +39,7 @@ interface BalanceComponentProps {
   symbol?: JSX.Element
   showSymbol?: boolean
   frozen?: boolean
-  isColorChange?: boolean
+  colored?: boolean
   frozenSymbol?: boolean
 }
 
@@ -47,7 +47,7 @@ const BalanceComponent = ({
   symbol,
   showSymbol = true,
   frozen = false,
-  isColorChange = false,
+  colored = true,
   frozenSymbol = true,
   children,
 }: PropsWithChildren<BalanceComponentProps>) => {
@@ -55,7 +55,7 @@ const BalanceComponent = ({
     <span
       className={classNames('balance-hook', 'd-inline-flex align-items-center', {
         [styles.frozen]: frozen,
-        [styles.balance]: !isColorChange,
+        [styles.balanceColor]: colored,
       })}
     >
       {children}
@@ -69,7 +69,7 @@ const DECIMAL_POINT_CHAR = '.'
 
 type BitcoinBalanceProps = Omit<BalanceComponentProps, 'symbol'> & { value: number }
 
-const BitcoinBalance = ({ value, ...props }: BitcoinBalanceProps) => {
+const BitcoinBalance = ({ value, colored = true, ...props }: BitcoinBalanceProps) => {
   const numberString = formatBtc(value)
   const [integerPart, fractionalPart] = numberString.split(DECIMAL_POINT_CHAR)
 
@@ -78,10 +78,10 @@ const BitcoinBalance = ({ value, ...props }: BitcoinBalanceProps) => {
   const fractionalPartStartsWithZero = fractionPartArray[0] === '0'
 
   return (
-    <BalanceComponent symbol={BTC_SYMBOL} {...props}>
+    <BalanceComponent symbol={BTC_SYMBOL} colored={colored} {...props}>
       <span
-        className={classNames(`slashed-zeroes`, {
-          [styles.bitcoinAmount]: !props.isColorChange,
+        className={classNames(`slashed-zeroes`, styles.bitcoinAmount, styles.bitcoinAmountSpacing, {
+          [styles.bitcoinAmountColor]: colored,
         })}
         data-testid="bitcoin-amount"
         data-integer-part-is-zero={integerPartIsZero}
@@ -105,11 +105,11 @@ const BitcoinBalance = ({ value, ...props }: BitcoinBalanceProps) => {
 
 type SatsBalanceProps = Omit<BalanceComponentProps, 'symbol'> & { value: number }
 
-const SatsBalance = ({ value, ...props }: SatsBalanceProps) => {
+const SatsBalance = ({ value, colored = true, ...props }: SatsBalanceProps) => {
   return (
     <BalanceComponent symbol={SAT_SYMBOL} {...props}>
       <span
-        className={classNames(`slashed-zeroes`, { [styles.satsAmount]: !props.isColorChange })}
+        className={classNames(`slashed-zeroes`, { [styles.satsAmountColor]: colored })}
         data-testid="sats-amount"
         data-raw-value={value}
       >

--- a/src/components/Divider.module.css
+++ b/src/components/Divider.module.css
@@ -1,0 +1,32 @@
+.dividerContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.dividerContainer .dividerLine {
+  margin: 0;
+  width: 50%;
+  flex-grow: 0;
+  flex-shrink: 1;
+}
+
+.dividerContainer .dividerButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 1rem;
+  flex-shrink: 0;
+  flex-grow: 1;
+  color: var(--bs-body-color);
+  cursor: pointer;
+  background-color: transparent;
+  border: 1px solid var(--bs-body-color);
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+}
+
+.dividerContainer .dividerButton:disabled {
+  cursor: not-allowed;
+}

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,0 +1,27 @@
+import * as rb from 'react-bootstrap'
+import classNames from 'classnames'
+import Sprite from './Sprite'
+import styles from './Divider.module.css'
+
+type DividerProps = rb.ColProps & {
+  toggled: boolean
+  onToggle: (current: boolean) => void
+  disabled?: boolean
+  className?: string
+}
+
+export default function Divider({ toggled, onToggle, disabled, className, ...colProps }: DividerProps) {
+  return (
+    <rb.Row className={classNames('d-flex', 'justify-content-center', className)}>
+      <rb.Col xs={12} {...colProps}>
+        <div className={styles.dividerContainer}>
+          <hr className={styles.dividerLine} />
+          <button className={styles.dividerButton} disabled={disabled} onClick={() => onToggle(toggled)}>
+            <Sprite symbol={toggled ? 'caret-up' : 'caret-down'} width="20" height="20" />
+          </button>
+          <hr className={styles.dividerLine} />
+        </div>
+      </rb.Col>
+    </rb.Row>
+  )
+}

--- a/src/components/JarSelectorModal.tsx
+++ b/src/components/JarSelectorModal.tsx
@@ -91,9 +91,15 @@ export default function JarSelectorModal({
       </rb.Modal.Body>
       <rb.Modal.Footer className={styles.modalFooter}>
         <rb.Button variant="light" onClick={cancel} className="d-flex justify-content-center align-items-center">
-          {t('modal.confirm_button_reject')}
+          <Sprite symbol="cancel" width="26" height="26" />
+          <div>{t('modal.confirm_button_reject')}</div>
         </rb.Button>
-        <rb.Button disabled={isConfirming || selectedJar === undefined} variant="dark" onClick={confirm}>
+        <rb.Button
+          disabled={isConfirming || selectedJar === undefined}
+          variant="dark"
+          onClick={confirm}
+          className="flex-1 d-flex justify-content-center align-items-center"
+        >
           {isConfirming ? (
             <>
               <rb.Spinner as="span" animation="border" size="sm" role="status" />

--- a/src/components/MainWalletView.module.css
+++ b/src/components/MainWalletView.module.css
@@ -27,36 +27,3 @@
   width: 100%;
   height: 3.5rem;
 }
-
-.jarsDividerContainer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.jarsDividerContainer .dividerLine {
-  margin: 0;
-  width: 50%;
-  flex-grow: 0;
-  flex-shrink: 1;
-}
-
-.jarsDividerContainer .dividerButton {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 0 1rem;
-  flex-shrink: 0;
-  flex-grow: 1;
-  color: var(--bs-body-color);
-  cursor: pointer;
-  background-color: transparent;
-  border: 1px solid var(--bs-body-color);
-  border-radius: 50%;
-  width: 2rem;
-  height: 2rem;
-}
-
-.jarsDividerContainer .dividerButton:disabled {
-  cursor: not-allowed;
-}

--- a/src/components/MainWalletView.tsx
+++ b/src/components/MainWalletView.tsx
@@ -13,6 +13,7 @@ import { ExtendedLink } from './ExtendedLink'
 import { JarDetailsOverlay } from './jar_details/JarDetailsOverlay'
 import { Jars } from './Jars'
 import styles from './MainWalletView.module.css'
+import Divider from './Divider'
 
 interface WalletHeaderProps {
   walletName: string
@@ -226,21 +227,13 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
             </div>
           </rb.Row>
         </rb.Collapse>
-        <rb.Row className="d-flex justify-content-center">
-          <rb.Col xs={showJars ? 12 : 10} md={showJars ? 12 : 8}>
-            <div className={styles.jarsDividerContainer}>
-              <hr className={styles.dividerLine} />
-              <button
-                className={styles.dividerButton}
-                disabled={serviceInfo?.rescanning}
-                onClick={() => setShowJars((current) => !current)}
-              >
-                <Sprite symbol={showJars ? 'caret-up' : 'caret-down'} width="20" height="20" />
-              </button>
-              <hr className={styles.dividerLine} />
-            </div>
-          </rb.Col>
-        </rb.Row>
+        <Divider
+          toggled={showJars}
+          onToggle={() => setShowJars((current) => !current)}
+          disabled={serviceInfo?.rescanning}
+          xs={showJars ? 12 : 10}
+          md={showJars ? 12 : 8}
+        />
       </div>
     </div>
   )

--- a/src/components/Modal.module.css
+++ b/src/components/Modal.module.css
@@ -8,7 +8,7 @@
   box-shadow: 0px 0px 24px rgba(0, 0, 0, 0.25) !important;
 }
 
-.modal-header {
+.modalHeader {
   display: flex !important;
   justify-content: center !important;
   background-color: transparent !important;
@@ -16,20 +16,20 @@
   padding: 1.25rem 1.25rem 0 1.25rem !important;
 }
 
-.modal-title {
+.modalTitle {
   font-size: 1.3rem !important;
   font-weight: 600 !important;
   color: var(--bs-body-color) !important;
 }
 
-.modal-body {
+.modalBody {
   text-align: center !important;
   font-size: 1rem !important;
   font-weight: 400 !important;
   padding: 0.25rem 1.25rem 1rem 1.25rem !important;
 }
 
-.modal-footer {
+.modalFooter {
   display: flex !important;
   justify-content: center !important;
   gap: 1rem;
@@ -37,7 +37,7 @@
   padding: 1rem 1.25rem 1.25rem 1.25rem !important;
 }
 
-.modal-footer :global .btn {
+.modalFooter :global .btn {
   --bs-btn-border-color: var(--bs-border-color);
   flex-grow: 1;
   min-height: 2.8rem;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,19 +1,18 @@
 import { ReactNode, PropsWithChildren } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
-import styles from './Modal.module.css'
 import Sprite from './Sprite'
+import styles from './Modal.module.css'
 
-type BaseModalProps = {
-  isShown: boolean
-  title: ReactNode | string
-  onCancel: () => void
-  backdrop?: rb.ModalProps['backdrop']
-  size?: rb.ModalProps['size']
-  showCloseButton?: boolean
-  headerClassName?: string
-  titleClassName?: string
-}
+type BaseModalProps = Pick<rb.ModalProps, 'className' | 'backdrop' | 'size'> &
+  Pick<rb.ModalHeaderProps, 'closeButton'> & {
+    isShown: boolean
+    title: ReactNode | string
+    onCancel: () => void
+    headerClassName?: rb.ModalHeaderProps['className']
+    titleClassName?: rb.ModalTitleProps['className']
+  }
+
 const BaseModal = ({
   isShown,
   title,
@@ -21,9 +20,10 @@ const BaseModal = ({
   onCancel,
   size,
   backdrop = 'static',
-  showCloseButton = false,
-  headerClassName,
-  titleClassName,
+  closeButton = false,
+  className = styles.modal,
+  headerClassName = styles.modalHeader,
+  titleClassName = styles.modalTitle,
 }: PropsWithChildren<BaseModalProps>) => {
   return (
     <rb.Modal
@@ -35,10 +35,10 @@ const BaseModal = ({
       animation={true}
       backdrop={backdrop}
       size={size}
-      className={styles.modal}
+      className={className}
     >
-      <rb.Modal.Header className={`${styles['modal-header']} ${headerClassName}`} closeButton={showCloseButton}>
-        <rb.Modal.Title className={`${styles['modal-title']} ${titleClassName}`}>{title}</rb.Modal.Title>
+      <rb.Modal.Header className={headerClassName} closeButton={closeButton}>
+        <rb.Modal.Title className={titleClassName}>{title}</rb.Modal.Title>
       </rb.Modal.Header>
       {children}
     </rb.Modal>
@@ -59,8 +59,8 @@ const InfoModal = ({
 }: PropsWithChildren<InfoModalProps>) => {
   return (
     <BaseModal {...baseModalProps} onCancel={onCancel} backdrop={true}>
-      <rb.Modal.Body className={styles['modal-body']}>{children}</rb.Modal.Body>
-      <rb.Modal.Footer className={styles['modal-footer']}>
+      <rb.Modal.Body className={styles.modalBody}>{children}</rb.Modal.Body>
+      <rb.Modal.Footer className={styles.modalFooter}>
         <rb.Button variant="outline-dark" onClick={() => onSubmit()}>
           {submitButtonText}
         </rb.Button>
@@ -72,7 +72,6 @@ const InfoModal = ({
 export type ConfirmModalProps = BaseModalProps & {
   onConfirm: () => void
   disabled?: boolean
-  confirmVariant?: string
 }
 
 const ConfirmModal = ({
@@ -80,15 +79,14 @@ const ConfirmModal = ({
   onCancel,
   onConfirm,
   disabled = false,
-  confirmVariant = 'outline-dark',
   ...baseModalProps
 }: PropsWithChildren<ConfirmModalProps>) => {
   const { t } = useTranslation()
 
   return (
     <BaseModal {...baseModalProps} onCancel={onCancel}>
-      <rb.Modal.Body className={styles['modal-body']}>{children}</rb.Modal.Body>
-      <rb.Modal.Footer className={styles['modal-footer']}>
+      <rb.Modal.Body className={styles.modalBody}>{children}</rb.Modal.Body>
+      <rb.Modal.Footer className={styles.modalFooter}>
         <rb.Button
           variant="outline-dark"
           onClick={() => onCancel()}
@@ -97,7 +95,7 @@ const ConfirmModal = ({
           <Sprite symbol="cancel" width="26" height="26" />
           <div>{t('modal.confirm_button_reject')}</div>
         </rb.Button>
-        <rb.Button variant={confirmVariant} onClick={() => onConfirm()} disabled={disabled}>
+        <rb.Button variant={'outline-dark'} onClick={() => onConfirm()} disabled={disabled}>
           {t('modal.confirm_button_accept')}
         </rb.Button>
       </rb.Modal.Footer>
@@ -105,4 +103,4 @@ const ConfirmModal = ({
   )
 }
 
-export { InfoModal, ConfirmModal }
+export { BaseModal, InfoModal, ConfirmModal }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -95,7 +95,7 @@ const ConfirmModal = ({
           <Sprite symbol="cancel" width="26" height="26" />
           <div>{t('modal.confirm_button_reject')}</div>
         </rb.Button>
-        <rb.Button variant={'outline-dark'} onClick={() => onConfirm()} disabled={disabled}>
+        <rb.Button variant="outline-dark" onClick={() => onConfirm()} disabled={disabled}>
           {t('modal.confirm_button_accept')}
         </rb.Button>
       </rb.Modal.Footer>

--- a/src/components/Send/AmountInputField.tsx
+++ b/src/components/Send/AmountInputField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import * as rb from 'react-bootstrap'
 import { useField, useFormikContext } from 'formik'
@@ -34,25 +34,6 @@ export const AmountInputField = ({
   const [field] = useField<AmountValue>(name)
   const form = useFormikContext<any>()
   const ref = useRef<HTMLInputElement>(null)
-
-  //Effect to change the field value whenever the sourceJarBalance changes (sourceJarBalance will change when quick freeze/unfreeze is performed or different source jar is selected)
-  useEffect(() => {
-    if (!sourceJarBalance) return
-
-    const currentValue = formatBtcDisplayValue(sourceJarBalance.calculatedAvailableBalanceInSats)
-
-    if (field.value?.isSweep && field.value.displayValue !== currentValue) {
-      form.setFieldValue(
-        field.name,
-        {
-          value: 0,
-          isSweep: true,
-          displayValue: formatBtcDisplayValue(sourceJarBalance.calculatedAvailableBalanceInSats),
-        },
-        true,
-      )
-    }
-  }, [sourceJarBalance, field, form])
 
   return (
     <>

--- a/src/components/Send/ShowUtxos.module.css
+++ b/src/components/Send/ShowUtxos.module.css
@@ -18,10 +18,6 @@
   color: #eb5757 !important;
 }
 
-.subTitle {
-  color: #777777 !important;
-}
-
 .utxoTagDeposit {
   color: #999999;
   border: 1px solid #bbbbbb;

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -10,11 +10,11 @@ import { WalletInfo, Utxo, useCurrentWalletInfo, Utxos } from '../../context/Wal
 import { useSettings, Settings } from '../../context/SettingsContext'
 import Alert from '../Alert'
 import Balance from '../Balance'
+import Divider from '../Divider'
 import { ConfirmModal } from '../Modal'
 import Sprite from '../Sprite'
 import { utxoTags } from '../jar_details/UtxoList'
 import { shortenStringMiddle } from '../../utils'
-import mainStyles from '../MainWalletView.module.css'
 import styles from './ShowUtxos.module.css'
 
 interface ShowUtxosProps {
@@ -41,12 +41,6 @@ interface UtxoListDisplayProps {
   settings: Settings
   showRadioButton: boolean
   showBackgroundColor: boolean
-}
-
-interface DividerProps {
-  toggled: boolean
-  onToggle: (current: boolean) => void
-  className?: string
 }
 
 // Utility function to Identifies Icons
@@ -222,22 +216,6 @@ const UtxoListDisplay = ({
         )}
       </Table>
     </div>
-  )
-}
-
-const Divider = ({ toggled, onToggle, className }: DividerProps) => {
-  return (
-    <rb.Row className={classNames('d-flex justify-content-center', className)}>
-      <rb.Col xs={12}>
-        <div className={mainStyles.jarsDividerContainer}>
-          <hr className={mainStyles.dividerLine} />
-          <button className={mainStyles.dividerButton} onClick={() => onToggle(toggled)}>
-            <Sprite symbol={toggled ? 'caret-up' : 'caret-down'} width="20" height="20" />
-          </button>
-          <hr className={mainStyles.dividerLine} />
-        </div>
-      </rb.Col>
-    </rb.Row>
   )
 }
 

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -179,7 +179,7 @@ const UtxoRow = memo(
             valueString={valueString}
             convertToUnit={settings.unit}
             showBalance={true}
-            isColorChange={true}
+            colored={false}
             frozen={isFrozen}
             frozenSymbol={false}
           />

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -32,7 +32,7 @@ interface ShowUtxosProps {
 interface UtxoRowProps {
   utxo: Utxo
   utxoIndex: number
-  onToggle?: (index: number, isFrozen: boolean) => void
+  onToggle: (index: number, isFrozen: boolean) => void
   isFrozen: boolean
   settings: Settings
   showRadioButton: boolean
@@ -43,7 +43,7 @@ interface UtxoRowProps {
 
 interface UtxoListDisplayProps {
   utxos: Array<Utxo>
-  onToggle?: (index: number, isFrozen: boolean) => void
+  onToggle: (index: number, isFrozen: boolean) => void
   settings: Settings
   showRadioButton: boolean
   showBackgroundColor: boolean
@@ -145,7 +145,7 @@ const UtxoRow = memo(
         className={classNames(rowAndTagClass.row, 'cursor-pointer', {
           'bg-transparent': !showBackgroundColor,
         })}
-        onClick={() => onToggle && onToggle(utxoIndex, frozen)}
+        onClick={() => onToggle(utxoIndex, frozen)}
       >
         {showRadioButton && (
           <Cell>
@@ -154,7 +154,7 @@ const UtxoRow = memo(
               type="checkbox"
               checked={checked}
               onChange={() => {
-                onToggle && onToggle(utxoIndex, isFrozen)
+                onToggle(utxoIndex, isFrozen)
               }}
               className={classNames(isFrozen ? styles.squareFrozenToggleButton : styles.squareToggleButton, {
                 [styles.selected]: checked,

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -68,9 +68,6 @@ const formatConfirmations = (conf: number) => {
   return { symbol: 'confs-full', confirmations: conf }
 }
 
-// Utility function to convert Satoshi to Bitcoin
-const satsToBtc = (sats: number) => (sats / 100000000).toFixed(8)
-
 // Utility function to Identifies Icons
 const utxoIcon = (tag: string, isFrozen: boolean) => {
   if (isFrozen && tag === 'bond') return 'timelock'
@@ -107,7 +104,6 @@ const UtxoRow = memo(
 
     const address = useMemo(() => shortenStringMiddle(utxoAddress, 16), [utxoAddress])
     const conf = useMemo(() => formatConfirmations(confirmations), [confirmations])
-    const valueString = useMemo(() => satsToBtc(value).toString(), [value])
     const tag = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
 
     const { icon, rowAndTagClass } = useMemo(() => {
@@ -176,7 +172,7 @@ const UtxoRow = memo(
         </Cell>
         <Cell>
           <Balance
-            valueString={valueString}
+            valueString={String(value)}
             convertToUnit={settings.unit}
             showBalance={true}
             colored={false}

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -39,7 +39,6 @@ interface UtxoListDisplayProps {
   utxos: SelectableUtxo[]
   onToggle: (utxo: SelectableUtxo) => void
   settings: Settings
-  showRadioButton: boolean
   showBackgroundColor: boolean
 }
 
@@ -162,27 +161,19 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
   )
 }
 
-const UtxoListDisplay = ({
-  utxos,
-  onToggle,
-  settings,
-  showRadioButton = true,
-  showBackgroundColor = true,
-}: UtxoListDisplayProps) => {
+const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true }: UtxoListDisplayProps) => {
   const { t } = useTranslation()
   const walletInfo = useCurrentWalletInfo()
 
-  //Table theme to manage view
   const TABLE_THEME = {
     Table: `
-    font-size: ${showRadioButton ? '1rem' : '0.87rem'};
-    --data-table-library_grid-template-columns: ${showRadioButton ? '3.5rem 2.5rem 12rem 2fr 3fr 10rem ' : '2.5rem 10rem 5fr 3fr 7.5rem'};
+    --data-table-library_grid-template-columns: 3.5rem 2.5rem 12rem 2fr 3fr 10rem;
     @media only screen and (min-width: 768px) {
-      --data-table-library_grid-template-columns: ${showRadioButton ? '3.5rem 2.5rem 14rem 5fr 3fr 10rem' : '2.5rem 11rem 5fr 3fr 7.5rem'};
+      --data-table-library_grid-template-columns: 3.5rem 2.5rem 14rem 5fr 3fr 10rem};
     }
   `,
     BaseCell: `
-    padding:${showRadioButton ? '0.5rem' : '0.55rem'} 0.35rem !important;
+    padding: 0.35rem 0.25rem !important;
     margin: 0.15rem 0px !important;
   `,
   }
@@ -291,7 +282,6 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
                   )
                 }}
                 settings={settings}
-                showRadioButton={true}
                 showBackgroundColor={true}
               />
             </rb.Row>
@@ -312,7 +302,6 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
                     )
                   }}
                   settings={settings}
-                  showRadioButton={true}
                   showBackgroundColor={true}
                 />
               </rb.Row>

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -224,7 +224,6 @@ type SelectableUtxo = Utxo & { checked: boolean; selectable: boolean }
 const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: ShowUtxosProps) => {
   const { t } = useTranslation()
   const settings = useSettings()
-  const [showFrozenUtxos, setShowFrozenUtxos] = useState(false)
 
   const [upperUtxos, setUpperUtxos] = useState<SelectableUtxo[]>(
     utxos
@@ -252,13 +251,7 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
     () => [...upperUtxos, ...lowerUtxos].filter((it) => it.checked),
     [upperUtxos, lowerUtxos],
   )
-
-  //Effect to hide the Divider line when there is no unFrozen-UTXOs present
-  useEffect(() => {
-    if (upperUtxos.length === 0 && lowerUtxos.length > 0) {
-      setShowFrozenUtxos(true)
-    }
-  }, [upperUtxos.length, lowerUtxos.length])
+  const [showFrozenUtxos, setShowFrozenUtxos] = useState(upperUtxos.length === 0 && lowerUtxos.length > 0)
 
   return (
     <ConfirmModal
@@ -276,7 +269,7 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
       {!isLoading ? (
         <>
           <div className={classNames(styles.subTitle, 'm-3 mb-4 text-start')}>
-            {upperUtxos.length !== 0
+            {upperUtxos.length > 0
               ? t('show_utxos.show_utxo_subtitle')
               : t('show_utxos.show_utxo_subtitle_when_allutxos_are_frozen')}
           </div>

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -27,8 +27,8 @@ interface ShowUtxosProps {
 }
 
 interface UtxoRowProps {
-  utxo: SelectableUtxo
-  onToggle: (utxo: SelectableUtxo) => void
+  utxo: SelectableUtxoTableRowData
+  onToggle: (utxo: SelectableUtxoTableRowData) => void
   settings: Settings
   showBackgroundColor: boolean
   walletInfo: WalletInfo
@@ -161,6 +161,11 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
   )
 }
 
+type SelectableUtxoTableRowData = SelectableUtxo & {
+  // TODO: add "tags" here and remove from "Utxo" type
+  // tags?: { tag: string; color: string }[]
+} & Pick<TableTypes.TableNode, 'id'>
+
 const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true }: UtxoListDisplayProps) => {
   const { t } = useTranslation()
   const walletInfo = useCurrentWalletInfo()
@@ -179,18 +184,26 @@ const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true
   }
   const tableTheme = useTheme(TABLE_THEME)
 
+  const tableData: TableTypes.Data<SelectableUtxoTableRowData> = useMemo(
+    () => ({
+      nodes: utxos.map(
+        (utxo: Utxo) =>
+          ({
+            ...utxo,
+            id: utxo.utxo,
+          }) as SelectableUtxoTableRowData,
+      ),
+    }),
+    [utxos],
+  )
+
   return (
     <div className={classNames(styles.utxoListDisplayHeight, 'overflow-y-auto')}>
-      <Table
-        className="bg"
-        data={{ nodes: utxos }}
-        theme={tableTheme}
-        layout={{ custom: true, horizontalScroll: true }}
-      >
-        {(utxosList: TableTypes.TableProps<SelectableUtxo>) => (
+      <Table className="bg" data={tableData} theme={tableTheme} layout={{ custom: true, horizontalScroll: true }}>
+        {(utxosList: TableTypes.TableProps<SelectableUtxoTableRowData>) => (
           <Body>
             {walletInfo &&
-              utxosList.map((utxo: SelectableUtxo, index: number) => {
+              utxosList.map((utxo: SelectableUtxoTableRowData, index: number) => {
                 return (
                   <UtxoRow
                     key={index}

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -6,14 +6,13 @@ import classNames from 'classnames'
 import { Table, Body, Row, Cell } from '@table-library/react-table-library/table'
 import { useTheme } from '@table-library/react-table-library/theme'
 import * as TableTypes from '@table-library/react-table-library/types/table'
-import { WalletInfo, Utxo, useCurrentWalletInfo } from '../../context/WalletContext'
+import { WalletInfo, Utxo, useCurrentWalletInfo, Utxos } from '../../context/WalletContext'
 import { useSettings, Settings } from '../../context/SettingsContext'
 import Alert from '../Alert'
 import Balance from '../Balance'
 import { ConfirmModal } from '../Modal'
 import Sprite from '../Sprite'
 import { utxoTags } from '../jar_details/UtxoList'
-import { UtxoList } from './SourceJarSelector'
 import { shortenStringMiddle } from '../../utils'
 import mainStyles from '../MainWalletView.module.css'
 import styles from './ShowUtxos.module.css'
@@ -24,10 +23,10 @@ interface ShowUtxosProps {
   onConfirm: () => void
   alert: SimpleAlert | undefined
   isLoading: boolean
-  frozenUtxos: UtxoList
-  unFrozenUtxos: UtxoList
-  setFrozenUtxos: (arg: UtxoList) => void
-  setUnFrozenUtxos: (arg: UtxoList) => void
+  frozenUtxos: Utxos
+  unFrozenUtxos: Utxos
+  setFrozenUtxos: (arg: Utxos) => void
+  setUnFrozenUtxos: (arg: Utxos) => void
 }
 
 interface UtxoRowProps {

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -13,9 +13,10 @@ import Balance from '../Balance'
 import { ConfirmModal } from '../Modal'
 import Sprite from '../Sprite'
 import { utxoTags } from '../jar_details/UtxoList'
+import { UtxoList } from './SourceJarSelector'
+import { shortenStringMiddle } from '../../utils'
 import mainStyles from '../MainWalletView.module.css'
 import styles from './ShowUtxos.module.css'
-import { UtxoList } from './SourceJarSelector'
 
 interface ShowUtxosProps {
   isOpen: boolean
@@ -54,9 +55,6 @@ interface DividerProps {
   setIsState: (arg: boolean) => void
   className?: string
 }
-
-// Utility function to format Bitcoin address
-const formatAddress = (address: string) => `${address.slice(0, 10)}...${address.slice(-8)}`
 
 // Utility function to format the confirmations
 const formatConfirmations = (conf: number) => {
@@ -106,7 +104,7 @@ const UtxoRow = memo(
   }: UtxoRowProps) => {
     const { address: utxoAddress, confirmations, value, checked, frozen } = utxo
 
-    const address = useMemo(() => formatAddress(utxoAddress), [utxoAddress])
+    const address = useMemo(() => shortenStringMiddle(utxoAddress, 16), [utxoAddress])
     const conf = useMemo(() => formatConfirmations(confirmations), [confirmations])
     const valueString = useMemo(() => satsToBtc(value).toString(), [value])
     const tag = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -75,9 +75,10 @@ const satsToBtc = (sats: number) => (sats / 100000000).toFixed(8)
 const utxoIcon = (tag: string, isFrozen: boolean) => {
   if (isFrozen && tag === 'bond') return 'timelock'
   if (isFrozen) return 'snowflake'
-  if (tag === 'deposit' || tag === 'non-cj-change' || tag === 'reused') return 'Unmixed'
   if (tag === 'bond') return 'timelock'
-  return 'mixed'
+  if (tag === 'cj-out') return 'mixed'
+  if (tag === 'deposit' || tag === 'non-cj-change' || tag === 'reused') return 'unmixed'
+  return 'unmixed' // fallback
 }
 
 // Utility function to allot classes
@@ -111,7 +112,7 @@ const UtxoRow = memo(
 
     const { icon, rowAndTagClass } = useMemo(() => {
       if (tag.length === 0) {
-        return { icon: 'Unmixed', rowAndTagClass: { row: styles.depositUtxo, tag: styles.utxoTagDeposit } }
+        return { icon: 'unmixed', rowAndTagClass: { row: styles.depositUtxo, tag: styles.utxoTagDeposit } }
       }
       return { icon: utxoIcon(tag[0].tag, isFrozen), rowAndTagClass: allotClasses(tag[0].tag, isFrozen) }
     }, [tag, isFrozen])

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -276,11 +276,11 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
           </div>
         ) : (
           <>
-            <div className={classNames(styles.subTitle, 'm-3 mb-4')}>
+            <rb.Row className="text-secondary px-3 mb-2">
               {upperUtxos.length > 0
                 ? t('show_utxos.show_utxo_subtitle')
                 : t('show_utxos.show_utxo_subtitle_when_allutxos_are_frozen')}
-            </div>
+            </rb.Row>
             {alert && (
               <rb.Row>
                 <Alert variant={alert.variant} message={alert.message} />
@@ -326,12 +326,17 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
         <rb.Button
           variant="light"
           onClick={() => onCancel()}
-          className="d-flex justify-content-center align-items-center flex-grow-1"
+          className="d-flex flex-1 justify-content-center align-items-center"
         >
           <Sprite symbol="cancel" width="26" height="26" />
           <div>{t('modal.confirm_button_reject')}</div>
         </rb.Button>
-        <rb.Button className="flex-grow-1" variant="dark" onClick={() => onConfirm(selectedUtxos)} disabled={isLoading}>
+        <rb.Button
+          variant="dark"
+          onClick={() => onConfirm(selectedUtxos)}
+          disabled={isLoading}
+          className="d-flex flex-1 justify-content-center align-items-center"
+        >
           {t('modal.confirm_button_accept')}
         </rb.Button>
       </rb.Modal.Footer>

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -170,7 +170,7 @@ const UtxoRow = memo(
         <Cell>
           <Sprite symbol={icon} width="23px" height="23px" />
         </Cell>
-        <Cell>{address}</Cell>
+        <Cell className="slashed-zeroes">{address}</Cell>
         <Cell>
           <ConfirmationCell />
         </Cell>
@@ -224,7 +224,7 @@ const UtxoListDisplay = ({
   return (
     <div className={classNames(styles.utxoListDisplayHeight, 'overflow-y-auto')}>
       <Table
-        className={'bg'}
+        className="bg"
         data={{ nodes: utxos }}
         theme={tableTheme}
         layout={{ custom: true, horizontalScroll: true }}
@@ -327,7 +327,7 @@ const ShowUtxos = ({
       title={t('show_utxos.show_utxo_title')}
       size="lg"
       showCloseButton={true}
-      confirmVariant={'dark'}
+      confirmVariant="dark"
       headerClassName={styles.customHeaderClass}
       titleClassName={styles.customTitleClass}
     >

--- a/src/components/Send/SourceJarSelector.tsx
+++ b/src/components/Send/SourceJarSelector.tsx
@@ -3,7 +3,7 @@ import { useField, useFormikContext } from 'formik'
 import * as rb from 'react-bootstrap'
 import { jarFillLevel, SelectableJar } from '../jars/Jar'
 import { noop } from '../../utils'
-import { WalletInfo, CurrentWallet, useReloadCurrentWalletInfo, Utxo } from '../../context/WalletContext'
+import { WalletInfo, CurrentWallet, useReloadCurrentWalletInfo, Utxo, Utxos } from '../../context/WalletContext'
 import styles from './SourceJarSelector.module.css'
 import { ShowUtxos } from './ShowUtxos'
 import { useTranslation } from 'react-i18next'
@@ -25,8 +25,6 @@ interface ShowUtxosProps {
   isOpen: boolean
 }
 
-export type UtxoList = Utxo[]
-
 export const SourceJarSelector = ({
   name,
   label,
@@ -44,8 +42,8 @@ export const SourceJarSelector = ({
   const [showUtxos, setShowUtxos] = useState<ShowUtxosProps>()
   const [alert, setAlert] = useState<SimpleAlert>()
   const [isUtxosLoading, setIsUtxosLoading] = useState<boolean>(false)
-  const [unFrozenUtxos, setUnFrozenUtxos] = useState<UtxoList>([])
-  const [frozenUtxos, setFrozenUtxos] = useState<UtxoList>([])
+  const [unFrozenUtxos, setUnFrozenUtxos] = useState<Utxos>([])
+  const [frozenUtxos, setFrozenUtxos] = useState<Utxos>([])
 
   const jarBalances = useMemo(() => {
     if (!walletInfo) return []

--- a/src/components/Send/SourceJarSelector.tsx
+++ b/src/components/Send/SourceJarSelector.tsx
@@ -102,22 +102,21 @@ export const SourceJarSelector = ({
       .map((utxo) => ({ utxo: utxo.utxo, freeze: true }))
 
     try {
+      setIsUtxosLoading(true)
       const res = await Promise.all([
         ...frozenUtxosToUpdate.map((utxo) => Api.postFreeze({ ...wallet, signal: abortCtrl.signal }, utxo)),
         ...unFrozenUtxosToUpdate.map((utxo) => Api.postFreeze({ ...wallet, signal: abortCtrl.signal }, utxo)),
       ])
 
       if (res.length !== 0) {
-        setIsUtxosLoading(true)
         await reloadCurrentWalletInfo.reloadUtxos({ signal: abortCtrl.signal })
       }
 
       setShowUtxos(undefined)
+      setIsUtxosLoading(false)
     } catch (err: any) {
-      if (!abortCtrl.signal.aborted) {
-        setAlert({ variant: 'danger', message: err.message, dismissible: true })
-      }
-    } finally {
+      if (abortCtrl.signal.aborted) return
+      setAlert({ variant: 'danger', message: err.message, dismissible: true })
       setIsUtxosLoading(false)
     }
   }, [frozenUtxos, unFrozenUtxos, wallet, reloadCurrentWalletInfo])

--- a/src/components/Send/SourceJarSelector.tsx
+++ b/src/components/Send/SourceJarSelector.tsx
@@ -21,8 +21,8 @@ export type SourceJarSelectorProps = {
 }
 
 interface ShowUtxosProps {
-  jarIndex?: string
-  isOpen?: boolean
+  jarIndex: JarIndex
+  isOpen: boolean
 }
 
 export type UtxoList = Utxo[]
@@ -41,8 +41,8 @@ export const SourceJarSelector = ({
   const form = useFormikContext<any>()
   const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
 
-  const [showUtxos, setShowUtxos] = useState<ShowUtxosProps | undefined>(undefined)
-  const [alert, setAlert] = useState<SimpleAlert | undefined>(undefined)
+  const [showUtxos, setShowUtxos] = useState<ShowUtxosProps>()
+  const [alert, setAlert] = useState<SimpleAlert>()
   const [isUtxosLoading, setIsUtxosLoading] = useState<boolean>(false)
   const [unFrozenUtxos, setUnFrozenUtxos] = useState<UtxoList>([])
   const [frozenUtxos, setFrozenUtxos] = useState<UtxoList>([])
@@ -55,16 +55,15 @@ export const SourceJarSelector = ({
   }, [walletInfo])
 
   useEffect(() => {
-    if (showUtxos?.jarIndex && walletInfo?.utxosByJar) {
-      const data = Object.entries(walletInfo.utxosByJar).find(([key]) => key === showUtxos.jarIndex)
-      const utxos: any = data ? data[1] : []
+    if (walletInfo?.utxosByJar && showUtxos && showUtxos.jarIndex >= 0) {
+      const utxos = walletInfo.utxosByJar[showUtxos.jarIndex]
 
       const frozenUtxoList = utxos
-        .filter((utxo: any) => utxo.frozen)
-        .map((utxo: any) => ({ ...utxo, id: utxo.utxo, checked: false }))
+        .filter((utxo) => utxo.frozen)
+        .map((utxo) => ({ ...utxo, id: utxo.utxo, checked: false }))
       const unFrozenUtxosList = utxos
-        .filter((utxo: any) => !utxo.frozen)
-        .map((utxo: any) => ({ ...utxo, id: utxo.utxo, checked: true }))
+        .filter((utxo) => !utxo.frozen)
+        .map((utxo) => ({ ...utxo, id: utxo.utxo, checked: true }))
 
       setFrozenUtxos(frozenUtxoList)
       setUnFrozenUtxos(unFrozenUtxosList)
@@ -133,7 +132,7 @@ export const SourceJarSelector = ({
           <div className={styles.sourceJarsContainer}>
             {showUtxos?.isOpen && (
               <ShowUtxos
-                isOpen={showUtxos.isOpen}
+                isOpen={true}
                 onConfirm={handleUtxosFrozenState}
                 onCancel={() => {
                   setShowUtxos(undefined)
@@ -171,7 +170,7 @@ export const SourceJarSelector = ({
                         it.calculatedTotalBalanceInSats > 0
                       ) {
                         setShowUtxos({
-                          jarIndex: it.accountIndex.toString(),
+                          jarIndex: it.accountIndex,
                           isOpen: true,
                         })
                       }

--- a/src/components/Send/SourceJarSelector.tsx
+++ b/src/components/Send/SourceJarSelector.tsx
@@ -53,7 +53,7 @@ export const SourceJarSelector = ({
   }, [walletInfo])
 
   useEffect(() => {
-    if (walletInfo?.utxosByJar && showUtxos && showUtxos.jarIndex >= 0) {
+    if (walletInfo?.utxosByJar && showUtxos?.jarIndex !== undefined) {
       const utxos = walletInfo.utxosByJar[showUtxos.jarIndex]
 
       const frozenUtxoList = utxos

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -156,7 +156,7 @@ const toUtxo = (tableNode: TableTypes.TableNode): Utxo => {
   return utxo as Utxo
 }
 
-interface UtxoTableRow extends Utxo {
+interface UtxoTableRow extends Utxo, TableTypes.TableNode {
   _icon: JSX.Element
   _tags: Tag[]
   _confs: JSX.Element

--- a/src/components/settings/FeeConfigModal.module.css
+++ b/src/components/settings/FeeConfigModal.module.css
@@ -33,7 +33,6 @@
 
 .modalFooter .buttonContainer :global .btn {
   flex-grow: 1;
-  min-height: 2.8rem;
   font-weight: 500;
   border-color: none !important;
 }

--- a/src/components/settings/FeeConfigModal.tsx
+++ b/src/components/settings/FeeConfigModal.tsx
@@ -10,9 +10,9 @@ import { useUpdateConfigValues } from '../../context/ServiceConfigContext'
 import { isDebugFeatureEnabled } from '../../constants/debugFeatures'
 import ToggleSwitch from '../ToggleSwitch'
 import { isValidNumber, factorToPercentage, percentageToFactor } from '../../utils'
-import styles from './FeeConfigModal.module.css'
 import BitcoinAmountInput, { AmountValue, toAmountValue } from '../BitcoinAmountInput'
 import { JM_MAX_SWEEP_FEE_CHANGE_DEFAULT } from '../../constants/config'
+import styles from './FeeConfigModal.module.css'
 
 const __dev_allowFeeValuesReset = isDebugFeatureEnabled('allowFeeValuesReset')
 

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -53,8 +53,7 @@ export type Utxo = {
   // `locktime` in format "yyyy-MM-dd 00:00:00"
   // NOTE: it is unparsable with safari Date constructor
   locktime?: string
-  id: string
-  checked?: boolean
+  // TODO: remove 'tags' prop
   tags?: { tag: string; color: string }[]
 }
 
@@ -195,7 +194,6 @@ export const groupByJar = (utxos: Utxos): UtxosByJar => {
   return utxos.reduce((res, utxo) => {
     const { mixdepth } = utxo
     res[mixdepth] = res[mixdepth] || []
-    utxo.id = utxo.utxo
     res[mixdepth].push(utxo)
     return res
   }, {} as UtxosByJar)

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -706,9 +706,6 @@
     "selected_utxos": "Selected UTXOs",
     "show_utxo_title": "Select UTXOs to be considered",
     "show_utxo_subtitle": "The following UTXOs are considered in the transaction. Every unselected UTXO will be frozen and can be unfrozen later on.",
-    "show_utxo_subtitle_when_allutxos_are_frozen": "The following UTXOs are frozen. Please select them to be considered in the transaction.",
-    "alert_for_unfreeze_utxos": "At least one UTXO is required to perform a transaction",
-    "alert_for_time_locked": "Selected UTXO is Time Locked till",
-    "alert_for_empty_utxos": "Please Unfreeze UTXOs to send"
+    "show_utxo_subtitle_when_allutxos_are_frozen": "The following UTXOs are frozen. Please select them to be considered in the transaction."
   }
 }


### PR DESCRIPTION
Follow-up to #771.

TBD.

Still TODO:
- [x] Handle frozen/unfrozen expired/non-expired fidelity bonds correctly
- [x] Handle bond tags correctly (i.e. not using the translated display string for identification)
- [x] `ShowUtxos` should not use `ConfirmModal` (instead use an own/new distinct modal component?)
- [ ] Should `ShowUtxos` refactored to be external to `SourceJarSelector`?
- [ ] Rename `ShowUtxos` -> `QuickFreezeUtxoModal`?
- [ ] etc.