### PR TITLE
refactor(v2): use zustand for auth store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "jam",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@noble/hashes": "^1.8.0",
@@ -33,7 +33,8 @@
         "sonner": "^2.0.5",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
-        "tw-animate-css": "^1.3.4"
+        "tw-animate-css": "^1.3.4",
+        "zustand": "^5.0.7"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^4.0.0",
@@ -9296,6 +9297,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.7.tgz",
+      "integrity": "sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
-    "tw-animate-css": "^1.3.4"
+    "tw-animate-css": "^1.3.4",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.0",

--- a/src/components/CreateWallet.tsx
+++ b/src/components/CreateWallet.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { AlertCircle, Eye, EyeOff, Loader2, Lock, Wallet } from 'lucide-react'
 import { Link, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
+import { useStore } from 'zustand'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -9,11 +10,12 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { hashPassword } from '@/lib/hash'
 import { type CreateWalletResponse, createwallet, session } from '@/lib/jm-api/generated/client'
-import { clearSession, setSession } from '@/lib/session'
 import { formatWalletName } from '@/lib/utils'
+import { authStore } from '@/store/authStore'
 
 const CreateWallet = () => {
   const navigate = useNavigate()
+  const { clear: clearAuthState, update: updateAuthState } = useStore(authStore, (state) => state)
   const [walletName, setWalletName] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -45,7 +47,7 @@ const CreateWallet = () => {
       setIsLoading(true)
 
       // Clear any existing local session
-      clearSession()
+      clearAuthState()
 
       // Check if there's an active session on the server
       try {
@@ -115,10 +117,10 @@ const CreateWallet = () => {
       }
 
       // Save session and navigate to dashboard
-      setSession({
+      updateAuthState({
         walletFileName,
         auth: { token: createWalletResponse.token, refresh_token: createWalletResponse.refresh_token }, // We'll need to unlock it properly later
-        hashedSecret,
+        hashed_password: hashedSecret,
       })
 
       navigate('/login', {

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery } from '@tanstack/react-query'
 import { AlertCircle, Eye, EyeOff, Loader2, Lock, RefreshCwIcon, Wallet } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
+import { useStore } from 'zustand'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -14,8 +15,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useApiClient } from '@/hooks/useApiClient'
 import { hashPassword } from '@/lib/hash'
 import { listwalletsOptions, unlockwalletMutation } from '@/lib/jm-api/generated/client/@tanstack/react-query.gen'
-import { setSession } from '@/lib/session'
 import { formatWalletName } from '@/lib/utils'
+import { authStore } from '@/store/authStore'
 
 const LoginFormSkeleton = () => {
   return (
@@ -136,6 +137,7 @@ const LoginForm = ({ wallets, isSubmitting, onSubmit }: LoginFormProps) => {
 
 const LoginPage = () => {
   const navigate = useNavigate()
+  const updateAuthState = useStore(authStore, (state) => state.update)
   const client = useApiClient()
 
   const listwalletsQuery = useQuery({
@@ -185,10 +187,10 @@ const LoginPage = () => {
         },
       })
 
-      setSession({
+      updateAuthState({
         walletFileName: response.walletname,
         auth: { token: response.token, refresh_token: response.refresh_token },
-        hashedSecret,
+        hashed_password: hashedSecret,
       })
 
       await navigate('/')

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,7 +3,7 @@ import { Loader2, LogOut, Moon, Settings, Sun, Wallet } from 'lucide-react'
 import { Link, useNavigate } from 'react-router-dom'
 import type { Jar } from '@/components/layout/display-mode-context'
 import { Button } from '@/components/ui/button'
-import { clearSession } from '@/lib/session'
+import { authStore } from '@/store/authStore'
 import { DevBadge } from './ui/DevBadge'
 import { Skeleton } from './ui/skeleton'
 
@@ -20,7 +20,7 @@ export function Navbar({ theme, toggleTheme, formatAmount, getLogo, jars, isLoad
   const navigate = useNavigate()
 
   const handleLogout = async () => {
-    clearSession()
+    authStore.getState().clear()
     await navigate('/login')
   }
 

--- a/src/components/SwitchWallet.tsx
+++ b/src/components/SwitchWallet.tsx
@@ -10,8 +10,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Skeleton } from '@/components/ui/skeleton'
 import { useApiClient } from '@/hooks/useApiClient'
 import { listwalletsOptions, lockwalletOptions } from '@/lib/jm-api/generated/client/@tanstack/react-query.gen'
-import { clearSession } from '@/lib/session'
 import { formatWalletName } from '@/lib/utils'
+import { authStore } from '@/store/authStore'
 
 const SwitchWalletFormSkeleton = () => {
   return (
@@ -76,7 +76,7 @@ const SwitchWallet = ({ walletFileName }: { walletFileName: string }) => {
   const handleLockCurrentWallet = async () => {
     try {
       await lockCurrentWallet.refetch()
-      clearSession()
+      authStore.getState().clear()
       setCurrentWalletLocked(true)
       toast.success(
         t('wallets.wallet_preview.alert_wallet_locked_successfully', { walletName: formatWalletName(walletFileName) }),

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -21,13 +21,13 @@ import { useTheme } from 'next-themes'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
+import { useStore } from 'zustand'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 import { useApiClient } from '@/hooks/useApiClient'
 import { useFeatures } from '@/hooks/useFeatures'
-import { useSession } from '@/hooks/useSession'
 import { lockwalletOptions } from '@/lib/jm-api/generated/client/@tanstack/react-query.gen'
-import { clearSession } from '@/lib/session'
+import { authStore } from '@/store/authStore'
 import { useJamDisplayContext } from '../layout/display-mode-context'
 import { FeeLimitDialog } from './FeeLimitDialog'
 import { LanguageSelector } from './LanguageSelector'
@@ -47,7 +47,7 @@ export const Settings = ({ walletFileName }: SettingProps) => {
   const [showFeeLimitDialog, setShowFeeLimitDialog] = useState(false)
   const navigate = useNavigate()
   const client = useApiClient()
-  const session = useSession()
+  const hashedSecret = useStore(authStore, (state) => state.state?.hashed_password)
   const { isLogsEnabled } = useFeatures()
 
   const lockWalletQuery = useQuery({
@@ -61,7 +61,7 @@ export const Settings = ({ walletFileName }: SettingProps) => {
   const handleLockWallet = async () => {
     try {
       await lockWalletQuery.refetch()
-      clearSession()
+      authStore.getState().clear()
       toast.success(t('wallets.wallet_preview.alert_wallet_locked_successfully', { walletName: walletFileName }))
       navigate('/login')
     } catch (error: unknown) {
@@ -133,7 +133,7 @@ export const Settings = ({ walletFileName }: SettingProps) => {
             icon={Key}
             title={t('settings.show_seed')}
             action={() => setShowSeedDialog(true)}
-            disabled={!session?.hashedSecret}
+            disabled={hashedSecret === undefined}
           />
           <Separator className="opacity-50" />
           <SettingItem
@@ -241,7 +241,7 @@ export const Settings = ({ walletFileName }: SettingProps) => {
         </CardContent>
       </Card>
 
-      <SeedPhraseDialog open={showSeedDialog} onOpenChange={setShowSeedDialog} />
+      <SeedPhraseDialog walletFileName={walletFileName} open={showSeedDialog} onOpenChange={setShowSeedDialog} />
       <FeeLimitDialog walletFileName={walletFileName} open={showFeeLimitDialog} onOpenChange={setShowFeeLimitDialog} />
     </div>
   )

--- a/src/hooks/useFeatures.ts
+++ b/src/hooks/useFeatures.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
+import { useStore } from 'zustand'
 import { fetchFeatures } from '@/lib/api/logs'
-import { useSession } from './useSession'
+import { authStore } from '@/store/authStore'
 
 export interface Features {
   logs?: boolean
@@ -12,7 +13,7 @@ export interface FeatureItem {
 }
 
 export const useFeatures = () => {
-  const session = useSession()
+  const authState = useStore(authStore, (state) => state.state)
 
   const {
     data: features,
@@ -22,12 +23,12 @@ export const useFeatures = () => {
   } = useQuery({
     queryKey: ['features'],
     queryFn: async ({ signal }) => {
-      if (!session?.auth?.token) {
+      if (authState?.auth?.token === undefined) {
         throw new Error('No authentication token available')
       }
 
       const response = await fetchFeatures({
-        token: session.auth.token,
+        token: authState.auth.token,
         signal,
       })
 
@@ -38,7 +39,7 @@ export const useFeatures = () => {
       const data = await response.json()
       return data.features as Features
     },
-    enabled: !!session?.auth?.token,
+    enabled: !!authState?.auth?.token,
     retry: false,
   })
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
 import type { Client } from '@hey-api/client-fetch'
 import { createClient } from '@/lib/jm-api'
 import type { ClientOptions, UnlockWalletResponse } from '@/lib/jm-api/generated/client'
-import { getSession } from '@/lib/session'
+import { authStore } from '@/store/authStore'
 
 type ApiToken = UnlockWalletResponse['token']
 
@@ -20,9 +20,9 @@ async function loggingResponseInterceptor(response: Response) {
 
 const createJamAuthenticationMiddleware = () => {
   return async (request: Request) => {
-    const session = getSession()
-    if (session?.auth?.token) {
-      const authHeader = buildAuthHeader(session?.auth?.token)
+    const authState = authStore.getState().state
+    if (authState?.auth?.token) {
+      const authHeader = buildAuthHeader(authState.auth.token)
       request.headers.set(authHeader[0], authHeader[1])
     }
     return request

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,18 +1,10 @@
-import type { UnlockWalletResponse } from '@/lib/jm-api/generated/client'
-
 export interface RescanSession {
   rescanning: boolean
   progress?: number
 }
 
 interface SessionData {
-  walletFileName: string
-  auth: {
-    token: UnlockWalletResponse['token']
-    refresh_token: UnlockWalletResponse['refresh_token']
-  }
   rescan?: RescanSession
-  hashedSecret?: string
 }
 
 export const setSession = (session: Partial<SessionData>) => {
@@ -30,12 +22,6 @@ export const setSession = (session: Partial<SessionData>) => {
 export const getSession = (): Partial<SessionData> | null => {
   const session = sessionStorage.getItem('joinmarket')
   return session ? JSON.parse(session) : null
-}
-
-export const clearSession = () => {
-  sessionStorage.removeItem('joinmarket')
-
-  dispatchEvent('sessionUpdate')
 }
 
 // Dispatch custom event to notify components of session change

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,32 @@
+import { createStore } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import type { UnlockWalletResponse } from '../lib/jm-api/generated/client'
+
+type AuthState = {
+  walletFileName?: string
+  hashed_password?: string
+  auth?: {
+    token: UnlockWalletResponse['token']
+    refresh_token: UnlockWalletResponse['refresh_token']
+  }
+}
+
+interface AuthStoreState {
+  state?: AuthState
+  update: (val: Partial<AuthState>) => void
+  clear: () => void
+}
+
+export const authStore = createStore<AuthStoreState>()(
+  persist(
+    (set, get) => ({
+      state: {},
+      update: (val) => set({ state: { ...(get().state || {}), ...val } }),
+      clear: () => set({ state: undefined }),
+    }),
+    {
+      name: 'jam-auth',
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+)


### PR DESCRIPTION
Replaces custom handling of session storage with zustand.
Only the authentication related properties have been refactored.
"rescan" properties are still handled the previous way.

Let me know what you think @nischal-shetty2 