### PR TITLE
chore: update jar balance

### DIFF
--- a/src/components/jar_details/JarDetailsOverlay.tsx
+++ b/src/components/jar_details/JarDetailsOverlay.tsx
@@ -141,6 +141,10 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
     return selectedUtxos.map((it) => it.value).reduce((acc, curr) => acc + curr, 0)
   }, [selectedUtxos])
 
+  const utxosBalance: Api.AmountSats = useMemo(() => {
+    return utxos.reduce((acc, utxo) => acc + utxo.value, 0)
+  }, [utxos])
+
   const nextJar = useCallback(
     () => setJarIndex((current) => (current + 1 >= props.jars.length ? 0 : current + 1)),
     [props.jars],
@@ -366,7 +370,7 @@ const JarDetailsOverlay = (props: JarDetailsOverlayProps) => {
                         <div>
                           <Trans i18nKey="jar_details.utxo_list.text_balance_sum_total">
                             <Balance
-                              valueString={jar.account_balance}
+                              valueString={String(utxosBalance)}
                               convertToUnit={settings.unit}
                               showBalance={settings.showBalance}
                             />


### PR DESCRIPTION
fix #911 

- Fixed: the total displayed for a jar now sums the live UTXO values instead of using the possibly-stale jar.account_balance coming from /display.
- Passed String(utxosBalance) to the Balance component for the total line in the UTXO tab.
