### PR TITLE
feat: unit and visibility toggle on main wallet view

### DIFF
--- a/src/components/MainWalletView.tsx
+++ b/src/components/MainWalletView.tsx
@@ -148,18 +148,29 @@ export default function MainWalletView({ wallet }: MainWalletViewProps) {
         <rb.Row>
           <WalletHeaderRescanning walletName={wallet.displayName} isLoading={isLoading} />
         </rb.Row>
+      ) : !currentWalletInfo || isLoading ? (
+        <rb.Row>
+          <WalletHeaderPlaceholder />
+        </rb.Row>
       ) : (
-        <rb.Row onClick={() => settingsDispatch({ showBalance: !settings.showBalance })} className="cursor-pointer">
-          {!currentWalletInfo || isLoading ? (
-            <WalletHeaderPlaceholder />
-          ) : (
-            <WalletHeader
-              walletName={wallet.displayName}
-              balance={currentWalletInfo.balanceSummary.calculatedTotalBalanceInSats}
-              unit={settings.unit}
-              showBalance={settings.showBalance}
-            />
-          )}
+        <rb.Row
+          className="cursor-pointer"
+          onClick={() => {
+            if (!settings.showBalance) {
+              settingsDispatch({ unit: 'BTC', showBalance: true })
+            } else if (settings.unit === 'BTC') {
+              settingsDispatch({ unit: 'sats', showBalance: true })
+            } else {
+              settingsDispatch({ unit: 'BTC', showBalance: false })
+            }
+          }}
+        >
+          <WalletHeader
+            walletName={wallet.displayName}
+            balance={currentWalletInfo.balanceSummary.calculatedTotalBalanceInSats}
+            unit={settings.unit}
+            showBalance={settings.showBalance}
+          />
         </rb.Row>
       )}
       <div className={styles.walletBody}>


### PR DESCRIPTION
Most wallets have the ability to switch the unit of account (BTC or sats) by clicking at the balance.

Before this commit, the balance on the main wallet view has been a visibility toggle only. If a user clicked the balance it either showed the balance in the preferred unit or hid the balance.
e.g. BTC -> hidden -> BTC -> hidden, etc.

After this commit, a click will change the unit of the balance and only with a subsequent click toggles the visibility.
e.g. BTC -> sats -> hidden -> BTC -> sats, etc.
