### PR TITLE
chore(i18n): remove unused translations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,15 @@
 name: Build
 
 on:
-  # Run the build for pushes and pull requests targeting master
+  # Run the build for pushes and pull requests targeting master and devel
   push:
     branches:
       - master
+      - devel
   pull_request:
     branches:
       - master
+      - devel
 
 jobs:
   build:

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -135,30 +135,28 @@ export default function App() {
                   <h5 className="alert-heading">
                     {t('app.alert_no_connection', { connectionError: sessionConnectionError.message })}
                   </h5>
-                  {!sessionConnectionError.response?.ok && (
-                    <>
-                      <p>
-                        <Trans
-                          i18nKey="app.alert_no_connection_details"
-                          components={{
-                            1: (
-                              <a
-                                className="alert-link"
-                                href="https://jamdocs.org/FAQ/#how-to-resolve-no-connection-to-gateway"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                the docs
-                              </a>
-                            ),
-                          }}
-                        />
-                      </p>
-                      <pre>
-                        {sessionConnectionError.response.status}&nbsp;{sessionConnectionError.response.statusText}&nbsp;
-                        {sessionConnectionError.response.url}
-                      </pre>
-                    </>
+                  <p>
+                    <Trans
+                      i18nKey="app.alert_no_connection_details"
+                      components={{
+                        1: (
+                          <a
+                            className="alert-link"
+                            href="https://jamdocs.org/FAQ/#how-to-resolve-no-connection-to-gateway"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            the docs
+                          </a>
+                        ),
+                      }}
+                    />
+                  </p>
+                  {sessionConnectionError.response && !sessionConnectionError.response.ok && (
+                    <pre>
+                      {sessionConnectionError.response.status}&nbsp;{sessionConnectionError.response.statusText}&nbsp;
+                      {sessionConnectionError.response.url}
+                    </pre>
                   )}
                 </rb.Alert>
               }

--- a/src/components/Settings.test.tsx
+++ b/src/components/Settings.test.tsx
@@ -38,8 +38,8 @@ describe('<Settings />', () => {
     expect(screen.queryByText(/settings.button_switch_wallet/)).toBeVisible()
 
     expect(screen.getByText('settings.section_title_community')).toBeVisible()
+    expect(screen.queryByText(/settings.matrix/)).toBeVisible()
     expect(screen.queryByText(/settings.telegram/)).toBeVisible()
-    expect(screen.queryByText(/settings.jm_twitter/)).toBeVisible()
 
     expect(screen.getByText('settings.section_title_community')).toBeVisible()
     expect(screen.queryByText(/settings.documentation/)).toBeVisible()

--- a/src/components/Settings.test.tsx
+++ b/src/components/Settings.test.tsx
@@ -33,8 +33,12 @@ describe('<Settings />', () => {
     expect(screen.queryByText(/settings.use_(dark|light)_theme/)).toBeVisible()
     expect(screen.queryByText(/English/)).toBeVisible()
 
+    expect(screen.getByText('settings.section_title_market')).toBeVisible()
+    expect(screen.queryByText(/settings.show_fee_config/)).toBeVisible()
+
     expect(screen.getByText('settings.section_title_wallet')).toBeVisible()
     expect(screen.queryByText(/settings.(show|hide)_seed/)).toBeVisible()
+    expect(screen.queryByText(/settings.button_lock_wallet/)).toBeVisible()
     expect(screen.queryByText(/settings.button_switch_wallet/)).toBeVisible()
 
     expect(screen.getByText('settings.section_title_community')).toBeVisible()

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -221,7 +221,6 @@
     "github": "GitHub",
     "matrix": "Matrix",
     "telegram": "Telegram",
-    "jm_twitter": "JoinMarket Twitter",
     "confirm_locking_modal_title": "Wallet sperren",
     "confirm_locking_modal_body_earn": "Earn Modus aktiv. Das Sperren der Wallet wird diesen Modus beenden. Du kannst das Browserfenster schließen und Jam im Hintergrund weiterlaufen lassen. ",
     "confirm_locking_modal_body_jam": "Eine gemeinschaftliche Transaktion ist derzeit im Gange. Das Sperren der Wallet wird diese beenden. Du kannst das Browserfenster schließen und Jam im Hintergrund weiterlaufen lassen. ",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -233,7 +233,6 @@
     "github": "GitHub",
     "matrix": "Matrix",
     "telegram": "Telegram",
-    "jm_twitter": "JoinMarket Twitter",
     "confirm_locking_modal_title": "Lock Wallet",
     "confirm_locking_modal_body_earn": "Earn is active. Locking the wallet will stop the service. You can close the browser window to let it run in the background.",
     "confirm_locking_modal_body_jam": "A collaborative transaction is being executed. Locking the wallet will stop the service. You can close the browser window to let it run in the background.",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -165,7 +165,6 @@
     "github": "GitHub",
     "matrix": "Matrix",
     "telegram": "Telegram",
-    "jm_twitter": "JoinMarket Twitter",
     "confirm_locking_modal_title": "Verrouiller le Portefeuille",
     "fees": {
       "text_button_cancel": "Annuler",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -185,7 +185,6 @@
     "github": "GitHub",
     "matrix": "Matrix",
     "telegram": "Telegram",
-    "jm_twitter": "JoinMarket Twitter",
     "confirm_locking_modal_title": "Blocca portafoglio",
     "confirm_locking_modal_body_earn": "La funzione Guadagna è attiva. Il blocco del portafoglio interromperà il servizio. È possibile chiudere la finestra del browser per lasciarlo funzionare in background.",
     "confirm_locking_modal_body_jam": "È in corso l'esecuzione di una transazione collaborativa. Bloccando il portafoglio si interromperà il servizio. È possibile chiudere la finestra del browser per lasciarlo funzionare in background.",

--- a/src/i18n/locales/pt_BR/translation.json
+++ b/src/i18n/locales/pt_BR/translation.json
@@ -185,7 +185,6 @@
     "github": "GitHub",
     "matrix": "Matrix",
     "telegram": "Telegram",
-    "jm_twitter": "JoinMarket no Twitter",
     "confirm_locking_modal_title": "Trancar Carteira",
     "confirm_locking_modal_body_earn": "'Lucrar' está ativo. Bloquear a carteira interromperá o serviço. Você pode fechar a janela do navegador para deixá-lo rodar em segundo plano.",
     "confirm_locking_modal_body_jam": "Uma transação colaborativa está sendo executada. Bloquear a carteira interromperá o serviço. Você pode fechar a janela do navegador para deixá-lo rodar em segundo plano.",

--- a/src/i18n/locales/zh_Hans/translation.json
+++ b/src/i18n/locales/zh_Hans/translation.json
@@ -221,7 +221,6 @@
     "github": "GitHub",
     "matrix": "Matrix",
     "telegram": "Telegram",
-    "jm_twitter": "JoinMarket 推特",
     "confirm_locking_modal_title": "锁上钱包",
     "confirm_locking_modal_body_earn": "收益处于活跃状态。钱包上锁将停止服务。你可以关闭浏览器窗口并让它在背景中运行。",
     "confirm_locking_modal_body_jam": "协作式交易正在进行中。钱包上锁将停止服务。你可以关闭浏览器窗口并让它在背景中运行。",

--- a/src/i18n/locales/zh_Hant/translation.json
+++ b/src/i18n/locales/zh_Hant/translation.json
@@ -221,7 +221,6 @@
     "github": "GitHub",
     "matrix": "Matrix",
     "telegram": "Telegram",
-    "jm_twitter": "JoinMarket 推特",
     "confirm_locking_modal_title": "鎖上錢包",
     "confirm_locking_modal_body_earn": "收益處於活躍狀態。錢包上鎖將停止服務。你可以關閉瀏覽器窗口並讓它在背景中運行。",
     "confirm_locking_modal_body_jam": "協作式交易正在進行中。錢包上鎖將停止服務。你可以關閉瀏覽器窗口並讓它在背景中運行。",


### PR DESCRIPTION
Follow-up to https://github.com/joinmarket-webui/jam/pull/830.

- Removes unused translations
- Fixes the Settings page unit test
- Run GitHub workflows on `devel` branch