### PR TITLE
chore: small quick freeze modal adaptions

### DIFF
--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -73,7 +73,7 @@ const ReviewUtxos = ({ settings, availableUtxos, isSweep }: ReviewUtxosProps) =>
         <strong>
           {allUtxosAreUsed
             ? t('send.confirm_send_modal.label_selected_utxos')
-            : t('send.confirm_send_modal.label_considered_utxos')}
+            : t('send.confirm_send_modal.label_eligible_utxos')}
         </strong>
       </rb.Col>
       <rb.Col xs={8} md={9}>
@@ -84,7 +84,7 @@ const ReviewUtxos = ({ settings, availableUtxos, isSweep }: ReviewUtxosProps) =>
           <div className="my-2 text-start text-secondary">
             {allUtxosAreUsed
               ? t('send.confirm_send_modal.description_selected_utxos', { count: availableUtxos.length })
-              : t('send.confirm_send_modal.description_considered_utxos')}
+              : t('send.confirm_send_modal.description_eligible_utxos')}
           </div>
           <UtxoListDisplay
             utxos={availableUtxos.map((it) => ({ ...it, checked: false, selectable: false }))}

--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -69,13 +69,16 @@ const ReviewConsideredUtxos = ({ utxos }: ReviewConsideredUtxosProps) => {
   return (
     <rb.Row className="mt-2">
       <rb.Col xs={4} md={3} className="text-end">
-        <strong>{t('show_utxos.considered_utxos')}</strong>
+        <strong>{t('send.confirm_send_modal.label_considered_utxos')}</strong>
       </rb.Col>
       <rb.Col xs={8} md={9}>
         <Divider toggled={isOpen} onToggle={() => setIsOpen((current) => !current)} />
       </rb.Col>
       <rb.Collapse in={isOpen}>
-        <rb.Col xs={12} className="mt-2">
+        <rb.Col xs={12}>
+          <div className="my-2 text-start text-secondary">
+            {t('send.confirm_send_modal.description_considered_utxos')}
+          </div>
           <UtxoListDisplay
             utxos={utxos}
             settings={settings}

--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -69,10 +69,10 @@ const ReviewUtxos = ({ settings, availableUtxos, isSweep }: ReviewUtxosProps) =>
   const allUtxosAreUsed = isSweep || availableUtxos.length === 1
   return (
     <rb.Row className="mt-2">
-      <rb.Col xs={4} md={3} className="text-end">
+      <rb.Col xs={4} md={3} className="d-flex align-items-center justify-content-end text-end">
         <strong>
           {allUtxosAreUsed
-            ? t('send.confirm_send_modal.label_selected_utxos')
+            ? t('send.confirm_send_modal.label_selected_utxos', { count: availableUtxos.length })
             : t('send.confirm_send_modal.label_eligible_utxos')}
         </strong>
       </rb.Col>

--- a/src/components/PaymentConfirmModal.tsx
+++ b/src/components/PaymentConfirmModal.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import * as rb from 'react-bootstrap'
 import Sprite from './Sprite'
 import Balance from './Balance'
-import { useSettings } from '../context/SettingsContext'
+import { Settings, useSettings } from '../context/SettingsContext'
 import { FeeValues, TxFee, useEstimatedMaxCollaboratorFee } from '../hooks/Fees'
 import { ConfirmModal, ConfirmModalProps } from './Modal'
 import { AmountSats, BitcoinAddress } from '../libs/JmWalletApi'
@@ -11,7 +11,7 @@ import { jarInitial } from './jars/Jar'
 import { isValidNumber } from '../utils'
 import styles from './PaymentConfirmModal.module.css'
 import { Utxos } from '../context/WalletContext'
-import { SelectableUtxo, UtxoListDisplay } from './Send/ShowUtxos'
+import { UtxoListDisplay } from './Send/ShowUtxos'
 import Divider from './Divider'
 
 const feeRange: (txFee: TxFee, txFeeFactor: number) => [number, number] = (txFee, txFeeFactor) => {
@@ -58,18 +58,23 @@ const useMiningFeeText = ({ tx_fees, tx_fees_factor }: Pick<FeeValues, 'tx_fees'
   }, [t, tx_fees, tx_fees_factor])
 }
 
-type ReviewConsideredUtxosProps = {
-  utxos: SelectableUtxo[]
+type ReviewUtxosProps = Required<Pick<PaymentDisplayInfo, 'isSweep' | 'availableUtxos'>> & {
+  settings: Settings
 }
-const ReviewConsideredUtxos = ({ utxos }: ReviewConsideredUtxosProps) => {
-  const { t } = useTranslation()
-  const settings = useSettings()
-  const [isOpen, setIsOpen] = useState<boolean>(false)
 
+const ReviewUtxos = ({ settings, availableUtxos, isSweep }: ReviewUtxosProps) => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState<boolean>(availableUtxos.length === 1)
+
+  const allUtxosAreUsed = isSweep || availableUtxos.length === 1
   return (
     <rb.Row className="mt-2">
       <rb.Col xs={4} md={3} className="text-end">
-        <strong>{t('send.confirm_send_modal.label_considered_utxos')}</strong>
+        <strong>
+          {allUtxosAreUsed
+            ? t('send.confirm_send_modal.label_selected_utxos')
+            : t('send.confirm_send_modal.label_considered_utxos')}
+        </strong>
       </rb.Col>
       <rb.Col xs={8} md={9}>
         <Divider toggled={isOpen} onToggle={() => setIsOpen((current) => !current)} />
@@ -77,10 +82,12 @@ const ReviewConsideredUtxos = ({ utxos }: ReviewConsideredUtxosProps) => {
       <rb.Collapse in={isOpen}>
         <rb.Col xs={12}>
           <div className="my-2 text-start text-secondary">
-            {t('send.confirm_send_modal.description_considered_utxos')}
+            {allUtxosAreUsed
+              ? t('send.confirm_send_modal.description_selected_utxos', { count: availableUtxos.length })
+              : t('send.confirm_send_modal.description_considered_utxos')}
           </div>
           <UtxoListDisplay
-            utxos={utxos}
+            utxos={availableUtxos.map((it) => ({ ...it, checked: false, selectable: false }))}
             settings={settings}
             onToggle={() => {
               // No-op since these UTXOs are only for review and are not selectable
@@ -101,7 +108,7 @@ interface PaymentDisplayInfo {
   numCollaborators?: number
   feeConfigValues?: FeeValues
   showPrivacyInfo?: boolean
-  consideredUtxos?: Utxos
+  availableUtxos?: Utxos
 }
 
 interface PaymentConfirmModalProps extends ConfirmModalProps {
@@ -118,7 +125,7 @@ export function PaymentConfirmModal({
     numCollaborators,
     feeConfigValues,
     showPrivacyInfo = true,
-    consideredUtxos = [],
+    availableUtxos = [],
   },
   children,
   ...confirmModalProps
@@ -246,8 +253,8 @@ export function PaymentConfirmModal({
             </rb.Col>
           </rb.Row>
         )}
-        {consideredUtxos.length !== 0 && (
-          <ReviewConsideredUtxos utxos={consideredUtxos.map((it) => ({ ...it, checked: false, selectable: false }))} />
+        {availableUtxos.length > 0 && (
+          <ReviewUtxos settings={settings} availableUtxos={availableUtxos} isSweep={isSweep} />
         )}
         {children && (
           <rb.Row>

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -212,7 +212,7 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
     <BaseModal
       isShown={isOpen}
       onCancel={onCancel}
-      title={t('show_utxos.show_utxo_title')}
+      title={t('show_utxos.title')}
       backdrop={!isLoading}
       closeButton={!isLoading}
       headerClassName=""
@@ -226,10 +226,9 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
           </div>
         ) : (
           <>
-            <rb.Row className="text-secondary px-3 mb-2">
-              {upperUtxos.length > 0
-                ? t('show_utxos.show_utxo_subtitle')
-                : t('show_utxos.show_utxo_subtitle_when_allutxos_are_frozen')}
+            <rb.Row className="text-secondary mb-2">
+              <div>{t('show_utxos.subtitle', { count: selectedUtxos.length })}</div>
+              <div>{t('show_utxos.text_subtitle_addon')}</div>
             </rb.Row>
             {alert && (
               <rb.Row>

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -35,16 +35,12 @@ interface UtxoRowProps {
   settings: Settings
   walletInfo: WalletInfo
   t: TFunction
-  // TODO: remove
-  showBackgroundColor?: boolean
 }
 
 interface UtxoListDisplayProps {
   utxos: SelectableUtxo[]
   onToggle: (utxo: SelectableUtxo) => void
   settings: Settings
-  // TODO: remove
-  showBackgroundColor?: boolean
 }
 
 const UtxoRow = ({ utxo, onToggle, settings, walletInfo, t }: UtxoRowProps) => {
@@ -113,7 +109,7 @@ type SelectableUtxoTableRowData = SelectableUtxo & Pick<TableTypes.TableNode, 'i
 
 const DEFAULT_UTXO_LIST_THEME = {
   Table: `
-  --data-table-library_grid-template-columns: 2.5rem 2.5rem 17rem 3rem 12rem 1fr};
+  --data-table-library_grid-template-columns: 2.5rem 2.5rem 17rem 3.75rem 11rem 1fr};
 `,
   BaseCell: `
   padding: 0.35rem 0.25rem !important;

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -212,9 +212,9 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
     <BaseModal
       isShown={isOpen}
       onCancel={onCancel}
-      backdrop={true}
       title={t('show_utxos.show_utxo_title')}
-      closeButton
+      backdrop={!isLoading}
+      closeButton={!isLoading}
       headerClassName=""
       titleClassName=""
     >
@@ -274,6 +274,7 @@ const ShowUtxos = ({ isOpen, onCancel, onConfirm, isLoading, utxos, alert }: Sho
         <rb.Button
           variant="light"
           onClick={() => onCancel()}
+          disabled={isLoading}
           className="d-flex flex-1 justify-content-center align-items-center"
         >
           <Sprite symbol="cancel" width="26" height="26" />

--- a/src/components/Send/ShowUtxos.tsx
+++ b/src/components/Send/ShowUtxos.tsx
@@ -78,7 +78,7 @@ const UtxoRow = ({ utxo, onToggle, settings, walletInfo, t }: UtxoRowProps) => {
       <Cell>
         <UtxoIcon value={utxo} tags={tags} />
       </Cell>
-      <Cell className="slashed-zeroes">
+      <Cell className="font-monospace slashed-zeroes">
         <rb.OverlayTrigger
           overlay={(props) => (
             <rb.Tooltip className="slashed-zeroes" {...props}>

--- a/src/components/Send/SourceJarSelector.tsx
+++ b/src/components/Send/SourceJarSelector.tsx
@@ -110,7 +110,7 @@ export const SourceJarSelector = ({
               return (
                 <div key={it.accountIndex}>
                   <SelectableJar
-                    tooltipText={t('show_utxos.select_utxos')}
+                    tooltipText={t('show_utxos.text_select_utxos_tooltip')}
                     isOpen={true}
                     index={it.accountIndex}
                     balance={it.calculatedAvailableBalanceInSats}

--- a/src/components/Send/index.tsx
+++ b/src/components/Send/index.tsx
@@ -521,7 +521,7 @@ export default function Send({ wallet }: SendProps) {
             isCoinjoin: showConfirmSendModal.isCoinJoin,
             numCollaborators: showConfirmSendModal.numCollaborators!,
             feeConfigValues: { ...feeConfigValues, tx_fees: showConfirmSendModal.txFee },
-            consideredUtxos: (walletInfo?.utxosByJar[showConfirmSendModal.sourceJarIndex!] || [])
+            availableUtxos: (walletInfo?.utxosByJar[showConfirmSendModal.sourceJarIndex!] || [])
               .filter((utxo) => !utxo.frozen)
               .sort((a, b) => a.confirmations - b.confirmations),
           }}

--- a/src/components/utxo/Confirmations.module.css
+++ b/src/components/utxo/Confirmations.module.css
@@ -1,10 +1,7 @@
 .confirmations {
-  width: 2rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 0.1rem 0.2rem;
-  border-radius: 0.2rem;
   font-size: 0.75rem;
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -351,7 +351,9 @@
       "text_miner_fee_in_satspervbyte_exact": "{{ value }} sats/vByte",
       "text_miner_fee_in_satspervbyte_randomized": "{{ min }} - {{ max }} sats/vByte",
       "text_miner_fee_in_targeted_blocks_one": "High priority estimate (next block)",
-      "text_miner_fee_in_targeted_blocks_other": "Using estimate for inclusion in next {{ count }} blocks"
+      "text_miner_fee_in_targeted_blocks_other": "Using estimate for inclusion in next {{ count }} blocks",
+      "label_considered_utxos": "Considered UTXOs",
+      "description_considered_utxos": "One or more of the following UTXOs are taken into account to create the transaction."
     },
     "confirm_abort_modal": {
       "title": "Abort payment",
@@ -718,7 +720,6 @@
   },
   "show_utxos": {
     "select_utxos": "Select UTXOs",
-    "considered_utxos": "Considered UTXOs",
     "show_utxo_title": "Select UTXOs to be considered",
     "show_utxo_subtitle": "The following UTXOs are considered in the transaction. Every unselected UTXO will be frozen and can be unfrozen later on.",
     "show_utxo_subtitle_when_allutxos_are_frozen": "The following UTXOs are frozen. Please select them to be considered in the transaction."

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -352,11 +352,11 @@
       "text_miner_fee_in_satspervbyte_randomized": "{{ min }} - {{ max }} sats/vByte",
       "text_miner_fee_in_targeted_blocks_one": "High priority estimate (next block)",
       "text_miner_fee_in_targeted_blocks_other": "Using estimate for inclusion in next {{ count }} blocks",
-      "label_considered_utxos": "Considered UTXOs",
-      "description_considered_utxos": "One or more of the following UTXOs will be used to create the transaction: ",
+      "label_eligible_utxos": "Eligible UTXOs",
+      "description_eligible_utxos": "One or more of the following UTXOs will be included in the transaction: ",
       "label_selected_utxos": "Selected UTXOs",
-      "description_selected_utxos_one": "The following UTXO will used to create the transaction: ",
-      "description_selected_utxos_other": "The following UTXOs will used to create the transaction: "
+      "description_selected_utxos_one": "The following UTXO will be included the transaction: ",
+      "description_selected_utxos_other": "The following UTXOs will be included the transaction: "
     },
     "confirm_abort_modal": {
       "title": "Abort payment",
@@ -722,9 +722,11 @@
     }
   },
   "show_utxos": {
-    "select_utxos": "Select UTXOs",
-    "show_utxo_title": "Select UTXOs to be considered",
-    "show_utxo_subtitle": "The following UTXOs are considered in the transaction. Every unselected UTXO will be frozen and can be unfrozen later on.",
-    "show_utxo_subtitle_when_allutxos_are_frozen": "The following UTXOs are frozen. Please select them to be considered in the transaction."
+    "text_select_utxos_tooltip": "Select UTXOs",
+    "title": "Select eligible UTXOs",
+    "subtitle_zero": "Please select one or more UTXOs for possible inclusion in the transaction.",
+    "subtitle_one": "The selected UTXO is eligible for inclusion in the transaction.",
+    "subtitle_other": "The selected UTXOs are eligible for inclusion in the transaction.",
+    "text_subtitle_addon": "Unselected UTXOs will be frozen and can be unfrozen later anytime."
   }
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -354,9 +354,10 @@
       "text_miner_fee_in_targeted_blocks_other": "Using estimate for inclusion in next {{ count }} blocks",
       "label_eligible_utxos": "Eligible UTXOs",
       "description_eligible_utxos": "One or more of the following UTXOs will be included in the transaction: ",
-      "label_selected_utxos": "Selected UTXOs",
-      "description_selected_utxos_one": "The following UTXO will be included the transaction: ",
-      "description_selected_utxos_other": "The following UTXOs will be included the transaction: "
+      "label_selected_utxos_one": "Selected UTXO",
+      "label_selected_utxos_other": "Selected UTXOs",
+      "description_selected_utxos_one": "The following UTXO will be included in the transaction: ",
+      "description_selected_utxos_other": "The following UTXOs will be included in the transaction: "
     },
     "confirm_abort_modal": {
       "title": "Abort payment",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -353,7 +353,10 @@
       "text_miner_fee_in_targeted_blocks_one": "High priority estimate (next block)",
       "text_miner_fee_in_targeted_blocks_other": "Using estimate for inclusion in next {{ count }} blocks",
       "label_considered_utxos": "Considered UTXOs",
-      "description_considered_utxos": "One or more of the following UTXOs are taken into account to create the transaction."
+      "description_considered_utxos": "One or more of the following UTXOs will be used to create the transaction: ",
+      "label_selected_utxos": "Selected UTXOs",
+      "description_selected_utxos_one": "The following UTXO will used to create the transaction: ",
+      "description_selected_utxos_other": "The following UTXOs will used to create the transaction: "
     },
     "confirm_abort_modal": {
       "title": "Abort payment",


### PR DESCRIPTION
This PR tries to enhance the phrasing in the Quick Freeze and Payment Confirm modal on the Send page.
Distinction is done between "Eligible UTXOs" (for non-sweeps) and "Selected UTXOs" (for sweeps).
Please let me know what you think - feedback is desperately needed!
Also, if you have better versions of the texts and phrases in mind - please post them here as comment or as change suggestion! :pray: 

#### Quick Freeze Confirm Modal 
- Visually adjust the "confirmations" block
- Title from `"Select UTXOs to be considered"` to just `"Select UTXOs"`
- Phrase `"The following UTXOs are considered in the transaction. "` to one of the following
```json
    "subtitle_zero": "Please select one or more UTXOs for possible inclusion in the transaction.",
    "subtitle_one": "The selected UTXO is eligible for inclusion in the transaction.",
    "subtitle_other": "The selected UTXOs are eligible for inclusion in the transaction.",
``` 
- Phrase `"Every unselected UTXO will be frozen and can be unfrozen later on."` to `"Unselected UTXOs will be frozen and can be unfrozen later anytime."`
 

#### Payment Confirm Modal 
- Non-sweep sends with more than one UTXO use label ~~"Considered UTXOs"~~ `"Eligible UTXOs"`
  -  With description `"One or more of the following UTXOs will be included in the transaction: "`
- Sweeps or non-sweep sends with single UTXOs use label `"Selected UTXOs"`
  - With description:
     -  Either `"The following UTXO will be included in the transaction: "` (single UTXO)
     -  Or  `"The following UTXOs will be included in the transaction: "` (multple UTXOs)

## :camera_flash:  Screenshots (already outdated)

<img src="https://github.com/user-attachments/assets/57e5c599-9528-43eb-a948-4c67d3a80e3a" width=350 />

<img src="https://github.com/user-attachments/assets/ce1daf12-6937-4404-a8d4-a94389fb8f74" width=350 />

<img src="https://github.com/user-attachments/assets/fe4b26f2-5d8a-4522-916a-d20ef91b7393" width=350 />

---

<img src="https://github.com/user-attachments/assets/286a08f9-1dd7-48a9-8d75-30b170d4f9c5" width=350 />
<img src="https://github.com/user-attachments/assets/8bafeb09-dad9-4cc1-bc56-affd8752442b" width=350 />
<img src="https://github.com/user-attachments/assets/8c390438-5fc2-445e-8826-a87a41be1aca" width=350 />


