### PR TITLE
UI : Show considered UTXOs before performing transaction

### DIFF
--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -82,7 +82,6 @@ const ReviewConsideredUtxos = ({ utxos }: ReviewConsideredUtxosProps) => {
             onToggle={() => {
               // No-op since these UTXOs are only for review and are not selectable
             }}
-            showBackgroundColor={false}
           />
         </rb.Col>
       </rb.Collapse>

--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useMemo } from 'react'
+import { PropsWithChildren, useMemo, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import * as rb from 'react-bootstrap'
 import Sprite from './Sprite'
@@ -10,6 +10,9 @@ import { AmountSats, BitcoinAddress } from '../libs/JmWalletApi'
 import { jarInitial } from './jars/Jar'
 import { isValidNumber } from '../utils'
 import styles from './PaymentConfirmModal.module.css'
+import { Utxos } from '../context/WalletContext'
+import { SelectableUtxo, UtxoListDisplay } from './Send/ShowUtxos'
+import Divider from './Divider'
 
 const feeRange: (txFee: TxFee, txFeeFactor: number) => [number, number] = (txFee, txFeeFactor) => {
   if (txFee.unit !== 'sats/kilo-vbyte') {
@@ -55,6 +58,38 @@ const useMiningFeeText = ({ tx_fees, tx_fees_factor }: Pick<FeeValues, 'tx_fees'
   }, [t, tx_fees, tx_fees_factor])
 }
 
+type ReviewConsideredUtxosProps = {
+  utxos: SelectableUtxo[]
+}
+const ReviewConsideredUtxos = ({ utxos }: ReviewConsideredUtxosProps) => {
+  const { t } = useTranslation()
+  const settings = useSettings()
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  return (
+    <rb.Row className="mt-2">
+      <rb.Col xs={4} md={3} className="text-end">
+        <strong>{t('show_utxos.considered_utxos')}</strong>
+      </rb.Col>
+      <rb.Col xs={8} md={9}>
+        <Divider toggled={isOpen} onToggle={() => setIsOpen((current) => !current)} />
+      </rb.Col>
+      <rb.Collapse in={isOpen}>
+        <rb.Col xs={12} className="mt-2">
+          <UtxoListDisplay
+            utxos={utxos}
+            settings={settings}
+            onToggle={() => {
+              // No-op since these UTXOs are only for review and are not selectable
+            }}
+            showBackgroundColor={false}
+          />
+        </rb.Col>
+      </rb.Collapse>
+    </rb.Row>
+  )
+}
+
 interface PaymentDisplayInfo {
   sourceJarIndex?: JarIndex
   destination: BitcoinAddress | string
@@ -64,6 +99,7 @@ interface PaymentDisplayInfo {
   numCollaborators?: number
   feeConfigValues?: FeeValues
   showPrivacyInfo?: boolean
+  consideredUtxos?: Utxos
 }
 
 interface PaymentConfirmModalProps extends ConfirmModalProps {
@@ -80,6 +116,7 @@ export function PaymentConfirmModal({
     numCollaborators,
     feeConfigValues,
     showPrivacyInfo = true,
+    consideredUtxos = [],
   },
   children,
   ...confirmModalProps
@@ -97,7 +134,7 @@ export function PaymentConfirmModal({
 
   return (
     <ConfirmModal {...confirmModalProps}>
-      <rb.Container className="mt-2">
+      <rb.Container className="mt-2" fluid>
         {showPrivacyInfo && (
           <rb.Row className="mt-2 mb-3">
             <rb.Col xs={12} className="text-center">
@@ -206,6 +243,9 @@ export function PaymentConfirmModal({
               {miningFeeText}
             </rb.Col>
           </rb.Row>
+        )}
+        {consideredUtxos.length !== 0 && (
+          <ReviewConsideredUtxos utxos={consideredUtxos.map((it) => ({ ...it, checked: false, selectable: false }))} />
         )}
         {children && (
           <rb.Row>

--- a/src/components/Send/SendForm.tsx
+++ b/src/components/Send/SendForm.tsx
@@ -26,7 +26,7 @@ import {
   isValidNumCollaborators,
 } from './helpers'
 import { AccountBalanceSummary } from '../../context/BalanceSummary'
-import { WalletInfo, CurrentWallet, Utxos } from '../../context/WalletContext'
+import { WalletInfo, CurrentWallet } from '../../context/WalletContext'
 import { useSettings } from '../../context/SettingsContext'
 import styles from './SendForm.module.css'
 import { TxFeeInputField, validateTxFee } from '../settings/TxFeeInputField'
@@ -214,7 +214,7 @@ export interface SendFormValues {
   txFee?: TxFee
   isCoinJoin: boolean
   numCollaborators?: number
-  consideredUtxos?: Utxos
+  consideredUtxos?: string[]
 }
 
 interface InnerSendFormProps {

--- a/src/components/Send/SendForm.tsx
+++ b/src/components/Send/SendForm.tsx
@@ -26,7 +26,7 @@ import {
   isValidNumCollaborators,
 } from './helpers'
 import { AccountBalanceSummary } from '../../context/BalanceSummary'
-import { WalletInfo, CurrentWallet } from '../../context/WalletContext'
+import { WalletInfo, CurrentWallet, Utxos } from '../../context/WalletContext'
 import { useSettings } from '../../context/SettingsContext'
 import styles from './SendForm.module.css'
 import { TxFeeInputField, validateTxFee } from '../settings/TxFeeInputField'
@@ -214,6 +214,7 @@ export interface SendFormValues {
   txFee?: TxFee
   isCoinJoin: boolean
   numCollaborators?: number
+  consideredUtxos?: Utxos
 }
 
 interface InnerSendFormProps {

--- a/src/components/Send/SendForm.tsx
+++ b/src/components/Send/SendForm.tsx
@@ -214,7 +214,6 @@ export interface SendFormValues {
   txFee?: TxFee
   isCoinJoin: boolean
   numCollaborators?: number
-  consideredUtxos?: string[]
 }
 
 interface InnerSendFormProps {

--- a/src/components/Send/ShowUtxos.module.css
+++ b/src/components/Send/ShowUtxos.module.css
@@ -31,6 +31,7 @@
   height: 24px;
 }
 
-.checkbox:checked {
+.checkbox:checked,
+.checkbox:indeterminate {
   accent-color: var(--bs-black);
 }

--- a/src/components/Send/ShowUtxos.module.css
+++ b/src/components/Send/ShowUtxos.module.css
@@ -1,5 +1,5 @@
 .utxoListDisplayHeight {
-  max-height: 17.6rem;
+  max-height: 15.7rem;
 }
 
 .row.row-normal {

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -51,7 +51,15 @@ interface UtxoListDisplayProps {
   disableCheckboxCell?: boolean
 }
 
-const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t }: UtxoRowProps) => {
+const UtxoRow = ({
+  utxo,
+  onToggle,
+  showBackgroundColor,
+  settings,
+  walletInfo,
+  t,
+  disableCheckboxCell,
+}: UtxoRowProps) => {
   const displayAddress = useMemo(() => shortenStringMiddle(utxo.address, 24), [utxo.address])
   const tags = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
 
@@ -66,20 +74,22 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
       })}
       onClick={() => utxo.selectable && onToggle(utxo)}
     >
-      <Cell>
-        {utxo.selectable && (
-          <div className="d-flex justify-content-center align-items-center">
-            <input
-              id={`utxo-checkbox-${utxo.utxo}`}
-              type="checkbox"
-              checked={utxo.checked}
-              disabled={!utxo.selectable}
-              onChange={() => utxo.selectable && onToggle(utxo)}
-              className={styles.checkbox}
-            />
-          </div>
-        )}
-      </Cell>
+      {!disableCheckboxCell && (
+        <Cell>
+          {utxo.selectable && (
+            <div className="d-flex justify-content-center align-items-center">
+              <input
+                id={`utxo-checkbox-${utxo.utxo}`}
+                type="checkbox"
+                checked={utxo.checked}
+                disabled={!utxo.selectable}
+                onChange={() => utxo.selectable && onToggle(utxo)}
+                className={styles.checkbox}
+              />
+            </div>
+          )}
+        </Cell>
+      )}
       <Cell>
         <UtxoIcon value={utxo} tags={tags} />
       </Cell>

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -36,6 +36,7 @@ interface UtxoRowProps {
   showBackgroundColor: boolean
   walletInfo: WalletInfo
   t: TFunction
+  disableCheckboxCell?: boolean
 }
 
 interface UtxoListDisplayProps {
@@ -43,6 +44,11 @@ interface UtxoListDisplayProps {
   onToggle: (utxo: SelectableUtxo) => void
   settings: Settings
   showBackgroundColor: boolean
+  customTheme?: {
+    Table: string
+    BaseCell: string
+  }
+  disableCheckboxCell?: boolean
 }
 
 const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t }: UtxoRowProps) => {
@@ -110,11 +116,18 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
 
 type SelectableUtxoTableRowData = SelectableUtxo & Pick<TableTypes.TableNode, 'id'>
 
-const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true }: UtxoListDisplayProps) => {
+const UtxoListDisplay = ({
+  utxos,
+  onToggle,
+  settings,
+  showBackgroundColor = true,
+  customTheme,
+  disableCheckboxCell = false,
+}: UtxoListDisplayProps) => {
   const { t } = useTranslation()
   const walletInfo = useCurrentWalletInfo()
 
-  const TABLE_THEME = {
+  const defaultTheme = {
     Table: `
     --data-table-library_grid-template-columns: 2.5rem 2.5rem 17rem 3rem 12rem 1fr};
   `,
@@ -128,7 +141,7 @@ const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true
     }
   `,
   }
-  const tableTheme = useTheme(TABLE_THEME)
+  const tableTheme = useTheme(customTheme ?? defaultTheme)
 
   const tableData: TableTypes.Data<SelectableUtxoTableRowData> = useMemo(
     () => ({
@@ -159,6 +172,7 @@ const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true
                     settings={settings}
                     walletInfo={walletInfo}
                     t={t}
+                    disableCheckboxCell={disableCheckboxCell}
                   />
                 )
               })}
@@ -169,7 +183,7 @@ const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true
   )
 }
 
-type SelectableUtxo = Utxo & { checked: boolean; selectable: boolean }
+export type SelectableUtxo = Utxo & { checked: boolean; selectable: boolean }
 
 // TODO: rename to QuickFreezeUtxosModal?
 const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: ShowUtxosProps) => {
@@ -290,4 +304,4 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
   )
 }
 
-export { ShowUtxos }
+export { ShowUtxos, UtxoListDisplay }

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -33,19 +33,21 @@ interface UtxoRowProps {
   utxo: SelectableUtxoTableRowData
   onToggle: (utxo: SelectableUtxoTableRowData) => void
   settings: Settings
-  showBackgroundColor: boolean
   walletInfo: WalletInfo
   t: TFunction
+  // TODO: remove
+  showBackgroundColor?: boolean
 }
 
 interface UtxoListDisplayProps {
   utxos: SelectableUtxo[]
   onToggle: (utxo: SelectableUtxo) => void
   settings: Settings
-  showBackgroundColor: boolean
+  // TODO: remove
+  showBackgroundColor?: boolean
 }
 
-const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t }: UtxoRowProps) => {
+const UtxoRow = ({ utxo, onToggle, settings, walletInfo, t }: UtxoRowProps) => {
   const displayAddress = useMemo(() => shortenStringMiddle(utxo.address, 24), [utxo.address])
   const tags = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
 
@@ -54,7 +56,6 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
       item={utxo}
       className={classNames(styles.row, styles[`row-${tags[0]?.color || 'normal'}`], {
         [styles['row-frozen']]: utxo.frozen,
-        'bg-transparent': !showBackgroundColor,
         'cursor-pointer': utxo.selectable,
         'cursor-not-allowed': !utxo.selectable,
       })}
@@ -128,7 +129,7 @@ const DEFAULT_UTXO_LIST_THEME = {
 `,
 }
 
-const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true }: UtxoListDisplayProps) => {
+const UtxoListDisplay = ({ utxos, onToggle, settings }: UtxoListDisplayProps) => {
   const { t } = useTranslation()
   const walletInfo = useCurrentWalletInfo()
 
@@ -159,7 +160,6 @@ const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true
                     key={index}
                     utxo={utxo}
                     onToggle={onToggle}
-                    showBackgroundColor={showBackgroundColor}
                     settings={settings}
                     walletInfo={walletInfo}
                     t={t}
@@ -245,7 +245,6 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
                   )
                 }}
                 settings={settings}
-                showBackgroundColor={true}
               />
             </rb.Row>
             {upperUtxos.length > 0 && lowerUtxos.length > 0 && (
@@ -265,7 +264,6 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
                     )
                   }}
                   settings={settings}
-                  showBackgroundColor={true}
                 />
               </rb.Row>
             </rb.Collapse>

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -36,7 +36,6 @@ interface UtxoRowProps {
   showBackgroundColor: boolean
   walletInfo: WalletInfo
   t: TFunction
-  disableCheckboxCell?: boolean
 }
 
 interface UtxoListDisplayProps {
@@ -44,29 +43,16 @@ interface UtxoListDisplayProps {
   onToggle: (utxo: SelectableUtxo) => void
   settings: Settings
   showBackgroundColor: boolean
-  customTheme?: {
-    Table: string
-    BaseCell: string
-  }
-  disableCheckboxCell?: boolean
 }
 
-const UtxoRow = ({
-  utxo,
-  onToggle,
-  showBackgroundColor,
-  settings,
-  walletInfo,
-  t,
-  disableCheckboxCell,
-}: UtxoRowProps) => {
+const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t }: UtxoRowProps) => {
   const displayAddress = useMemo(() => shortenStringMiddle(utxo.address, 24), [utxo.address])
   const tags = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
 
   return (
     <Row
       item={utxo}
-      className={classNames(styles.row, styles[`row-${tags[0].color || 'normal'}`], {
+      className={classNames(styles.row, styles[`row-${tags[0]?.color || 'normal'}`], {
         [styles['row-frozen']]: utxo.frozen,
         'bg-transparent': !showBackgroundColor,
         'cursor-pointer': utxo.selectable,
@@ -74,22 +60,20 @@ const UtxoRow = ({
       })}
       onClick={() => utxo.selectable && onToggle(utxo)}
     >
-      {!disableCheckboxCell && (
-        <Cell>
-          {utxo.selectable && (
-            <div className="d-flex justify-content-center align-items-center">
-              <input
-                id={`utxo-checkbox-${utxo.utxo}`}
-                type="checkbox"
-                checked={utxo.checked}
-                disabled={!utxo.selectable}
-                onChange={() => utxo.selectable && onToggle(utxo)}
-                className={styles.checkbox}
-              />
-            </div>
-          )}
-        </Cell>
-      )}
+      <Cell>
+        {utxo.selectable && (
+          <div className="d-flex justify-content-center align-items-center">
+            <input
+              id={`utxo-checkbox-${utxo.utxo}`}
+              type="checkbox"
+              checked={utxo.checked}
+              disabled={!utxo.selectable}
+              onChange={() => utxo.selectable && onToggle(utxo)}
+              className={styles.checkbox}
+            />
+          </div>
+        )}
+      </Cell>
       <Cell>
         <UtxoIcon value={utxo} tags={tags} />
       </Cell>
@@ -126,32 +110,29 @@ const UtxoRow = ({
 
 type SelectableUtxoTableRowData = SelectableUtxo & Pick<TableTypes.TableNode, 'id'>
 
-const UtxoListDisplay = ({
-  utxos,
-  onToggle,
-  settings,
-  showBackgroundColor = true,
-  customTheme,
-  disableCheckboxCell = false,
-}: UtxoListDisplayProps) => {
+const DEFAULT_UTXO_LIST_THEME = {
+  Table: `
+  --data-table-library_grid-template-columns: 2.5rem 2.5rem 17rem 3rem 12rem 1fr};
+`,
+  BaseCell: `
+  padding: 0.35rem 0.25rem !important;
+  margin: 0.15rem 0px !important;
+`,
+  Cell: `
+  &:nth-of-type(3) {
+    text-align: left;
+  }
+  &:nth-of-type(5) {
+    text-align: right;
+  }
+`,
+}
+
+const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true }: UtxoListDisplayProps) => {
   const { t } = useTranslation()
   const walletInfo = useCurrentWalletInfo()
 
-  const defaultTheme = {
-    Table: `
-    --data-table-library_grid-template-columns: 2.5rem 2.5rem 17rem 3rem 12rem 1fr};
-  `,
-    BaseCell: `
-    padding: 0.35rem 0.25rem !important;
-    margin: 0.15rem 0px !important;
-  `,
-    Cell: `
-    &:nth-of-type(5) {
-      text-align: right;
-    }
-  `,
-  }
-  const tableTheme = useTheme(customTheme ?? defaultTheme)
+  const tableTheme = useTheme(DEFAULT_UTXO_LIST_THEME)
 
   const tableData: TableTypes.Data<SelectableUtxoTableRowData> = useMemo(
     () => ({
@@ -182,7 +163,6 @@ const UtxoListDisplay = ({
                     settings={settings}
                     walletInfo={walletInfo}
                     t={t}
-                    disableCheckboxCell={disableCheckboxCell}
                   />
                 )
               })}

--- a/src/components/Send/SourceJarSelector.tsx
+++ b/src/components/Send/SourceJarSelector.tsx
@@ -37,13 +37,10 @@ export const SourceJarSelector = ({
 }: SourceJarSelectorProps) => {
   const { t } = useTranslation()
   const [field] = useField<JarIndex>(name)
-  const [consideredUtxos] = useField<Utxos | undefined>('consideredUtxos')
   const form = useFormikContext<any>()
   const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
 
   const [showUtxos, setShowUtxos] = useState<ShowUtxosProps>()
-  //const [unFrozenUtxos, setUnFrozenUtxos] = useState<Utxos>([])
-  //const [frozenUtxos, setFrozenUtxos] = useState<Utxos>([])
 
   const jarBalances = useMemo(() => {
     if (!walletInfo) return []
@@ -51,27 +48,6 @@ export const SourceJarSelector = ({
       (lhs, rhs) => lhs.accountIndex - rhs.accountIndex,
     )
   }, [walletInfo])
-
-  /*useEffect(() => {
-    if (frozenUtxos.length === 0 && unFrozenUtxos.length === 0) {
-      return
-    }
-    const frozenUtxosToUpdate = frozenUtxos.filter((utxo: Utxo) => utxo.checked && !utxo.locktime)
-    const timeLockedUtxo = frozenUtxos.find((utxo: Utxo) => utxo.checked && utxo.locktime)
-    const allUnFrozenUnchecked = unFrozenUtxos.every((utxo: Utxo) => !utxo.checked)
-
-    if (frozenUtxos.length > 0 && timeLockedUtxo) {
-      setAlert({ variant: 'danger', message: `${t('show_utxos.alert_for_time_locked')} ${timeLockedUtxo.locktime}` })
-    } else if (
-      (frozenUtxos.length > 0 || unFrozenUtxos.length > 0) &&
-      allUnFrozenUnchecked &&
-      frozenUtxosToUpdate.length === 0
-    ) {
-      setAlert({ variant: 'warning', message: t('show_utxos.alert_for_unfreeze_utxos'), dismissible: true })
-    } else {
-      setAlert(undefined)
-    }
-  }, [frozenUtxos, unFrozenUtxos, t, setAlert])*/
 
   const handleUtxosFrozenState = useCallback(
     async (selectedUtxos: Utxos) => {
@@ -98,20 +74,7 @@ export const SourceJarSelector = ({
         ])
 
         if (res.length !== 0) {
-          const allUtxosData = await reloadCurrentWalletInfo.reloadUtxos({ signal: abortCtrl.signal })
-          if (allUtxosData) {
-            const selectedUtxos = allUtxosData.utxos
-              .filter((utxo) => utxo.mixdepth === field.value && !utxo.frozen)
-              .map((utxo) => utxo.utxo)
-            form.setFieldValue(consideredUtxos.name, selectedUtxos, true)
-          }
-        } else {
-          if (walletInfo) {
-            const selectedUtxos = walletInfo.utxosByJar[field.value]
-              .filter((utxo) => !utxo.frozen)
-              .map((utxo) => utxo.utxo)
-            form.setFieldValue(consideredUtxos.name, selectedUtxos, true)
-          }
+          await reloadCurrentWalletInfo.reloadUtxos({ signal: abortCtrl.signal })
         }
 
         setShowUtxos(undefined)
@@ -120,7 +83,7 @@ export const SourceJarSelector = ({
         setShowUtxos({ ...showUtxos, isLoading: false, alert: { variant: 'danger', message: err.message } })
       }
     },
-    [showUtxos, wallet, reloadCurrentWalletInfo, field, form, walletInfo, consideredUtxos],
+    [showUtxos, wallet, reloadCurrentWalletInfo],
   )
 
   return (
@@ -161,7 +124,6 @@ export const SourceJarSelector = ({
                     variant={it.accountIndex === field.value ? variant : undefined}
                     onClick={(jarIndex) => {
                       form.setFieldValue(field.name, jarIndex, true)
-                      form.setFieldValue(consideredUtxos.name, undefined, false)
                       if (
                         it.accountIndex === field.value &&
                         !disabled &&
@@ -172,12 +134,6 @@ export const SourceJarSelector = ({
                           utxos: walletInfo.utxosByJar[it.accountIndex],
                           isLoading: false,
                         })
-                      }
-                      if (walletInfo) {
-                        const selectedUtxos = walletInfo.utxosByJar[jarIndex]
-                          .filter((utxo) => !utxo.frozen)
-                          .map((utxo) => utxo.utxo)
-                        form.setFieldValue(consideredUtxos.name, selectedUtxos, true)
                       }
                     }}
                   />

--- a/src/components/Send/SourceJarSelector.tsx
+++ b/src/components/Send/SourceJarSelector.tsx
@@ -3,7 +3,7 @@ import { useField, useFormikContext } from 'formik'
 import * as rb from 'react-bootstrap'
 import { jarFillLevel, SelectableJar } from '../jars/Jar'
 import { noop } from '../../utils'
-import { WalletInfo, CurrentWallet, useReloadCurrentWalletInfo, Utxos } from '../../context/WalletContext'
+import { WalletInfo, CurrentWallet, useReloadCurrentWalletInfo, Utxo, Utxos } from '../../context/WalletContext'
 import styles from './SourceJarSelector.module.css'
 import { ShowUtxos } from './ShowUtxos'
 import { useTranslation } from 'react-i18next'
@@ -37,6 +37,7 @@ export const SourceJarSelector = ({
 }: SourceJarSelectorProps) => {
   const { t } = useTranslation()
   const [field] = useField<JarIndex>(name)
+  const [consideredUtxos] = useField<Utxos | undefined>('consideredUtxos')
   const form = useFormikContext<any>()
   const reloadCurrentWalletInfo = useReloadCurrentWalletInfo()
 
@@ -147,6 +148,7 @@ export const SourceJarSelector = ({
                     variant={it.accountIndex === field.value ? variant : undefined}
                     onClick={(jarIndex) => {
                       form.setFieldValue(field.name, jarIndex, true)
+                      form.setFieldValue(consideredUtxos.name, undefined, false)
                       if (
                         it.accountIndex === field.value &&
                         !disabled &&

--- a/src/components/Send/SourceJarSelector.tsx
+++ b/src/components/Send/SourceJarSelector.tsx
@@ -173,6 +173,12 @@ export const SourceJarSelector = ({
                           isLoading: false,
                         })
                       }
+                      if (walletInfo) {
+                        const selectedUtxos = walletInfo.utxosByJar[jarIndex]
+                          .filter((utxo) => !utxo.frozen)
+                          .map((utxo) => utxo.utxo)
+                        form.setFieldValue(consideredUtxos.name, selectedUtxos, true)
+                      }
                     }}
                   />
                 </div>

--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -92,13 +92,13 @@ const ReviewConsideredUtxos = ({ utxos }: ReviewConsideredUtxosProps) => {
 
   const customTheme = {
     Table: `
-    --data-table-library_grid-template-columns: 2.5rem 10rem 5fr 3fr 8.7rem;
+    --data-table-library_grid-template-columns: 2.5rem 12rem 2fr 1fr 8.7rem;
     @media only screen and (min-width: 768px) {
-      --data-table-library_grid-template-columns: 2.5rem 10rem 5fr 3fr 8.7rem;
+      --data-table-library_grid-template-columns: 1.7rem 11.3rem 2fr 1fr 8.7rem;
     }
   `,
     BaseCell: `
-    padding: 0.35rem  0.25rem !important;
+    padding: 0.35rem  0.15rem !important;
     margin: 0.15rem 0px !important;
   `,
   }

--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -542,9 +542,17 @@ export default function Send({ wallet }: SendProps) {
             feeConfigValues: { ...feeConfigValues, tx_fees: showConfirmSendModal.txFee },
           }}
         >
-          {showConfirmSendModal.amount!.isSweep && showConfirmSendModal.consideredUtxos && (
-            <ReviewConsideredUtxos utxos={showConfirmSendModal.consideredUtxos} />
-          )}
+          {showConfirmSendModal.amount?.isSweep &&
+            showConfirmSendModal.consideredUtxos &&
+            walletInfo &&
+            showConfirmSendModal.sourceJarIndex !== undefined &&
+            (() => {
+              const selectedUtxosList = showConfirmSendModal.consideredUtxos
+              const utxoList = walletInfo.utxosByJar[showConfirmSendModal.sourceJarIndex].filter((utxo) =>
+                selectedUtxosList.some((selectedUtxos) => selectedUtxos === utxo.utxo),
+              )
+              return <ReviewConsideredUtxos utxos={utxoList} />
+            })()}
         </PaymentConfirmModal>
       )}
     </div>

--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -18,11 +18,7 @@ import { useLoadConfigValue } from '../../context/ServiceConfigContext'
 import { useWaitForUtxosToBeSpent } from '../../hooks/WaitForUtxosToBeSpent'
 import { routes } from '../../constants/routes'
 import { JM_MINIMUM_MAKERS_DEFAULT } from '../../constants/config'
-
 import { initialNumCollaborators } from './helpers'
-import { SelectableUtxo, UtxoListDisplay } from './ShowUtxos'
-import Divider from '../Divider'
-import { useSettings } from '../../context/SettingsContext'
 
 const INITIAL_DESTINATION = null
 const INITIAL_SOURCE_JAR_INDEX = null
@@ -80,53 +76,6 @@ const createInitialValues = (numCollaborators: number, feeConfigValues: FeeValue
     isCoinJoin: INITIAL_IS_COINJOIN,
     numCollaborators,
   }
-}
-
-type ReviewConsideredUtxosProps = {
-  utxos: SelectableUtxo[]
-}
-const ReviewConsideredUtxos = ({ utxos }: ReviewConsideredUtxosProps) => {
-  const { t } = useTranslation()
-  const settings = useSettings()
-  const [isOpen, setIsOpen] = useState<boolean>(false)
-
-  const customTheme = {
-    Table: `
-    --data-table-library_grid-template-columns: 2.5rem 12rem 2fr 1fr 8.7rem;
-    @media only screen and (min-width: 768px) {
-      --data-table-library_grid-template-columns: 1.7rem 11.3rem 2fr 1fr 8.7rem;
-    }
-  `,
-    BaseCell: `
-    padding: 0.35rem  0.15rem !important;
-    margin: 0.15rem 0px !important;
-  `,
-  }
-
-  return (
-    <rb.Row className="mt-3">
-      <rb.Col xs={4} md={3} className="text-end">
-        <strong>{t('show_utxos.considered_utxos')}</strong>
-      </rb.Col>
-      <rb.Col xs={8} md={9}>
-        <Divider toggled={isOpen} onToggle={() => setIsOpen((current) => !current)} className="mb-3" />
-        <rb.Collapse in={isOpen}>
-          <div className="text-start">
-            <UtxoListDisplay
-              utxos={utxos}
-              settings={settings}
-              onToggle={() => {
-                // No-op since these UTXOs are only for review and are not selectable
-              }}
-              showBackgroundColor={false}
-              customTheme={customTheme}
-              disableCheckboxCell={true}
-            />
-          </div>
-        </rb.Collapse>
-      </rb.Col>
-    </rb.Row>
-  )
 }
 
 type SendProps = {
@@ -565,20 +514,11 @@ export default function Send({ wallet }: SendProps) {
             isCoinjoin: showConfirmSendModal.isCoinJoin,
             numCollaborators: showConfirmSendModal.numCollaborators!,
             feeConfigValues: { ...feeConfigValues, tx_fees: showConfirmSendModal.txFee },
+            consideredUtxos: (walletInfo?.utxosByJar[showConfirmSendModal.sourceJarIndex!] || [])
+              .filter((utxo) => !utxo.frozen)
+              .sort((a, b) => a.confirmations - b.confirmations),
           }}
-        >
-          {showConfirmSendModal.consideredUtxos &&
-            walletInfo &&
-            showConfirmSendModal.sourceJarIndex !== undefined &&
-            (() => {
-              const selectedUtxosList = showConfirmSendModal.consideredUtxos
-              const utxoList = walletInfo.utxosByJar[showConfirmSendModal.sourceJarIndex]
-                .filter((utxo) => selectedUtxosList.some((selectedUtxos) => selectedUtxos === utxo.utxo))
-                .map((it) => ({ ...it, checked: false, selectable: false }))
-                .sort((a, b) => a.confirmations - b.confirmations)
-              return <ReviewConsideredUtxos utxos={utxoList} />
-            })()}
-        </PaymentConfirmModal>
+        />
       )}
     </div>
   )

--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -12,7 +12,7 @@ import { scrollToTop } from '../../utils'
 import { PaymentConfirmModal } from '../PaymentConfirmModal'
 import FeeConfigModal, { FeeConfigSectionKey } from '../settings/FeeConfigModal'
 import { FeeValues, TxFee, useFeeConfigValues } from '../../hooks/Fees'
-import { useReloadCurrentWalletInfo, useCurrentWalletInfo, CurrentWallet } from '../../context/WalletContext'
+import { useReloadCurrentWalletInfo, useCurrentWalletInfo, CurrentWallet, Utxos } from '../../context/WalletContext'
 import { useServiceInfo, useReloadServiceInfo } from '../../context/ServiceInfoContext'
 import { useLoadConfigValue } from '../../context/ServiceConfigContext'
 import { useWaitForUtxosToBeSpent } from '../../hooks/WaitForUtxosToBeSpent'
@@ -20,6 +20,8 @@ import { routes } from '../../constants/routes'
 import { JM_MINIMUM_MAKERS_DEFAULT } from '../../constants/config'
 
 import { initialNumCollaborators } from './helpers'
+import { Divider, UtxoListDisplay } from './ShowUtxos'
+import { useSettings } from '../../context/SettingsContext'
 
 const INITIAL_DESTINATION = null
 const INITIAL_SOURCE_JAR_INDEX = null
@@ -77,6 +79,29 @@ const createInitialValues = (numCollaborators: number, feeConfigValues: FeeValue
     isCoinJoin: INITIAL_IS_COINJOIN,
     numCollaborators,
   }
+}
+
+type ReviewConsideredUtxosProps = {
+  utxos: Utxos
+}
+const ReviewConsideredUtxos = ({ utxos }: ReviewConsideredUtxosProps) => {
+  const { t } = useTranslation()
+  const settings = useSettings()
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  return (
+    <rb.Row className="mt-3">
+      <rb.Col xs={4} md={3} className="text-end">
+        <strong>{t('show_utxos.considered_utxos')}</strong>
+      </rb.Col>
+      <rb.Col xs={8} md={9}>
+        <Divider isState={isOpen} setIsState={setIsOpen} className="mb-3" />
+        {isOpen && (
+          <UtxoListDisplay utxos={utxos} settings={settings} showRadioButton={false} showBackgroundColor={false} />
+        )}
+      </rb.Col>
+    </rb.Row>
+  )
 }
 
 type SendProps = {
@@ -516,7 +541,11 @@ export default function Send({ wallet }: SendProps) {
             numCollaborators: showConfirmSendModal.numCollaborators!,
             feeConfigValues: { ...feeConfigValues, tx_fees: showConfirmSendModal.txFee },
           }}
-        />
+        >
+          {showConfirmSendModal.amount!.isSweep && showConfirmSendModal.consideredUtxos && (
+            <ReviewConsideredUtxos utxos={showConfirmSendModal.consideredUtxos} />
+          )}
+        </PaymentConfirmModal>
       )}
     </div>
   )

--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -567,8 +567,7 @@ export default function Send({ wallet }: SendProps) {
             feeConfigValues: { ...feeConfigValues, tx_fees: showConfirmSendModal.txFee },
           }}
         >
-          {showConfirmSendModal.amount?.isSweep &&
-            showConfirmSendModal.consideredUtxos &&
+          {showConfirmSendModal.consideredUtxos &&
             walletInfo &&
             showConfirmSendModal.sourceJarIndex !== undefined &&
             (() => {

--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -115,7 +115,9 @@ const ReviewConsideredUtxos = ({ utxos }: ReviewConsideredUtxosProps) => {
             <UtxoListDisplay
               utxos={utxos}
               settings={settings}
-              onToggle={() => {}}
+              onToggle={() => {
+                // No-op since these UTXOs are only for review and are not selectable
+              }}
               showBackgroundColor={false}
               customTheme={customTheme}
               disableCheckboxCell={true}

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -45,6 +45,14 @@ const TABLE_THEME = {
   `,
   BaseCell: `
     padding: 0.25rem 0.25rem !important;
+
+    input[type="checkbox"] {
+      width: 16px;
+      height: 16px;
+    }
+    input:checked, input:indeterminate {
+      accent-color: var(--bs-black);
+    }
     &:nth-of-type(1) {
       text-align: center;
     }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -707,7 +707,7 @@
   },
   "show_utxos": {
     "select_utxos": "Select UTXOs",
-    "selected_utxos": "Selected UTXOs",
+    "considered_utxos": "Considered UTXOs",
     "show_utxo_title": "Select UTXOs to be considered",
     "show_utxo_subtitle": "The following UTXOs are considered in the transaction. Every unselected UTXO will be frozen and can be unfrozen later on.",
     "show_utxo_subtitle_when_allutxos_are_frozen": "The following UTXOs are frozen. Please select them to be considered in the transaction."


### PR DESCRIPTION
This PR fixes #773 

Changes:
1. User are now able to review their `considered UTXOs` before performing a sweep
2. Successful implementation of 
![image](https://github.com/joinmarket-webui/jam/assets/112259776/944af9aa-db71-4441-9dc2-a5c3ecca02ff)
