### PR TITLE
dev: use `npm run dev` to run app in dev mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ This creates and funds a wallet `Satoshi` with password `test`.
 Start the UI on port 3000:
 
 ```sh
-npm run dev:start
+npm run dev
 ```
 
 Make your changes and be sure to manually test them before submitting them to us.
@@ -100,7 +100,7 @@ This creates and funds a wallet `Satoshi` with password `test`.
 Start the UI on port 3000:
 
 ```sh
-npm run dev:start
+npm run dev
 ```
 
 Enjoy the test drive!

--- a/docker/regtest/readme.md
+++ b/docker/regtest/readme.md
@@ -22,7 +22,7 @@ npm run regtest:init
 npm run regtest:mine
 
 # start jam in development mode
-npm run dev:start
+npm run dev
 
 [...]
 
@@ -49,7 +49,7 @@ npm run regtest:init
 Once the regtest environment is up and running you can start Jam with:
 
 ```sh
-npm run dev:start
+npm run dev
 ```
 
 ### Stop

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -11,7 +11,7 @@ For a complete development environment you need a local JoinMarket instance that
 ## Linting
 
 We use Create React App's [default ESLint integration](https://create-react-app.dev/docs/setting-up-your-editor/#displaying-lint-output-in-the-editor).
-You'll see linting issues in the console when running the app with `npm run dev:start`.
+You'll see linting issues in the console when running the app with `npm run dev`.
 Pull request builds will fail if ESLint is not happy with the code.
 
 ## Code Formatting
@@ -118,5 +118,5 @@ In short:
 ```bash
 git clone https://github.com/joinmarket-webui/jam.git
 cd jam/
-npm install && npm run dev:start
+npm install && npm run dev
 ```

--- a/package.json
+++ b/package.json
@@ -47,8 +47,10 @@
     "react-router-dom": "^6.26.1"
   },
   "scripts": {
-    "dev:start": "REACT_APP_JAM_DEV_MODE=true npm start",
-    "dev:start:secondary": "PORT=3001 JAM_BACKEND=jam-standalone JAM_API_PORT=29080 npm run dev:start",
+    "dev:start": "echo 'Deprecated command will be removed soon. Please use `npm run dev` instead.'",
+    "dev:start:secondary": "echo 'Deprecated command will be removed soon. Please use `npm run dev:secondary` instead.'",
+    "dev": "REACT_APP_JAM_DEV_MODE=true npm start",
+    "dev:secondary": "PORT=3001 JAM_BACKEND=jam-standalone JAM_API_PORT=29080 npm run dev:start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/src/components/LogOverlay.tsx
+++ b/src/components/LogOverlay.tsx
@@ -159,7 +159,7 @@ export function LogOverlay({ currentWallet, show, onHide }: LogOverlayProps) {
                 <div className="my-4">
                   <span className="badge rounded-pill bg-warning me-2">dev</span>
                   In order to test the log file feature, start the application with
-                  <code className="mx-2">npm run dev:start:secondary</code>.
+                  <code className="mx-2">npm run dev:secondary</code>.
                 </div>
               )}
               {alert && <rb.Alert variant={alert.variant}>{alert.message}</rb.Alert>}


### PR DESCRIPTION
Small improvement for local development:
Changes the command for running in dev mode from `npm run dev:start` to `npm run dev` (e.g. as next.js does).