### PR TITLE
fix: always show balances in orderbook

### DIFF
--- a/src/components/orderbook/OrderbookContent.tsx
+++ b/src/components/orderbook/OrderbookContent.tsx
@@ -263,6 +263,7 @@ export const OrderbookContent = ({ enabled, className }: OrderbookContentProps) 
                       <span>{t('orderbook.market_summary_median_abs_fee_label')}:</span>
                       <Balance
                         valueString={String(Math.round(marketSummary.medianAbsFee))}
+                        showBalance={true}
                         enableVisibilityToggle={false}
                       />
                     </p>
@@ -276,13 +277,25 @@ export const OrderbookContent = ({ enabled, className }: OrderbookContentProps) 
                   )}
                   <p className="flex min-w-0 flex-wrap items-center gap-x-1 gap-y-0.5">
                     <span>{t('orderbook.market_summary_total_liquidity_label')}:</span>
-                    <Balance valueString={String(marketSummary.totalLiquidity)} enableVisibilityToggle={false} />
+                    <Balance
+                      valueString={String(marketSummary.totalLiquidity)}
+                      showBalance={true}
+                      enableVisibilityToggle={false}
+                    />
                   </p>
                   <p className="flex min-w-0 flex-wrap items-center gap-x-1 gap-y-0.5">
                     <span>{t('orderbook.market_summary_offer_min_size_label')}:</span>
-                    <Balance valueString={String(marketSummary.minOfferSize)} enableVisibilityToggle={false} />
+                    <Balance
+                      valueString={String(marketSummary.minOfferSize)}
+                      showBalance={true}
+                      enableVisibilityToggle={false}
+                    />
                     <span>–</span>
-                    <Balance valueString={String(marketSummary.maxOfferSize)} enableVisibilityToggle={false} />
+                    <Balance
+                      valueString={String(marketSummary.maxOfferSize)}
+                      showBalance={true}
+                      enableVisibilityToggle={false}
+                    />
                   </p>
                   <p className="break-words">
                     {t('orderbook.market_summary_bonded_makers', {

--- a/src/components/orderbook/OrderbookTable.privateMode.test.tsx
+++ b/src/components/orderbook/OrderbookTable.privateMode.test.tsx
@@ -1,0 +1,95 @@
+import type React from 'react'
+import { StrictMode } from 'react'
+import '@testing-library/jest-dom/vitest'
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { JamDisplayContextProvider } from '@/context/JamDisplayContextProvider'
+import { withRuntimeLocale } from '@/test/withRuntimeLocale'
+import { OrderbookTable, type OrderTableEntry } from './OrderbookTable'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('@/components/ui/jam/TablePagination', () => ({
+  TablePagination: () => null,
+}))
+
+// Private mode ON. Orderbook values are public market data and must stay
+// readable (see issue #1453). vi.mock factories are hoisted above all imports,
+// so the store stub has to be built inside vi.hoisted.
+const mockStore = vi.hoisted(() => {
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- needs to live inside the hoisted stub
+  const noop = () => {}
+  const storeState = {
+    state: {
+      currencyUnit: 'sats',
+      privateMode: true,
+      addressChunking: true,
+    },
+    update: noop,
+    clear: noop,
+  }
+  return {
+    // getState must return a stable reference or useSyncExternalStore loops.
+    getState: () => storeState,
+    subscribe: () => noop,
+  }
+})
+
+vi.mock('@/store/jamSettingsStore', () => ({
+  jamSettingsStore: mockStore,
+  useDeveloperMode: () => ({ enabled: false }),
+}))
+
+const entry: OrderTableEntry = {
+  bondValue: { amount: 0, displayValue: '0', value: 0 },
+  counterparty: 'maker-a',
+  fee: { displayValue: '250', value: 250 },
+  maximumSize: '200000',
+  minerFeeContribution: '0',
+  minimumSize: '5000',
+  orderId: '0',
+  type: {
+    badgeColor: 'default',
+    displayValue: 'absolute',
+    isAbsolute: true,
+    isRelative: false,
+    tooltip: 'Native SW Absolute Fee',
+    value: 'sw0absoffer',
+  },
+}
+
+describe('OrderbookTable in private mode', () => {
+  it('shows orderbook balances even though private mode is enabled', async () => {
+    await withRuntimeLocale('en-US', async () => {
+      render(
+        <StrictMode>
+          <JamDisplayContextProvider>
+            <OrderbookTable tableEntries={[entry]} selectedEntries={[]} pinnedEntries={[]} />
+          </JamDisplayContextProvider>
+        </StrictMode>,
+      )
+
+      // absolute fee, min size and max size render as plain sats values,
+      // not the private-mode mask
+      await waitFor(() => {
+        expect(document.querySelector('[data-raw-value="250"]')).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(document.querySelector('[data-raw-value="5000"]')).toBeInTheDocument()
+      })
+      await waitFor(() => {
+        expect(document.querySelector('[data-raw-value="200000"]')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/components/orderbook/OrderbookTable.tsx
+++ b/src/components/orderbook/OrderbookTable.tsx
@@ -119,7 +119,7 @@ export const OrderbookTable = ({
             },
           }) => {
             return isAbsolute ? (
-              <Balance valueString={fee.displayValue} />
+              <Balance valueString={fee.displayValue} showBalance={true} />
             ) : (
               <span className="slashed-zero tabular-nums">{fee.displayValue}</span>
             )
@@ -132,7 +132,7 @@ export const OrderbookTable = ({
         columnHelper.accessor('minimumSize', {
           header: () => <div className="flex items-center">{t('orderbook.table.heading_minimum_size')}</div>,
           sortFn: (a, b) => Number(a.original.minimumSize) - Number(b.original.minimumSize),
-          cell: (info) => <Balance valueString={String(info.getValue())} />,
+          cell: (info) => <Balance valueString={String(info.getValue())} showBalance={true} />,
           meta: {
             align: 'right',
             numeric: true,
@@ -141,7 +141,7 @@ export const OrderbookTable = ({
         columnHelper.accessor('maximumSize', {
           header: () => <div className="flex items-center">{t('orderbook.table.heading_maximum_size')}</div>,
           sortFn: (a, b) => Number(a.original.maximumSize) - Number(b.original.maximumSize),
-          cell: (info) => <Balance valueString={String(info.getValue())} />,
+          cell: (info) => <Balance valueString={String(info.getValue())} showBalance={true} />,
           meta: {
             align: 'right',
             numeric: true,
@@ -150,7 +150,7 @@ export const OrderbookTable = ({
         columnHelper.accessor('minerFeeContribution', {
           header: () => <div className="flex items-center">{t('orderbook.table.heading_miner_fee_contribution')}</div>,
           sortFn: (a, b) => Number(a.original.minerFeeContribution) - Number(b.original.minerFeeContribution),
-          cell: (info) => <Balance valueString={String(info.getValue())} />,
+          cell: (info) => <Balance valueString={String(info.getValue())} showBalance={true} />,
           enableHiding: true,
           meta: {
             align: 'right',


### PR DESCRIPTION
## What does this PR do?

Problem:
- In private mode the orderbook view masks fee, min/max order size and market summary values. These are public market data from the local orderbook, not wallet balances, so hiding them is unnecessary and makes the orderbook unreadable.

Solution:
- Pass `showBalance={true}` to those `Balance` components (table: fee, min/max size, miner fee contribution; content: market summary). Same pattern already used in the bond value tooltip in the same table, so no new mechanism.

Result:
- `src/components/orderbook/OrderbookTable.privateMode.test.tsx` renders the table with private mode enabled and asserts the values render unmasked; it fails without the fix.
- Full unit suite: 903/903 passing (`npm test` with NODE_OPTIONS=--no-webstorage). `tsc -b`, eslint and prettier clean.

- Fixes #1453

## Visual Demo

Regtest environment not available here, so covered by the private-mode rendering test instead. Before: values show as the `*****` mask in private mode. After: plain sats values.