### PR TITLE
fix(ui): fidelity bond utxo row color in dark mode

### DIFF
--- a/src/components/Send/ShowUtxos.module.css
+++ b/src/components/Send/ShowUtxos.module.css
@@ -26,6 +26,18 @@
   color: #2d9cdb !important;
 }
 
+.row.row-dark {
+  --bs-code-color: var(--bs-gray-600);
+  background-color: var(--bs-gray-200);
+  color: var(--bs-gray-600);
+}
+
+:root[data-theme='dark'] .row.row-dark {
+  --bs-code-color: var(--bs-gray-900);
+  background-color: var(--bs-gray-700);
+  color: var(--bs-gray-900);
+}
+
 .checkbox {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
Fixes the color of unfrozen and expired fidelity bond utxos in dark mode, e.g. in utxo selection and confirm modal.

(This should not have affected anybody if Jam has been exclusively used to control a JM node, as unfreezing Fidelity Bonds is not supported via the UI).

## :camera_flash: 
### Before
<img src="https://github.com/user-attachments/assets/b08d20c5-f7c7-42d8-8e5c-1c785b624cb0" width=250 />

### After
<img src="https://github.com/user-attachments/assets/9ec476e4-7ef3-4dce-a430-fcd8adb4af56" width=250 />

