### PR TITLE
feat: add SchedulerConfirmationModal component for starting scheduled sweep

### DIFF
--- a/src/components/Jam.tsx
+++ b/src/components/Jam.tsx
@@ -18,6 +18,7 @@ import FeeConfigModal from './settings/FeeConfigModal'
 
 import styles from './Jam.module.css'
 import { useFeeConfigValues } from '../hooks/Fees'
+import SchedulerConfirmationModal from './SchedulerConfirmationModal'
 
 const DEST_ADDRESS_COUNT_PROD = 3
 const DEST_ADDRESS_COUNT_TEST = 1
@@ -536,7 +537,7 @@ export default function Jam({ wallet }: JamProps) {
 
                           <p className="text-secondary mb-4">{t('scheduler.description_fees')}</p>
 
-                          <rb.Button
+                          {/* <rb.Button
                             className="w-100 mb-4"
                             variant="dark"
                             size="lg"
@@ -547,7 +548,11 @@ export default function Jam({ wallet }: JamProps) {
                               {t('scheduler.button_start')}
                               <Sprite symbol="caret-right" width="24" height="24" className="ms-1" />
                             </div>
-                          </rb.Button>
+                          </rb.Button> */}
+                          <SchedulerConfirmationModal
+                            onConfirm={handleSubmit}
+                            disabled={isOperationDisabled || isSubmitting || !isValid}
+                          />
                         </rb.Form>
                       </>
                     )}

--- a/src/components/Jam.tsx
+++ b/src/components/Jam.tsx
@@ -536,19 +536,6 @@ export default function Jam({ wallet }: JamProps) {
                           })}
 
                           <p className="text-secondary mb-4">{t('scheduler.description_fees')}</p>
-
-                          {/* <rb.Button
-                            className="w-100 mb-4"
-                            variant="dark"
-                            size="lg"
-                            type="submit"
-                            disabled={isOperationDisabled || isSubmitting || !isValid}
-                          >
-                            <div className="d-flex justify-content-center align-items-center">
-                              {t('scheduler.button_start')}
-                              <Sprite symbol="caret-right" width="24" height="24" className="ms-1" />
-                            </div>
-                          </rb.Button> */}
                           <SchedulerConfirmationModal
                             onConfirm={handleSubmit}
                             disabled={isOperationDisabled || isSubmitting || !isValid}

--- a/src/components/SchedulerConfirmationModal.module.css
+++ b/src/components/SchedulerConfirmationModal.module.css
@@ -1,0 +1,6 @@
+.modalFooter :global(.btn) {
+  flex-grow: 1;
+  min-height: 2.8rem;
+  font-weight: 500;
+  border-color: none !important;
+}

--- a/src/components/SchedulerConfirmationModal.module.css
+++ b/src/components/SchedulerConfirmationModal.module.css
@@ -1,6 +1,54 @@
-.modalFooter :global(.btn) {
+:global .modal-backdrop {
+  background-color: rgba(0, 0, 0, 0.5) !important;
+}
+
+.modal :global .modal-content {
+  background-color: var(--bs-body-bg) !important;
+  border-radius: 1rem !important;
+  box-shadow: 0px 0px 24px rgba(0, 0, 0, 0.25) !important;
+}
+
+.modalHeader {
+  display: flex !important;
+  justify-content: flex-start !important;
+  background-color: transparent !important;
+  padding: 1.25rem !important;
+}
+
+.modalTitle {
+  width: 100%;
+  font-size: 1rem !important;
+  font-weight: 400 !important;
+  color: var(--bs-body-color) !important;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modalTitle .cancelButton {
+  padding: 0 0 0 1rem;
+  color: var(--bs-body-color);
+  background-color: transparent !important;
+  border: none;
+}
+
+.modalFooter {
+  display: flex !important;
+  justify-content: center !important;
+  gap: 1rem;
+  background-color: transparent !important;
+  padding: 1rem 1.25rem 1.25rem 1.25rem !important;
+}
+
+.modalFooter :global .btn {
   flex-grow: 1;
   min-height: 2.8rem;
   font-weight: 500;
   border-color: none !important;
+}
+
+@media only screen and (min-width: 768px) {
+  .jarsContainer {
+    gap: 1.5rem;
+  }
 }

--- a/src/components/SchedulerConfirmationModal.module.css
+++ b/src/components/SchedulerConfirmationModal.module.css
@@ -1,13 +1,3 @@
-:global .modal-backdrop {
-  background-color: rgba(0, 0, 0, 0.5) !important;
-}
-
-.modal :global .modal-content {
-  background-color: var(--bs-body-bg) !important;
-  border-radius: 1rem !important;
-  box-shadow: 0px 0px 24px rgba(0, 0, 0, 0.25) !important;
-}
-
 .modalHeader {
   display: flex !important;
   justify-content: flex-start !important;
@@ -25,30 +15,7 @@
   align-items: center;
 }
 
-.modalTitle .cancelButton {
-  padding: 0 0 0 1rem;
-  color: var(--bs-body-color);
-  background-color: transparent !important;
-  border: none;
-}
-
-.modalFooter {
-  display: flex !important;
-  justify-content: center !important;
-  gap: 1rem;
-  background-color: transparent !important;
-  padding: 1rem 1.25rem 1.25rem 1.25rem !important;
-}
-
-.modalFooter :global .btn {
-  flex-grow: 1;
-  min-height: 2.8rem;
-  font-weight: 500;
-  border-color: none !important;
-}
-
-@media only screen and (min-width: 768px) {
-  .jarsContainer {
-    gap: 1.5rem;
-  }
+.modalBody {
+  color: var(--bs-body-color) !important;
+  text-align: left !important;
 }

--- a/src/components/SchedulerConfirmationModal.tsx
+++ b/src/components/SchedulerConfirmationModal.tsx
@@ -25,18 +25,29 @@ export default function SchedulerConfirmationModal({ onConfirm, disabled }: Sche
         </div>
       </rb.Button>
 
-      <rb.Modal show={show} onHide={handleClose} dialogClassName={styles['modal']}>
-        <rb.Modal.Header closeButton>
-          <rb.Modal.Title>
+      <rb.Modal
+        show={show}
+        keyboard={true}
+        onEscapeKeyDown={handleClose}
+        onHide={handleClose}
+        centered={true}
+        className={styles['modal']}
+        size="lg"
+      >
+        <rb.Modal.Header className={styles['modalHeader']}>
+          <rb.Modal.Title className={styles['modalTitle']}>
             <div>{t('scheduler.confirm_modal.title')}</div>
+            <rb.Button onClick={handleClose} className={styles['cancelButton']}>
+              <Sprite symbol="cancel" width="26" height="26" />
+            </rb.Button>
           </rb.Modal.Title>
         </rb.Modal.Header>
-        <rb.Modal.Body>{t('scheduler.confirm_modal.body')}</rb.Modal.Body>
+        <rb.Modal.Body className={styles['modalBody']}>{t('scheduler.confirm_modal.body')}</rb.Modal.Body>
         <rb.Modal.Footer className={styles['modalFooter']}>
           <rb.Button variant="light" onClick={handleClose} className="d-flex justify-content-center align-items-center">
             {t('modal.confirm_button_reject')}
           </rb.Button>
-          <rb.Button variant="dark" onClick={onConfirm}>
+          <rb.Button variant="dark" onClick={onConfirm} disabled={disabled}>
             {t('modal.confirm_button_accept')}
           </rb.Button>
         </rb.Modal.Footer>

--- a/src/components/SchedulerConfirmationModal.tsx
+++ b/src/components/SchedulerConfirmationModal.tsx
@@ -3,6 +3,7 @@ import styles from './SchedulerConfirmationModal.module.css'
 import { useState } from 'react'
 import Sprite from './Sprite'
 import { useTranslation } from 'react-i18next'
+import { ConfirmModal } from './Modal'
 
 interface SchedulerConfirmationModalProps {
   onConfirm: () => void
@@ -25,33 +26,18 @@ export default function SchedulerConfirmationModal({ onConfirm, disabled }: Sche
         </div>
       </rb.Button>
 
-      <rb.Modal
-        show={show}
-        keyboard={true}
-        onEscapeKeyDown={handleClose}
-        onHide={handleClose}
-        centered={true}
-        className={styles['modal']}
+      <ConfirmModal
+        isShown={show}
+        title={t('scheduler.confirm_modal.title')}
+        onCancel={handleClose}
+        onConfirm={onConfirm}
         size="lg"
+        showCloseButton={true}
+        headerClassName={styles['modalHeader']}
+        titleClassName={styles['modalTitle']}
       >
-        <rb.Modal.Header className={styles['modalHeader']}>
-          <rb.Modal.Title className={styles['modalTitle']}>
-            <div>{t('scheduler.confirm_modal.title')}</div>
-            <rb.Button onClick={handleClose} className={styles['cancelButton']}>
-              <Sprite symbol="cancel" width="26" height="26" />
-            </rb.Button>
-          </rb.Modal.Title>
-        </rb.Modal.Header>
-        <rb.Modal.Body className={styles['modalBody']}>{t('scheduler.confirm_modal.body')}</rb.Modal.Body>
-        <rb.Modal.Footer className={styles['modalFooter']}>
-          <rb.Button variant="light" onClick={handleClose} className="d-flex justify-content-center align-items-center">
-            {t('modal.confirm_button_reject')}
-          </rb.Button>
-          <rb.Button variant="dark" onClick={onConfirm} disabled={disabled}>
-            {t('modal.confirm_button_accept')}
-          </rb.Button>
-        </rb.Modal.Footer>
-      </rb.Modal>
+        <div className={styles['modalBody']}>{t('scheduler.confirm_modal.body')}</div>
+      </ConfirmModal>
     </>
   )
 }

--- a/src/components/SchedulerConfirmationModal.tsx
+++ b/src/components/SchedulerConfirmationModal.tsx
@@ -1,0 +1,46 @@
+import * as rb from 'react-bootstrap'
+import styles from './SchedulerConfirmationModal.module.css'
+import { useState } from 'react'
+import Sprite from './Sprite'
+import { useTranslation } from 'react-i18next'
+
+interface SchedulerConfirmationModalProps {
+  onConfirm: () => void
+  disabled: boolean
+}
+
+export default function SchedulerConfirmationModal({ onConfirm, disabled }: SchedulerConfirmationModalProps) {
+  const { t } = useTranslation()
+  const [show, setShow] = useState(false)
+
+  const handleClose = () => setShow(false)
+  const handleShow = () => setShow(true)
+
+  return (
+    <>
+      <rb.Button className="w-100 mb-4" variant="dark" size="lg" disabled={disabled} onClick={handleShow}>
+        <div className="d-flex justify-content-center align-items-center">
+          {t('scheduler.button_start')}
+          <Sprite symbol="caret-right" width="24" height="24" className="ms-1" />
+        </div>
+      </rb.Button>
+
+      <rb.Modal show={show} onHide={handleClose} dialogClassName={styles['modal']}>
+        <rb.Modal.Header closeButton>
+          <rb.Modal.Title>
+            <div>{t('scheduler.confirm_modal.title')}</div>
+          </rb.Modal.Title>
+        </rb.Modal.Header>
+        <rb.Modal.Body>{t('scheduler.confirm_modal.body')}</rb.Modal.Body>
+        <rb.Modal.Footer className={styles['modalFooter']}>
+          <rb.Button variant="light" onClick={handleClose} className="d-flex justify-content-center align-items-center">
+            {t('modal.confirm_button_reject')}
+          </rb.Button>
+          <rb.Button variant="dark" onClick={onConfirm}>
+            {t('modal.confirm_button_accept')}
+          </rb.Button>
+        </rb.Modal.Footer>
+      </rb.Modal>
+    </>
+  )
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -659,6 +659,10 @@
       "subtitle": "Successfully completed a single scheduled transaction.",
       "subtitle_other": "Successfully completed {{ count }} scheduled transactions.",
       "text_button_submit": "Continue"
+    },
+    "confirm_modal": {
+      "title": "Start Scheduled Sweep",
+      "body": "Are you sure you want to start the scheduled sweep?"
     }
   },
   "modal": {


### PR DESCRIPTION
This PR completes #796 

Made a Confirmation Modal that starts the scheduler only when the user confirms it.

![image](https://github.com/user-attachments/assets/0287b143-d92e-4657-8e78-0a5fef770ce8)
