### PR TITLE
fix(main): properly fade out jar tooltips

### DIFF
--- a/src/components/jars/Jar.tsx
+++ b/src/components/jars/Jar.tsx
@@ -209,12 +209,14 @@ const SelectableJar = ({
  */
 const OpenableJar = ({ tooltipText, onClick, ...jarProps }: OpenableJarProps) => {
   const [jarIsOpen, setJarIsOpen] = useState(false)
-  const onMouseOver = () => setJarIsOpen(true)
-  const onMouseOut = () => setJarIsOpen(false)
+  const openJar = () => setJarIsOpen(true)
+  const closeJar = () => setJarIsOpen(false)
 
   return (
-    <div onMouseOver={onMouseOver} onMouseOut={onMouseOut}>
+    <div onMouseOver={openJar} onMouseOut={closeJar}>
       <rb.OverlayTrigger
+        placement="top"
+        trigger="hover"
         popperConfig={{
           modifiers: [
             {


### PR DESCRIPTION
Fixes #839.

A side effect of this is, that it will not show the tooltip anymore if you focus the jars (e.g. by using the keyboard), which is not ideal but feels okay.

How to test? Follow the steps in  #839 and verify the tooltip now correctly disappears.