### PR TITLE
Settings: remove link to dead JM twitter

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -256,12 +256,6 @@ export default function Settings({ wallet, stopWallet }: SettingsProps) {
               {t('settings.telegram')}
             </div>
           </a>
-          <a href="https://twitter.com/joinmarket" target="_blank" rel="noopener noreferrer" className="link-dark">
-            <div className="d-flex align-items-center">
-              <Sprite symbol="twitter" width="24" height="24" className="me-2 p-1" />
-              {t('settings.jm_twitter')}
-            </div>
-          </a>
         </div>
         <div className={styles['section-title']}>{t('settings.section_title_dev')}</div>
         <div className={styles['settings-links']}>


### PR DESCRIPTION
it's a dead account

I was also removed from the Jam docs https://github.com/joinmarket-webui/jamdocs/pull/61, as JM doesn't want to link to this account either

![jmtwitterremoval](https://github.com/user-attachments/assets/5cbdab0b-4715-43d3-a9a7-3c0633a349c9)
