### PR TITLE
refactor: align utxo list and modal components

### DIFF
--- a/src/components/Send/ShowUtxos.module.css
+++ b/src/components/Send/ShowUtxos.module.css
@@ -2,26 +2,26 @@
   max-height: 17.6rem;
 }
 
-.row {
-  background-color: transparent;
+.row.row-normal {
+  background-color: transparent !important;
 }
 
-.row-success {
+.row.row-success {
   background-color: #27ae600d !important;
   color: #27ae60 !important;
 }
 
-.row-warning {
+.row.row-warning {
   background-color: #bb97200d !important;
   color: #ebc957 !important;
 }
 
-.row-danger {
+.row.row-danger {
   background-color: #eb57570d !important;
   color: #eb5757 !important;
 }
 
-.row-frozen {
+.row.row-frozen {
   background-color: #2d9cdb0d !important;
   color: #2d9cdb !important;
 }

--- a/src/components/Send/ShowUtxos.module.css
+++ b/src/components/Send/ShowUtxos.module.css
@@ -47,38 +47,15 @@
   padding: 0rem 0.25rem;
 }
 
-.squareToggleButton {
-  appearance: none;
-  width: 22px;
-  height: 22px;
-  border-radius: 3px;
-  border: 1px solid var(--bs-body-color);
-  margin-top: 0.45rem;
+.checkbox {
+  width: 24px;
+  height: 24px;
 }
 
-.selected {
-  visibility: visible !important;
-  background-color: var(--bs-body-color);
-}
-
-.squareFrozenToggleButton {
-  appearance: none;
-  width: 22px;
-  height: 22px;
-  border-radius: 3px;
-  border: 1px solid #2d9cdb;
-  margin-top: 0.45rem;
+.checkbox:checked {
+  accent-color: var(--bs-black);
 }
 
 .utxoListDisplayHeight {
   max-height: 17.6rem;
-}
-
-.customHeaderClass {
-  background-color: var(--bs-gray-800) !important;
-  padding: var(--bs-modal-header-padding) !important;
-}
-
-.customTitleClass {
-  color: var(--bs-heading-color) !important;
 }

--- a/src/components/Send/ShowUtxos.module.css
+++ b/src/components/Send/ShowUtxos.module.css
@@ -1,50 +1,29 @@
-.joinedUtxoAndCjout {
+.utxoListDisplayHeight {
+  max-height: 17.6rem;
+}
+
+.row {
+  background-color: transparent;
+}
+
+.row-success {
   background-color: #27ae600d !important;
   color: #27ae60 !important;
 }
 
-.frozenUtxo {
-  background-color: #2d9cdb0d !important;
-  color: #2d9cdb !important;
+.row-warning {
+  background-color: #bb97200d !important;
+  color: #ebc957 !important;
 }
 
-.depositUtxo {
-  background-color: var(--bs-body-bg) !important;
-  color: var(--bs-modal-color) !important;
-}
-
-.changeAndReuseUtxo {
+.row-danger {
   background-color: #eb57570d !important;
   color: #eb5757 !important;
 }
 
-.utxoTagDeposit {
-  color: #999999;
-  border: 1px solid #bbbbbb;
-  background-color: #dedede !important;
-  border-radius: 0.35rem;
-  padding: 0rem 0.25rem;
-}
-
-.utxoTagJoinedAndCjout {
-  border: 1px solid #27ae60;
-  background-color: #c6eed7 !important;
-  border-radius: 0.35rem;
-  padding: 0rem 0.25rem;
-}
-
-.utxoTagFreeze {
-  border: 1px solid #2d9cdb;
-  background-color: #bce7ff !important;
-  border-radius: 0.35rem;
-  padding: 0rem 0.25rem;
-}
-
-.utxoTagChangeAndReuse {
-  border: 1px solid #eb5757;
-  background-color: #fac7c7 !important;
-  border-radius: 0.35rem;
-  padding: 0rem 0.25rem;
+.row-frozen {
+  background-color: #2d9cdb0d !important;
+  color: #2d9cdb !important;
 }
 
 .checkbox {
@@ -54,8 +33,4 @@
 
 .checkbox:checked {
   accent-color: var(--bs-black);
-}
-
-.utxoListDisplayHeight {
-  max-height: 17.6rem;
 }

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -77,16 +77,16 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
     >
       <Cell>
         {utxo.selectable && (
-          <input
-            id={`utxo-checkbox-${utxo.utxo}`}
-            type="checkbox"
-            checked={utxo.checked}
-            disabled={!utxo.selectable}
-            onChange={() => utxo.selectable && onToggle(utxo)}
-            className={classNames(utxo.frozen ? styles.squareFrozenToggleButton : styles.squareToggleButton, {
-              [styles.selected]: utxo.checked,
-            })}
-          />
+          <div className="d-flex justify-content-center align-items-center">
+            <input
+              id={`utxo-checkbox-${utxo.utxo}`}
+              type="checkbox"
+              checked={utxo.checked}
+              disabled={!utxo.selectable}
+              onChange={() => utxo.selectable && onToggle(utxo)}
+              className={styles.checkbox}
+            />
+          </div>
         )}
       </Cell>
       <Cell>
@@ -219,8 +219,8 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
       backdrop={true}
       title={t('show_utxos.show_utxo_title')}
       closeButton
-      headerClassName={styles.customHeaderClass}
-      titleClassName={styles.customTitleClass}
+      headerClassName=""
+      titleClassName=""
     >
       <rb.Modal.Body>
         {isLoading ? (

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -55,7 +55,7 @@ const allotClasses = (tag: string, isFrozen: boolean) => {
 }
 
 const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t }: UtxoRowProps) => {
-  const address = useMemo(() => shortenStringMiddle(utxo.address, 24), [utxo.address])
+  const displayAddress = useMemo(() => shortenStringMiddle(utxo.address, 24), [utxo.address])
   const tag = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
 
   const rowAndTagClass = useMemo(() => {
@@ -92,7 +92,17 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
       <Cell>
         <UtxoIcon value={utxo} tags={tag} />
       </Cell>
-      <Cell className="slashed-zeroes">{address}</Cell>
+      <Cell className="slashed-zeroes">
+        <rb.OverlayTrigger
+          overlay={(props) => (
+            <rb.Tooltip className="slashed-zeroes" {...props}>
+              {utxo.address}
+            </rb.Tooltip>
+          )}
+        >
+          <span>{displayAddress}</span>
+        </rb.OverlayTrigger>
+      </Cell>
       <Cell>
         <UtxoConfirmations value={utxo} />
       </Cell>

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -14,9 +14,10 @@ import Divider from '../Divider'
 import { BaseModal } from '../Modal'
 import Sprite from '../Sprite'
 import { utxoTags } from '../utxo/utils'
+import { UtxoConfirmations } from '../utxo/Confirmations'
+import UtxoIcon from '../utxo/UtxoIcon'
 import { shortenStringMiddle } from '../../utils'
 import styles from './ShowUtxos.module.css'
-import { UtxoConfirmations } from '../utxo/Confirmations'
 
 interface ShowUtxosProps {
   isOpen: boolean
@@ -43,16 +44,6 @@ interface UtxoListDisplayProps {
   showBackgroundColor: boolean
 }
 
-// Utility function to Identifies Icons
-const utxoIcon = (tag: string, isFrozen: boolean) => {
-  if (isFrozen && tag === 'bond') return 'timelock'
-  if (isFrozen) return 'snowflake'
-  if (tag === 'bond') return 'timelock'
-  if (tag === 'cj-out') return 'mixed'
-  if (tag === 'deposit' || tag === 'non-cj-change' || tag === 'reused') return 'unmixed'
-  return 'unmixed' // fallback
-}
-
 // Utility function to allot classes
 const allotClasses = (tag: string, isFrozen: boolean) => {
   if (isFrozen) return { row: styles.frozenUtxo, tag: styles.utxoTagFreeze }
@@ -67,11 +58,11 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
   const address = useMemo(() => shortenStringMiddle(utxo.address, 16), [utxo.address])
   const tag = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
 
-  const { icon, rowAndTagClass } = useMemo(() => {
+  const rowAndTagClass = useMemo(() => {
     if (tag.length === 0) {
-      return { icon: 'unmixed', rowAndTagClass: { row: styles.depositUtxo, tag: styles.utxoTagDeposit } }
+      return { row: styles.depositUtxo, tag: styles.utxoTagDeposit }
     }
-    return { icon: utxoIcon(tag[0].tag, utxo.frozen), rowAndTagClass: allotClasses(tag[0].tag, utxo.frozen) }
+    return allotClasses(tag[0].value, utxo.frozen)
   }, [tag, utxo.frozen])
 
   return (
@@ -99,7 +90,7 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
         )}
       </Cell>
       <Cell>
-        <Sprite symbol={icon} width="23px" height="23px" />
+        <UtxoIcon value={utxo} tags={tag} />
       </Cell>
       <Cell className="slashed-zeroes">{address}</Cell>
       <Cell>
@@ -116,7 +107,9 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
         />
       </Cell>
       <Cell>
-        <div className={classNames(rowAndTagClass.tag, 'd-inline-block')}>{tag.length ? tag[0].tag : ''}</div>
+        {tag.length > 0 && (
+          <div className={classNames(rowAndTagClass.tag, 'd-inline-block')}>{tag[0].displayValue}</div>
+        )}
       </Cell>
     </Row>
   )

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -55,7 +55,7 @@ const allotClasses = (tag: string, isFrozen: boolean) => {
 }
 
 const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t }: UtxoRowProps) => {
-  const address = useMemo(() => shortenStringMiddle(utxo.address, 16), [utxo.address])
+  const address = useMemo(() => shortenStringMiddle(utxo.address, 24), [utxo.address])
   const tag = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
 
   const rowAndTagClass = useMemo(() => {
@@ -126,14 +126,17 @@ const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true
 
   const TABLE_THEME = {
     Table: `
-    --data-table-library_grid-template-columns: 3.5rem 2.5rem 12rem 2fr 3fr 10rem;
-    @media only screen and (min-width: 768px) {
-      --data-table-library_grid-template-columns: 3.5rem 2.5rem 14rem 5fr 3fr 10rem};
-    }
+    --data-table-library_grid-template-columns: 2.5rem 2.5rem 17rem 3rem 12rem 1fr};
+
   `,
     BaseCell: `
     padding: 0.35rem 0.25rem !important;
     margin: 0.15rem 0px !important;
+  `,
+    Cell: `
+    &:nth-of-type(5) {
+      text-align: right;
+    }
   `,
   }
   const tableTheme = useTheme(TABLE_THEME)

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -16,6 +16,7 @@ import Sprite from '../Sprite'
 import { utxoTags } from '../utxo/utils'
 import { UtxoConfirmations } from '../utxo/Confirmations'
 import UtxoIcon from '../utxo/UtxoIcon'
+import UtxoTags from '../utxo/UtxoTags'
 import { shortenStringMiddle } from '../../utils'
 import styles from './ShowUtxos.module.css'
 
@@ -44,31 +45,15 @@ interface UtxoListDisplayProps {
   showBackgroundColor: boolean
 }
 
-// Utility function to allot classes
-const allotClasses = (tag: string, isFrozen: boolean) => {
-  if (isFrozen) return { row: styles.frozenUtxo, tag: styles.utxoTagFreeze }
-  if (tag === 'deposit') return { row: styles.depositUtxo, tag: styles.utxoTagDeposit }
-  if (tag === 'joined' || tag === 'cj-out') return { row: styles.joinedUtxoAndCjout, tag: styles.utxoTagJoinedAndCjout }
-  if (tag === 'non-cj-change' || tag === 'reused')
-    return { row: styles.changeAndReuseUtxo, tag: styles.utxoTagChangeAndReuse }
-  return { row: styles.depositUtxo, tag: styles.utxoTagDeposit }
-}
-
 const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t }: UtxoRowProps) => {
   const displayAddress = useMemo(() => shortenStringMiddle(utxo.address, 24), [utxo.address])
-  const tag = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
-
-  const rowAndTagClass = useMemo(() => {
-    if (tag.length === 0) {
-      return { row: styles.depositUtxo, tag: styles.utxoTagDeposit }
-    }
-    return allotClasses(tag[0].value, utxo.frozen)
-  }, [tag, utxo.frozen])
+  const tags = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
 
   return (
     <Row
       item={utxo}
-      className={classNames(rowAndTagClass.row, {
+      className={classNames(styles.row, styles[`row-${tags[0].color || 'normal'}`], {
+        [styles['row-frozen']]: utxo.frozen,
         'bg-transparent': !showBackgroundColor,
         'cursor-pointer': utxo.selectable,
         'cursor-not-allowed': !utxo.selectable,
@@ -90,7 +75,7 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
         )}
       </Cell>
       <Cell>
-        <UtxoIcon value={utxo} tags={tag} />
+        <UtxoIcon value={utxo} tags={tags} />
       </Cell>
       <Cell className="slashed-zeroes">
         <rb.OverlayTrigger
@@ -117,9 +102,7 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
         />
       </Cell>
       <Cell>
-        {tag.length > 0 && (
-          <div className={classNames(rowAndTagClass.tag, 'd-inline-block')}>{tag[0].displayValue}</div>
-        )}
+        <UtxoTags value={tags} />
       </Cell>
     </Row>
   )

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -125,10 +125,7 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
   )
 }
 
-type SelectableUtxoTableRowData = SelectableUtxo & {
-  // TODO: add "tags" here and remove from "Utxo" type
-  // tags?: { tag: string; color: string }[]
-} & Pick<TableTypes.TableNode, 'id'>
+type SelectableUtxoTableRowData = SelectableUtxo & Pick<TableTypes.TableNode, 'id'>
 
 const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true }: UtxoListDisplayProps) => {
   const { t } = useTranslation()
@@ -137,7 +134,6 @@ const UtxoListDisplay = ({ utxos, onToggle, settings, showBackgroundColor = true
   const TABLE_THEME = {
     Table: `
     --data-table-library_grid-template-columns: 2.5rem 2.5rem 17rem 3rem 12rem 1fr};
-
   `,
     BaseCell: `
     padding: 0.35rem 0.25rem !important;

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -13,7 +13,7 @@ import Balance from '../Balance'
 import Divider from '../Divider'
 import { BaseModal } from '../Modal'
 import Sprite from '../Sprite'
-import { utxoTags } from '../jar_details/UtxoList'
+import { utxoTags } from '../utxo/utils'
 import { shortenStringMiddle } from '../../utils'
 import styles from './ShowUtxos.module.css'
 

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -16,6 +16,7 @@ import Sprite from '../Sprite'
 import { utxoTags } from '../utxo/utils'
 import { shortenStringMiddle } from '../../utils'
 import styles from './ShowUtxos.module.css'
+import { UtxoConfirmations } from '../utxo/Confirmations'
 
 interface ShowUtxosProps {
   isOpen: boolean
@@ -62,48 +63,8 @@ const allotClasses = (tag: string, isFrozen: boolean) => {
   return { row: styles.depositUtxo, tag: styles.utxoTagDeposit }
 }
 
-interface ConfirmationFormat {
-  symbol: string
-  display: string
-  confirmations: number
-}
-
-const formatConfirmations = (confirmations: number): ConfirmationFormat => ({
-  symbol: `confs-${confirmations >= 6 ? 'full' : confirmations}`,
-  display: confirmations > 9999 ? `${Number(9999).toLocaleString()}+` : confirmations.toLocaleString(),
-  confirmations,
-})
-
-const Confirmations = ({ value }: { value: ConfirmationFormat }) =>
-  value.confirmations > 9999 ? (
-    <rb.OverlayTrigger
-      popperConfig={{
-        modifiers: [
-          {
-            name: 'offset',
-            options: {
-              offset: [0, 1],
-            },
-          },
-        ],
-      }}
-      overlay={(props) => <rb.Tooltip {...props}>{value.confirmations.toLocaleString()}</rb.Tooltip>}
-    >
-      <div>
-        <Sprite symbol={value.symbol} width="28px" height="28px" className="mb-1" />
-        {value.display}
-      </div>
-    </rb.OverlayTrigger>
-  ) : (
-    <div>
-      <Sprite symbol={value.symbol} width="28px" height="28px" className="mb-1" />
-      {value.display}
-    </div>
-  )
-
 const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t }: UtxoRowProps) => {
   const address = useMemo(() => shortenStringMiddle(utxo.address, 16), [utxo.address])
-  const confFormat = useMemo(() => formatConfirmations(utxo.confirmations), [utxo.confirmations])
   const tag = useMemo(() => utxoTags(utxo, walletInfo, t), [utxo, walletInfo, t])
 
   const { icon, rowAndTagClass } = useMemo(() => {
@@ -142,7 +103,7 @@ const UtxoRow = ({ utxo, onToggle, showBackgroundColor, settings, walletInfo, t 
       </Cell>
       <Cell className="slashed-zeroes">{address}</Cell>
       <Cell>
-        <Confirmations value={confFormat} />
+        <UtxoConfirmations value={utxo} />
       </Cell>
       <Cell>
         <Balance

--- a/src/components/jar_details/UtxoList.module.css
+++ b/src/components/jar_details/UtxoList.module.css
@@ -38,23 +38,6 @@
   color: var(--bs-body-color);
 }
 
-.utxoList .utxoConfirmations {
-  width: 2rem;
-  display: flex;
-  gap: 0.1rem;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 0.1rem 0.2rem;
-  border-radius: 0.2rem;
-  color: var(--bs-success);
-  font-size: 0.6rem;
-}
-
-.utxoList .utxoConfirmations-0 {
-  color: var(--bs-info);
-}
-
 .utxoList .utxoTagList > .utxoTag {
   display: flex;
   justify-content: center;

--- a/src/components/jar_details/UtxoList.module.css
+++ b/src/components/jar_details/UtxoList.module.css
@@ -32,44 +32,6 @@
   display: none !important;
 }
 
-.utxoList .utxoTagList {
-  display: flex;
-  gap: 0.5rem;
-  color: var(--bs-body-color);
-}
-
-.utxoList .utxoTagList > .utxoTag {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.3rem;
-  font-size: 0.7rem;
-  border: 1px solid var(--bs-body-color);
-  border-radius: 0.2rem;
-  padding: 0.1rem 0.3rem;
-}
-
-.utxoList .utxoTagList > .utxoTag.utxoTag-success {
-  color: var(--bs-success);
-  background-color: rgba(var(--bs-success-rgb), 0.1);
-  border-color: var(--bs-success);
-}
-.utxoList .utxoTagList > .utxoTag.utxoTag-warning {
-  color: var(--bs-warning);
-  background-color: rgba(var(--bs-warning-rgb), 0.1);
-  border-color: var(--bs-warning);
-}
-.utxoList .utxoTagList > .utxoTag.utxoTag-danger {
-  color: var(--bs-danger);
-  background-color: rgba(var(--bs-danger-rgb), 0.1);
-  border-color: var(--bs-danger);
-}
-.utxoList .utxoTagList > .utxoTag.utxoTag-dark {
-  color: var(--bs-white);
-  background-color: var(--bs-dark);
-  border-color: var(--bs-dark);
-}
-
 .utxoList .utxoListButtonDetails {
   font-size: 0.9rem;
 }

--- a/src/components/jar_details/UtxoList.module.css
+++ b/src/components/jar_details/UtxoList.module.css
@@ -7,10 +7,6 @@
   margin-bottom: 1px;
 }
 
-.utxoList .utxoIcon > .iconFrozen {
-  margin-bottom: 1px;
-}
-
 .utxoList tr.frozen td {
   --bs-code-color: var(--bs-blue);
   color: var(--bs-blue);
@@ -34,10 +30,6 @@
 }
 .utxoList tr.frozen :global .balance-hook .frozen-symbol-hook {
   display: none !important;
-}
-
-.utxoList .utxoIcon > .iconLocked {
-  margin-bottom: 3px;
 }
 
 .utxoList .utxoTagList {

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -12,7 +12,7 @@ import { useTheme } from '@table-library/react-table-library/theme'
 import { useSettings } from '../../context/SettingsContext'
 import { Utxo, WalletInfo } from '../../context/WalletContext'
 import * as fb from '../fb/utils'
-import { utxoTags, Tag } from '../utxo/utils'
+import { utxoTags, UtxoTag } from '../utxo/utils'
 import { shortenStringMiddle } from '../../utils'
 import Sprite from '../Sprite'
 import Balance from '../Balance'
@@ -92,7 +92,7 @@ const toUtxo = (tableNode: TableTypes.TableNode): Utxo => {
 
 interface UtxoTableRow extends Utxo, TableTypes.TableNode {
   _icon: JSX.Element
-  _tags: Tag[]
+  _tags: UtxoTag[]
   _confs: JSX.Element
 }
 
@@ -121,7 +121,7 @@ const UtxoList = ({
       nodes: utxos.map((utxo: Utxo) => ({
         ...utxo,
         id: utxo.utxo,
-        _icon: <UtxoIcon value={utxo} />,
+        _icon: <UtxoIcon value={utxo} size={20} />,
         _tags: utxoTags(utxo, walletInfo, t),
         _confs: <UtxoConfirmations className={utxo.confirmations === 0 ? 'text-info' : 'text-success'} value={utxo} />,
       })),
@@ -188,7 +188,9 @@ const UtxoList = ({
         [SORT_KEYS.value]: (array) => array.sort((a, b) => a.value - b.value),
         [SORT_KEYS.confirmations]: (array) => array.sort((a, b) => a.confirmations - b.confirmations),
         [SORT_KEYS.tags]: (array) =>
-          array.sort((a, b) => (String(a._tags[0]?.tag) || 'z').localeCompare(String(b._tags[0]?.tag) || 'z')),
+          array.sort((a, b) =>
+            (String(a._tags[0]?.displayValue) || 'z').localeCompare(String(b._tags[0]?.displayValue) || 'z'),
+          ),
       },
     },
   )
@@ -261,6 +263,7 @@ const UtxoList = ({
                         convertToUnit={settings.unit}
                         showBalance={settings.showBalance}
                         frozen={item.frozen}
+                        colored={!item.locktime}
                       />
                     </Cell>
                     <Cell>
@@ -283,9 +286,9 @@ const UtxoList = ({
                     <Cell>{item._confs}</Cell>
                     <Cell>
                       <div className={styles.utxoTagList}>
-                        {item._tags.map((tag: Tag, index: number) => (
+                        {item._tags.map((tag: UtxoTag, index: number) => (
                           <div key={index} className={classNames(styles.utxoTag, styles[`utxoTag-${tag.color}`])}>
-                            {tag.tag}
+                            {tag.displayValue}
                           </div>
                         ))}
                       </div>

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -19,21 +19,11 @@ import Balance from '../Balance'
 import TablePagination from '../TablePagination'
 import styles from './UtxoList.module.css'
 import UtxoIcon from '../utxo/UtxoIcon'
+import { UtxoConfirmations } from '../utxo/Confirmations'
 
 const withTooltip = ({ node, tooltip }: { node: React.ReactElement; tooltip: React.ReactElement }) => {
   return (
     <rb.OverlayTrigger overlay={(props) => <rb.Tooltip {...props}>{tooltip}</rb.Tooltip>}>{node}</rb.OverlayTrigger>
-  )
-}
-
-const utxoConfirmations = (utxo: Utxo) => {
-  const symbol = `confs-${utxo.confirmations >= 6 ? 'full' : utxo.confirmations}`
-
-  return (
-    <div className={classNames(styles.utxoConfirmations, styles[`utxoConfirmations-${utxo.confirmations}`])}>
-      <Sprite symbol={symbol} width="20" height="20" />
-      <div>{utxo.confirmations}</div>
-    </div>
   )
 }
 
@@ -133,7 +123,7 @@ const UtxoList = ({
         id: utxo.utxo,
         _icon: <UtxoIcon value={utxo} />,
         _tags: utxoTags(utxo, walletInfo, t),
-        _confs: utxoConfirmations(utxo),
+        _confs: <UtxoConfirmations value={utxo} />,
       })),
     }),
     [utxos, walletInfo, t],

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -123,7 +123,7 @@ const UtxoList = ({
         id: utxo.utxo,
         _icon: <UtxoIcon value={utxo} />,
         _tags: utxoTags(utxo, walletInfo, t),
-        _confs: <UtxoConfirmations value={utxo} />,
+        _confs: <UtxoConfirmations className={utxo.confirmations === 0 ? 'text-info' : 'text-success'} value={utxo} />,
       })),
     }),
     [utxos, walletInfo, t],

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import * as rb from 'react-bootstrap'
 import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
-import { TFunction } from 'i18next'
 import { Table, Header, HeaderRow, HeaderCell, Body, Row, Cell } from '@table-library/react-table-library/table'
 import { usePagination } from '@table-library/react-table-library/pagination'
 import { useRowSelect, HeaderCellSelect, CellSelect, SelectTypes } from '@table-library/react-table-library/select'
@@ -13,73 +12,18 @@ import { useTheme } from '@table-library/react-table-library/theme'
 import { useSettings } from '../../context/SettingsContext'
 import { Utxo, WalletInfo } from '../../context/WalletContext'
 import * as fb from '../fb/utils'
+import { utxoTags, Tag } from '../utxo/utils'
 import { shortenStringMiddle } from '../../utils'
 import Sprite from '../Sprite'
 import Balance from '../Balance'
 import TablePagination from '../TablePagination'
 import styles from './UtxoList.module.css'
+import UtxoIcon from '../utxo/UtxoIcon'
 
 const withTooltip = ({ node, tooltip }: { node: React.ReactElement; tooltip: React.ReactElement }) => {
   return (
     <rb.OverlayTrigger overlay={(props) => <rb.Tooltip {...props}>{tooltip}</rb.Tooltip>}>{node}</rb.OverlayTrigger>
   )
-}
-
-const ADDRESS_STATUS_COLORS: { [key: string]: string } = {
-  new: 'normal',
-  used: 'normal',
-  reused: 'danger',
-  'cj-out': 'success',
-  'change-out': 'warning',
-  'non-cj-change': 'normal',
-  deposit: 'normal',
-}
-
-type Tag = { tag: string; color: string }
-
-export const utxoTags = (utxo: Utxo, walletInfo: WalletInfo, t: TFunction): Tag[] => {
-  const rawStatus = walletInfo.addressSummary[utxo.address]?.status
-
-  let status: string | null = null
-
-  // If a UTXO is locked, it's `status` will be the locktime, with other states
-  // appended in brackets, e.g. `2099-12-01 [LOCKED] [FROZEN]`
-  if (rawStatus && !utxo.locktime) {
-    const indexOfOtherTag = rawStatus.indexOf('[')
-
-    if (indexOfOtherTag !== -1) {
-      status = rawStatus.substring(0, indexOfOtherTag).trim()
-    } else {
-      status = rawStatus
-    }
-  }
-
-  const tags: Tag[] = []
-
-  if (utxo.label) tags.push({ tag: utxo.label, color: 'normal' })
-  if (status) tags.push({ tag: status, color: ADDRESS_STATUS_COLORS[status] || 'normal' })
-  if (fb.utxo.isFidelityBond(utxo)) tags.push({ tag: t('jar_details.utxo_list.utxo_tag_fb'), color: 'dark' })
-  return tags
-}
-
-const utxoIcon = (utxo: Utxo, t: TFunction) => {
-  if (fb.utxo.isFidelityBond(utxo)) {
-    return withTooltip({
-      node: (
-        <div className={styles.utxoIcon}>
-          <Sprite className={styles.iconLocked} symbol="timelock" width="20" height="20" />
-        </div>
-      ),
-      tooltip: <div>{t('jar_details.utxo_list.utxo_tooltip_locktime', { locktime: utxo.locktime })}</div>,
-    })
-  } else if (utxo.frozen) {
-    return (
-      <div className={styles.utxoIcon}>
-        <Sprite className={styles.iconFrozen} symbol="snowflake" width="20" height="20" />
-      </div>
-    )
-  }
-  return <></>
 }
 
 const utxoConfirmations = (utxo: Utxo) => {
@@ -187,7 +131,7 @@ const UtxoList = ({
       nodes: utxos.map((utxo: Utxo) => ({
         ...utxo,
         id: utxo.utxo,
-        _icon: utxoIcon(utxo, t),
+        _icon: <UtxoIcon value={utxo} />,
         _tags: utxoTags(utxo, walletInfo, t),
         _confs: utxoConfirmations(utxo),
       })),

--- a/src/components/jar_details/UtxoList.tsx
+++ b/src/components/jar_details/UtxoList.tsx
@@ -20,6 +20,7 @@ import TablePagination from '../TablePagination'
 import styles from './UtxoList.module.css'
 import UtxoIcon from '../utxo/UtxoIcon'
 import { UtxoConfirmations } from '../utxo/Confirmations'
+import UtxoTags from '../utxo/UtxoTags'
 
 const withTooltip = ({ node, tooltip }: { node: React.ReactElement; tooltip: React.ReactElement }) => {
   return (
@@ -285,13 +286,7 @@ const UtxoList = ({
                     </Cell>
                     <Cell>{item._confs}</Cell>
                     <Cell>
-                      <div className={styles.utxoTagList}>
-                        {item._tags.map((tag: UtxoTag, index: number) => (
-                          <div key={index} className={classNames(styles.utxoTag, styles[`utxoTag-${tag.color}`])}>
-                            {tag.displayValue}
-                          </div>
-                        ))}
-                      </div>
+                      <UtxoTags value={item._tags} />
                     </Cell>
                     <Cell>
                       <rb.Button

--- a/src/components/utxo/Confirmations.module.css
+++ b/src/components/utxo/Confirmations.module.css
@@ -1,16 +1,10 @@
 .confirmations {
   width: 2rem;
   display: flex;
-  gap: 0.1rem;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   padding: 0.1rem 0.2rem;
   border-radius: 0.2rem;
-  color: var(--bs-success);
-  font-size: 0.6rem;
-}
-
-.confirmations-0 {
-  color: var(--bs-info);
+  font-size: 0.75rem;
 }

--- a/src/components/utxo/Confirmations.module.css
+++ b/src/components/utxo/Confirmations.module.css
@@ -1,0 +1,16 @@
+.confirmations {
+  width: 2rem;
+  display: flex;
+  gap: 0.1rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.2rem;
+  color: var(--bs-success);
+  font-size: 0.6rem;
+}
+
+.confirmations-0 {
+  color: var(--bs-info);
+}

--- a/src/components/utxo/Confirmations.tsx
+++ b/src/components/utxo/Confirmations.tsx
@@ -1,0 +1,19 @@
+import classNames from 'classnames'
+import { Utxo } from '../../context/WalletContext'
+import Sprite from '../Sprite'
+import styles from './Confirmations.module.css'
+
+interface UtxoConfirmationsProps {
+  value: Utxo
+}
+
+export function UtxoConfirmations({ value }: UtxoConfirmationsProps) {
+  const symbol = `confs-${value.confirmations >= 6 ? 'full' : value.confirmations}`
+
+  return (
+    <div className={classNames(styles.confirmations, styles[`confirmations-${value.confirmations}`])}>
+      <Sprite symbol={symbol} width="20" height="20" />
+      <div>{value.confirmations}</div>
+    </div>
+  )
+}

--- a/src/components/utxo/Confirmations.tsx
+++ b/src/components/utxo/Confirmations.tsx
@@ -1,19 +1,51 @@
+import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import classNames from 'classnames'
 import { Utxo } from '../../context/WalletContext'
 import Sprite from '../Sprite'
 import styles from './Confirmations.module.css'
 
-interface UtxoConfirmationsProps {
-  value: Utxo
+interface ConfirmationFormat {
+  symbol: string
+  display: string
+  tooltip?: string
+  confirmations: number
 }
 
-export function UtxoConfirmations({ value }: UtxoConfirmationsProps) {
-  const symbol = `confs-${value.confirmations >= 6 ? 'full' : value.confirmations}`
+const formatConfirmations = (confirmations: number): ConfirmationFormat => ({
+  symbol: `confs-${confirmations >= 6 ? 'full' : confirmations}`,
+  display: confirmations > 9999 ? `${Number(9999).toLocaleString()}+` : confirmations.toLocaleString(),
+  tooltip: confirmations > 9999 ? confirmations.toLocaleString() : undefined,
+  confirmations,
+})
 
-  return (
-    <div className={classNames(styles.confirmations, styles[`confirmations-${value.confirmations}`])}>
-      <Sprite symbol={symbol} width="20" height="20" />
-      <div>{value.confirmations}</div>
+export function Confirmations({ className, value }: { className?: string; value: ConfirmationFormat }) {
+  return value.tooltip !== undefined ? (
+    <OverlayTrigger
+      popperConfig={{
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              offset: [0, 1],
+            },
+          },
+        ],
+      }}
+      overlay={(props) => <Tooltip {...props}>{value.tooltip}</Tooltip>}
+    >
+      <div className={classNames(className, styles.confirmations, styles[`confirmations-${value.confirmations}`])}>
+        <Sprite symbol={value.symbol} width="20" height="20" />
+        <div>{value.display}</div>
+      </div>
+    </OverlayTrigger>
+  ) : (
+    <div className={classNames(className, styles.confirmations, styles[`confirmations-${value.confirmations}`])}>
+      <Sprite symbol={value.symbol} width="20" height="20" />
+      <div>{value.display}</div>
     </div>
   )
+}
+
+export function UtxoConfirmations({ className, value }: { className?: string; value: Utxo }) {
+  return <Confirmations className={className} value={formatConfirmations(value.confirmations)} />
 }

--- a/src/components/utxo/UtxoIcon.module.css
+++ b/src/components/utxo/UtxoIcon.module.css
@@ -1,0 +1,7 @@
+.utxoIcon > .iconFrozen {
+  margin-bottom: 1px;
+}
+
+.utxoIcon > .iconLocked {
+  margin-bottom: 3px;
+}

--- a/src/components/utxo/UtxoIcon.module.css
+++ b/src/components/utxo/UtxoIcon.module.css
@@ -1,7 +1,5 @@
-.utxoIcon > .iconFrozen {
-  margin-bottom: 1px;
-}
-
-.utxoIcon > .iconLocked {
-  margin-bottom: 3px;
+.utxoIcon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/src/components/utxo/UtxoIcon.tsx
+++ b/src/components/utxo/UtxoIcon.tsx
@@ -1,37 +1,59 @@
+import { PropsWithChildren, useMemo } from 'react'
 import * as rb from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import { Utxo } from '../../context/WalletContext'
 import * as fb from '../fb/utils'
+import { UtxoTag, UtxoStatus } from './utils'
 import Sprite from '../Sprite'
 import styles from './UtxoIcon.module.css'
 
-interface UtxoIconProps {
-  value: Utxo
+const toIcon = (utxo: Utxo, tags?: UtxoStatus[]) => {
+  if (fb.utxo.isFidelityBond(utxo)) return 'timelock'
+  if (utxo.frozen) return 'snowflake'
+  if (tags?.includes('cj-out')) return 'mixed'
+  if (tags) return 'unmixed'
+  return undefined
 }
 
-export default function UtxoIcon({ value }: UtxoIconProps) {
+function LockedIconTooltip({ utxo, children }: PropsWithChildren<{ utxo: Utxo }>) {
   const { t } = useTranslation()
 
+  return (
+    <rb.OverlayTrigger
+      overlay={(props) => (
+        <rb.Tooltip {...props}>
+          <div>{t('jar_details.utxo_list.utxo_tooltip_locktime', { locktime: utxo.locktime })}</div>
+        </rb.Tooltip>
+      )}
+    >
+      <div>{children}</div>
+    </rb.OverlayTrigger>
+  )
+}
+
+interface UtxoIconProps {
+  value: Utxo
+  tags?: UtxoTag[]
+  size?: 20 | 24
+}
+
+export default function UtxoIcon({ value, tags, size = 24 }: UtxoIconProps) {
+  const symbol = useMemo(
+    () =>
+      toIcon(
+        value,
+        tags?.map((it) => it.value),
+      ),
+    [value, tags],
+  )
+
+  const element = (
+    <div className={styles.utxoIcon}>{symbol && <Sprite symbol={symbol} width={size} height={size} />}</div>
+  )
+
   if (fb.utxo.isFidelityBond(value)) {
-    return (
-      <rb.OverlayTrigger
-        overlay={(props) => (
-          <rb.Tooltip {...props}>
-            <div>{t('jar_details.utxo_list.utxo_tooltip_locktime', { locktime: value.locktime })}</div>
-          </rb.Tooltip>
-        )}
-      >
-        <div className={styles.utxoIcon}>
-          <Sprite className={styles.iconLocked} symbol="timelock" width="20" height="20" />
-        </div>
-      </rb.OverlayTrigger>
-    )
-  } else if (value.frozen) {
-    return (
-      <div className={styles.utxoIcon}>
-        <Sprite className={styles.iconFrozen} symbol="snowflake" width="20" height="20" />
-      </div>
-    )
+    return <LockedIconTooltip utxo={value}>{element}</LockedIconTooltip>
   }
-  return <></>
+
+  return element
 }

--- a/src/components/utxo/UtxoIcon.tsx
+++ b/src/components/utxo/UtxoIcon.tsx
@@ -1,0 +1,37 @@
+import * as rb from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
+import { Utxo } from '../../context/WalletContext'
+import * as fb from '../fb/utils'
+import Sprite from '../Sprite'
+import styles from './UtxoIcon.module.css'
+
+interface UtxoIconProps {
+  value: Utxo
+}
+
+export default function UtxoIcon({ value }: UtxoIconProps) {
+  const { t } = useTranslation()
+
+  if (fb.utxo.isFidelityBond(value)) {
+    return (
+      <rb.OverlayTrigger
+        overlay={(props) => (
+          <rb.Tooltip {...props}>
+            <div>{t('jar_details.utxo_list.utxo_tooltip_locktime', { locktime: value.locktime })}</div>
+          </rb.Tooltip>
+        )}
+      >
+        <div className={styles.utxoIcon}>
+          <Sprite className={styles.iconLocked} symbol="timelock" width="20" height="20" />
+        </div>
+      </rb.OverlayTrigger>
+    )
+  } else if (value.frozen) {
+    return (
+      <div className={styles.utxoIcon}>
+        <Sprite className={styles.iconFrozen} symbol="snowflake" width="20" height="20" />
+      </div>
+    )
+  }
+  return <></>
+}

--- a/src/components/utxo/UtxoTags.module.css
+++ b/src/components/utxo/UtxoTags.module.css
@@ -1,0 +1,37 @@
+.utxoTagList {
+  display: flex;
+  gap: 0.5rem;
+  color: var(--bs-body-color);
+}
+
+.utxoTagList > .utxoTag {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.7rem;
+  border: 1px solid var(--bs-body-color);
+  border-radius: 0.2rem;
+  padding: 0.1rem 0.3rem;
+}
+
+.utxoTagList > .utxoTag.utxoTag-success {
+  color: var(--bs-success);
+  background-color: rgba(var(--bs-success-rgb), 0.1);
+  border-color: var(--bs-success);
+}
+.utxoTagList > .utxoTag.utxoTag-warning {
+  color: var(--bs-warning);
+  background-color: rgba(var(--bs-warning-rgb), 0.1);
+  border-color: var(--bs-warning);
+}
+.utxoTagList > .utxoTag.utxoTag-danger {
+  color: var(--bs-danger);
+  background-color: rgba(var(--bs-danger-rgb), 0.1);
+  border-color: var(--bs-danger);
+}
+.utxoTagList > .utxoTag.utxoTag-dark {
+  color: var(--bs-white);
+  background-color: var(--bs-dark);
+  border-color: var(--bs-dark);
+}

--- a/src/components/utxo/UtxoTags.tsx
+++ b/src/components/utxo/UtxoTags.tsx
@@ -1,0 +1,19 @@
+import classNames from 'classnames'
+import { UtxoTag } from '../utxo/utils'
+import styles from './UtxoTags.module.css'
+
+interface UtxoTagsProps {
+  value: UtxoTag[]
+}
+
+export default function UtxoTags({ value }: UtxoTagsProps) {
+  return (
+    <div className={styles.utxoTagList}>
+      {value.map((tag: UtxoTag, index: number) => (
+        <div key={index} className={classNames(styles.utxoTag, styles[`utxoTag-${tag.color}`])}>
+          {tag.displayValue}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/utxo/utils.ts
+++ b/src/components/utxo/utils.ts
@@ -2,7 +2,9 @@ import { TFunction } from 'i18next'
 import { Utxo, WalletInfo } from '../../context/WalletContext'
 import * as fb from '../fb/utils'
 
-const ADDRESS_STATUS_COLORS: { [key: string]: string } = {
+export type UtxoStatus = 'new' | 'used' | 'reused' | 'cj-out' | 'non-cj-change' | 'change-out' | 'deposit' | string
+
+const UTXO_STATUS_COLORS: { [key in UtxoStatus]: string } = {
   new: 'normal',
   used: 'normal',
   reused: 'danger',
@@ -12,15 +14,16 @@ const ADDRESS_STATUS_COLORS: { [key: string]: string } = {
   deposit: 'normal',
 }
 
-export type Tag = { tag: string; color: string }
+export type UtxoTag = { value: UtxoStatus; displayValue: string; color: string }
 
-export const utxoTags = (utxo: Utxo, walletInfo: WalletInfo, t: TFunction): Tag[] => {
+export const utxoTags = (utxo: Utxo, walletInfo: WalletInfo, t: TFunction): UtxoTag[] => {
   const rawStatus = walletInfo.addressSummary[utxo.address]?.status
 
   let status: string | null = null
 
   // If a UTXO is locked, it's `status` will be the locktime, with other states
   // appended in brackets, e.g. `2099-12-01 [LOCKED] [FROZEN]`
+  // other possible values include `cj-out`, `reused [FROZEN]`, etc.
   if (rawStatus && !utxo.locktime) {
     const indexOfOtherTag = rawStatus.indexOf('[')
 
@@ -31,10 +34,11 @@ export const utxoTags = (utxo: Utxo, walletInfo: WalletInfo, t: TFunction): Tag[
     }
   }
 
-  const tags: Tag[] = []
+  const tags: UtxoTag[] = []
 
-  if (status) tags.push({ tag: status, color: ADDRESS_STATUS_COLORS[status] || 'normal' })
-  if (fb.utxo.isFidelityBond(utxo)) tags.push({ tag: t('jar_details.utxo_list.utxo_tag_fb'), color: 'dark' })
-  if (utxo.label) tags.push({ tag: utxo.label, color: 'normal' })
+  if (fb.utxo.isFidelityBond(utxo))
+    tags.push({ value: 'bond', displayValue: t('jar_details.utxo_list.utxo_tag_fb'), color: 'dark' })
+  if (status) tags.push({ value: status, displayValue: status, color: UTXO_STATUS_COLORS[status] || 'normal' })
+  if (utxo.label) tags.push({ value: utxo.label, displayValue: utxo.label, color: 'normal' })
   return tags
 }

--- a/src/components/utxo/utils.ts
+++ b/src/components/utxo/utils.ts
@@ -1,0 +1,40 @@
+import { TFunction } from 'i18next'
+import { Utxo, WalletInfo } from '../../context/WalletContext'
+import * as fb from '../fb/utils'
+
+const ADDRESS_STATUS_COLORS: { [key: string]: string } = {
+  new: 'normal',
+  used: 'normal',
+  reused: 'danger',
+  'cj-out': 'success',
+  'change-out': 'warning',
+  'non-cj-change': 'normal',
+  deposit: 'normal',
+}
+
+export type Tag = { tag: string; color: string }
+
+export const utxoTags = (utxo: Utxo, walletInfo: WalletInfo, t: TFunction): Tag[] => {
+  const rawStatus = walletInfo.addressSummary[utxo.address]?.status
+
+  let status: string | null = null
+
+  // If a UTXO is locked, it's `status` will be the locktime, with other states
+  // appended in brackets, e.g. `2099-12-01 [LOCKED] [FROZEN]`
+  if (rawStatus && !utxo.locktime) {
+    const indexOfOtherTag = rawStatus.indexOf('[')
+
+    if (indexOfOtherTag !== -1) {
+      status = rawStatus.substring(0, indexOfOtherTag).trim()
+    } else {
+      status = rawStatus
+    }
+  }
+
+  const tags: Tag[] = []
+
+  if (status) tags.push({ tag: status, color: ADDRESS_STATUS_COLORS[status] || 'normal' })
+  if (fb.utxo.isFidelityBond(utxo)) tags.push({ tag: t('jar_details.utxo_list.utxo_tag_fb'), color: 'dark' })
+  if (utxo.label) tags.push({ tag: utxo.label, color: 'normal' })
+  return tags
+}

--- a/src/components/utxo/utils.ts
+++ b/src/components/utxo/utils.ts
@@ -10,7 +10,7 @@ const UTXO_STATUS_COLORS: { [key in UtxoStatus]: string } = {
   reused: 'danger',
   'cj-out': 'success',
   'change-out': 'warning',
-  'non-cj-change': 'normal',
+  'non-cj-change': 'warning',
   deposit: 'normal',
 }
 

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -53,8 +53,6 @@ export type Utxo = {
   // `locktime` in format "yyyy-MM-dd 00:00:00"
   // NOTE: it is unparsable with safari Date constructor
   locktime?: string
-  // TODO: remove 'tags' prop
-  tags?: { tag: string; color: string }[]
 }
 
 export type Utxos = Utxo[]


### PR DESCRIPTION
This is a follow-up PR to #771 which introduces some UTXO related UI components that can be reused across different pages or interface elements, i.e. the UTXO list in the Jar Details View and the Quick Freeze Modal on the Send page.

Some details are subject to discussion, e.g. the color scheme and/or icons.
This is not a pixel-perfect representation of the Figma designs, but simplifies the current state and increases reusability.

Next step would be alignment and adaptation of the wording (not done in this PR).

## :camera_flash: 

<img src="https://github.com/user-attachments/assets/7494b2f2-a683-41d9-b5d5-afae165f98d9" width=250 />
<img src="https://github.com/user-attachments/assets/4f5353f9-5ff2-4807-aa41-2f005ab20172" width=250 />

