### PR TITLE
fix(settings): clear seed cache on timeout

### DIFF
--- a/src/components/settings/SeedPhraseDialog.test.tsx
+++ b/src/components/settings/SeedPhraseDialog.test.tsx
@@ -113,8 +113,9 @@ describe('SeedPhraseDialog', () => {
 
   it('clears and masks the cached seed when verification expires', async () => {
     vi.useFakeTimers()
+    const props = { ...baseProps, autoCloseTimeout: 1_000, onOpenChange: vi.fn() }
     seedQuery = { ...seedQuery, data: ['word1', 'word2'] }
-    render(<SeedPhraseDialog {...baseProps} autoCloseTimeout={1_000} onOpenChange={vi.fn()} />)
+    const { rerender } = render(<SeedPhraseDialog {...props} />)
 
     verify()
     fireEvent.click(screen.getByTestId('reveal-switch'))
@@ -123,7 +124,12 @@ describe('SeedPhraseDialog', () => {
     await act(() => vi.advanceTimersByTimeAsync(1_332))
     expect(removeQueries).toHaveBeenCalledWith({ queryKey: ['seed'] })
 
+    seedQuery = { ...seedQuery, data: undefined }
     verify()
+    expect(refetch).toHaveBeenCalledTimes(1)
+
+    seedQuery = { ...seedQuery, data: ['word1', 'word2'] }
+    rerender(<SeedPhraseDialog {...props} />)
     expect(screen.getByTestId('seed-grid')).toHaveAttribute('data-masked', 'true')
   })
 })

--- a/src/components/settings/SeedPhraseDialog.test.tsx
+++ b/src/components/settings/SeedPhraseDialog.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { WalletFileName } from '@/lib/utils'
 import { SeedPhraseDialog } from './SeedPhraseDialog'
 
@@ -33,7 +33,11 @@ vi.mock('@/hooks/useApiClient', () => ({
 }))
 
 vi.mock('../ui/jam/SeedPhraseGrid', () => ({
-  SeedPhraseGrid: ({ value }: { value: string[] }) => <div data-testid="seed-grid">{value.join(' ')}</div>,
+  SeedPhraseGrid: ({ value, masked }: { value: string[]; masked: boolean }) => (
+    <div data-testid="seed-grid" data-masked={masked}>
+      {value.join(' ')}
+    </div>
+  ),
 }))
 
 vi.mock('../ui/spinner', () => ({
@@ -70,6 +74,8 @@ describe('SeedPhraseDialog', () => {
     seedQuery = { data: undefined, error: undefined, isFetching: false, refetch, dataUpdatedAt: 0 }
   })
 
+  afterEach(() => vi.useRealTimers())
+
   it('shows the password verification form before verification', () => {
     render(<SeedPhraseDialog {...baseProps} onOpenChange={vi.fn()} />)
     expect(screen.getByText('settings.seed_modal.verification.title')).toBeInTheDocument()
@@ -103,5 +109,21 @@ describe('SeedPhraseDialog', () => {
     fireEvent.click(screen.getByTestId('cancel'))
     expect(onOpenChange).toHaveBeenCalledWith(false)
     expect(removeQueries).toHaveBeenCalledWith({ queryKey: ['seed'] })
+  })
+
+  it('clears and masks the cached seed when verification expires', async () => {
+    vi.useFakeTimers()
+    seedQuery = { ...seedQuery, data: ['word1', 'word2'] }
+    render(<SeedPhraseDialog {...baseProps} autoCloseTimeout={1_000} onOpenChange={vi.fn()} />)
+
+    verify()
+    fireEvent.click(screen.getByTestId('reveal-switch'))
+    expect(screen.getByTestId('seed-grid')).toHaveAttribute('data-masked', 'false')
+
+    await act(() => vi.advanceTimersByTimeAsync(1_332))
+    expect(removeQueries).toHaveBeenCalledWith({ queryKey: ['seed'] })
+
+    verify()
+    expect(screen.getByTestId('seed-grid')).toHaveAttribute('data-masked', 'true')
   })
 })

--- a/src/components/settings/SeedPhraseDialog.tsx
+++ b/src/components/settings/SeedPhraseDialog.tsx
@@ -57,10 +57,14 @@ export const SeedPhraseDialog = ({
   const queryClient = useQueryClient()
   const client = useApiClient()
 
-  const seedQueryOptions = getseedOptions({
-    client,
-    path: { walletname: walletFileName },
-  })
+  const seedQueryOptions = useMemo(
+    () =>
+      getseedOptions({
+        client,
+        path: { walletname: walletFileName },
+      }),
+    [client, walletFileName],
+  )
 
   const {
     data: seedQueryData,
@@ -88,13 +92,21 @@ export const SeedPhraseDialog = ({
 
     const seedDisplayedAt = Math.max(seedQueryDataUpdatedAt, passwordVerifiedAt)
     const interval = setInterval(() => {
-      setTimeLeft(Math.max(0, seedDisplayedAt + autoCloseTimeout - Date.now()))
+      const nextTimeLeft = Math.max(0, seedDisplayedAt + autoCloseTimeout - Date.now())
+      setTimeLeft(nextTimeLeft)
+      if (nextTimeLeft <= 0) setRevealSeed(false)
     }, 333)
 
     return () => {
       clearInterval(interval)
     }
   }, [seedQueryDataUpdatedAt, isPasswordVerified, passwordVerifiedAt, autoCloseTimeout])
+
+  useEffect(() => {
+    if (timeLeft > 0) return
+
+    queryClient.removeQueries({ queryKey: seedQueryOptions.queryKey })
+  }, [queryClient, seedQueryOptions.queryKey, timeLeft])
 
   const handleClose = () => {
     onOpenChange(false)


### PR DESCRIPTION
### Summary

- remove the cached seed phrase when password verification expires
- reset the reveal state so the seed is masked after re-verification
- add a regression test for timeout cleanup

ping @theborakompanioni 

Closes #1449 