### PR TITLE
Improves readablity of balances on the tooltip in light mode

### DIFF
--- a/src/components/Orderbook.tsx
+++ b/src/components/Orderbook.tsx
@@ -190,7 +190,12 @@ const renderOrderAsRow = (item: OrderTableRow, settings: any) => {
             }}
             overlay={(props) => (
               <rb.Tooltip {...props}>
-                <Balance valueString={String(item.bondValue.amount)} convertToUnit={BTC} showBalance={true} />
+                <Balance
+                  valueString={String(item.bondValue.amount)}
+                  colored={false}
+                  convertToUnit={BTC}
+                  showBalance={true}
+                />
                 <div className="small">
                   {item.bondValue.displayLocktime} ({item.bondValue.displayExpiresIn})
                 </div>


### PR DESCRIPTION
Fixes #770 
Makes the text of the balances on the tooltip consistent.
Light-Mode:
![Screenshot 2024-08-24 at 5 02 35 PM](https://github.com/user-attachments/assets/a4e21395-6ea6-4d17-867b-15a2d5b460fd)
Dark-Mode:
![Screenshot 2024-08-24 at 5 08 12 PM](https://github.com/user-attachments/assets/e9168c15-2e7d-47bc-8e13-1d7e6a460ce7)
