### PR TITLE
Fix months order across timezones

### DIFF
--- a/src/components/fb/LockdateForm.test.tsx
+++ b/src/components/fb/LockdateForm.test.tsx
@@ -117,7 +117,7 @@ describe('<LockdateForm />', () => {
     })
   })
 
-  describe('_selectableMonth', () => {
+  describe('_selectableMonths', () => {
     const yearsRange = fb.toYearsRange(0, 2)
 
     const january2009 = new Date(Date.UTC(2009, 0))

--- a/src/components/fb/LockdateForm.tsx
+++ b/src/components/fb/LockdateForm.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import * as Api from '../../libs/JmWalletApi'
 import * as fb from './utils'
 
-const monthFormatter = (locales: string) => new Intl.DateTimeFormat(locales, { month: 'long' })
+const monthFormatter = (locales: string) => new Intl.DateTimeFormat(locales, { month: 'long', timeZone: 'UTC' })
 
 const DEFAULT_MONTH_FORMATTER = monthFormatter('en-US')
 


### PR DESCRIPTION
Fixes: #852 

The default `timeZone` for `Intl.DateTimeFormat` is based on the user's timezone, so because I'm behind UTC it get's shifted some hours back which leads to incorrect formatting of the month. Because we send the date in UTC to `Intl.DateTimeFormat` we can set UTC explicitly as the `timeZone` to solve the issue.

The test case `_selectableMonths / should display month name` was not passing on my end, and now it does.

Also fixed a supposedly typo on the `describe('_selectableMonth')` to reflect the correct name of the function that is being tested. I can adjust it back if you don't want unnecessary diff on the squashed commit.