### PR TITLE
Send: pin exact utxos when sweeping instead of re-deriving at broadcast time

### DIFF
--- a/src/components/send/ActiveCollaborativeSendAlert.test.tsx
+++ b/src/components/send/ActiveCollaborativeSendAlert.test.tsx
@@ -53,7 +53,7 @@ const sampleAttempt: PaymentAttempt = {
   utxosHashHex: bytesToHex(sha256(hexToBytes('00'))),
   walletFileName: 'test.jmdat',
   data: {
-    amount: { amount: 21_000, isSweep: false as const, sweepAmount: undefined },
+    amount: { amount: 21_000, isSweep: false as const, sweepAmount: undefined, sweepUtxos: undefined },
     destination: { address: 'bcrt1qdestinationaddress123456789', fromJar: undefined },
     isCoinJoin: true,
     numCollaborators: 5,

--- a/src/components/send/PaymentConfirmDialog.test.tsx
+++ b/src/components/send/PaymentConfirmDialog.test.tsx
@@ -70,6 +70,7 @@ const baseValues: SendFormValues = {
     amount: 12_000,
     isSweep: false,
     sweepAmount: undefined,
+    sweepUtxos: undefined,
   },
   destination: {
     address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
@@ -127,6 +128,7 @@ describe('PaymentConfirmDialog', () => {
         amount: undefined,
         isSweep: true,
         sweepAmount: 20_000,
+        sweepUtxos: ['aaaa'.repeat(16) + ':0'],
       },
       destination: {
         address: baseValues.destination.address,

--- a/src/components/send/SendForm.schema.test.ts
+++ b/src/components/send/SendForm.schema.test.ts
@@ -127,7 +127,7 @@ describe('createSendFormSchema', () => {
       schema.validate({
         ...validFormValues,
         source: { fromJar: jars[1].jarIndex },
-        amount: { isSweep: true, sweepAmount: MIN_SEND_AMOUNT },
+        amount: { isSweep: true, sweepAmount: MIN_SEND_AMOUNT, sweepUtxos: ['tx:0'] },
       }),
     ).rejects.toThrow('send.feedback_invalid_source_jar')
   })
@@ -137,7 +137,7 @@ describe('createSendFormSchema', () => {
       schema.validate({
         ...validFormValues,
         source: { fromJar: jars[2].jarIndex },
-        amount: { isSweep: true, sweepAmount: MIN_SEND_AMOUNT },
+        amount: { isSweep: true, sweepAmount: MIN_SEND_AMOUNT, sweepUtxos: ['tx:0'] },
       }),
     ).rejects.toThrow('send.feedback_invalid_source_jar_must_unfreeze_utxos')
   })
@@ -147,7 +147,7 @@ describe('createSendFormSchema', () => {
       schema.validate({
         ...validFormValues,
         source: { fromJar: jars[3].jarIndex },
-        amount: { isSweep: true, sweepAmount: MIN_SEND_AMOUNT },
+        amount: { isSweep: true, sweepAmount: MIN_SEND_AMOUNT, sweepUtxos: ['tx:0'] },
       }),
     ).rejects.toThrow('send.feedback_invalid_source_jar_must_freeze_fidelity_bond:{"count":2}')
   })
@@ -252,10 +252,26 @@ describe('createSendFormSchema', () => {
     await expect(
       schema.validate({
         ...validFormValues,
-        amount: { isSweep: true, sweepAmount: 9_000, amount: 500 },
+        amount: { isSweep: true, sweepAmount: 9_000, sweepUtxos: ['tx:0'], amount: 500 },
       }),
     ).resolves.toMatchObject({
-      amount: { isSweep: true, sweepAmount: 9_000, amount: null },
+      amount: { isSweep: true, sweepAmount: 9_000, sweepUtxos: ['tx:0'], amount: null },
     })
+  })
+
+  it('rejects sweeps without any captured utxos', async () => {
+    await expect(
+      schema.validate({
+        ...validFormValues,
+        amount: { isSweep: true, sweepAmount: 9_000, sweepUtxos: [] },
+      }),
+    ).rejects.toThrow('send.feedback_invalid_amount')
+
+    await expect(
+      schema.validate({
+        ...validFormValues,
+        amount: { isSweep: true, sweepAmount: 9_000, sweepUtxos: undefined },
+      }),
+    ).rejects.toThrow('amount.sweepUtxos is a required field')
   })
 })

--- a/src/components/send/SendForm.schema.ts
+++ b/src/components/send/SendForm.schema.ts
@@ -118,6 +118,15 @@ export const createSendFormSchema = (
                   .nullable()
                   .optional(),
             }),
+            sweepUtxos: yup.array().when('isSweep', {
+              is: (val: boolean) => val === true,
+              then: (schema) => schema.of(yup.string().required()).min(1, t('send.feedback_invalid_amount')).required(),
+              otherwise: (schema) =>
+                schema
+                  .transform(() => null)
+                  .nullable()
+                  .optional(),
+            }),
             amount: yup.number().when('isSweep', {
               is: (val: boolean) => val === true,
               then: (schema) =>

--- a/src/components/send/SendForm.test.tsx
+++ b/src/components/send/SendForm.test.tsx
@@ -126,6 +126,14 @@ vi.mock('@joinmarket-webui/joinmarket-api-ts/jm', () => ({
   getaddress: () => Promise.resolve(h.getaddressResult),
 }))
 
+// Reads the `amount` slice of the debug panel's `values:` JSON dump (only
+// rendered when `debug` is set), typed just enough for the sweep assertions.
+const readDebugAmountValues = (): { isSweep?: boolean; sweepUtxos?: string[] } => {
+  const valuesJson = screen.getByText('values:').nextElementSibling?.textContent ?? '{}'
+  const parsed = JSON.parse(valuesJson) as { amount?: { isSweep?: boolean; sweepUtxos?: string[] } }
+  return parsed.amount ?? {}
+}
+
 describe('SendForm', () => {
   const mockJars = [
     {
@@ -256,6 +264,70 @@ describe('SendForm', () => {
     expect(screen.queryByTestId('balance')).not.toBeInTheDocument()
 
     await flushActUpdates()
+  })
+
+  it('captures the jar’s current unfrozen utxos as sweepUtxos when clicking sweep', async () => {
+    const jarsWithUtxos = [
+      {
+        ...mockJars[0],
+        utxos: [
+          { utxo: 'aaaa'.repeat(16) + ':0', frozen: false, locktime: undefined },
+          { utxo: 'bbbb'.repeat(16) + ':1', frozen: false, locktime: undefined },
+          // frozen and timelocked utxos must not be captured
+          { utxo: 'cccc'.repeat(16) + ':0', frozen: true, locktime: undefined },
+        ],
+      },
+      mockJars[1],
+    ] as unknown as Jar[]
+
+    render(
+      <SendForm
+        onSubmit={vi.fn()}
+        walletFileName="test.jmdat"
+        jars={jarsWithUtxos}
+        walletBalanceSummary={mockBalanceSummary}
+        addressSummary={mockAddressSummary}
+        feeConfigValues={mockFeeConfigValues}
+        debug
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Jar 0' }))
+    fireEvent.click(document.querySelector('#btn-sweep-trigger')!)
+
+    await waitFor(() => {
+      const values = readDebugAmountValues()
+      expect(values.isSweep).toBe(true)
+      expect(values.sweepUtxos).toEqual(['aaaa'.repeat(16) + ':0', 'bbbb'.repeat(16) + ':1'])
+    })
+  })
+
+  it('clears sweepUtxos when clearing sweep or reselecting the source jar', async () => {
+    const jarsWithUtxos = [
+      { ...mockJars[0], utxos: [{ utxo: 'aaaa'.repeat(16) + ':0', frozen: false, locktime: undefined }] },
+      mockJars[1],
+    ] as unknown as Jar[]
+
+    render(
+      <SendForm
+        onSubmit={vi.fn()}
+        walletFileName="test.jmdat"
+        jars={jarsWithUtxos}
+        walletBalanceSummary={mockBalanceSummary}
+        addressSummary={mockAddressSummary}
+        feeConfigValues={mockFeeConfigValues}
+        debug
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Jar 0' }))
+    fireEvent.click(document.querySelector('#btn-sweep-trigger')!)
+
+    await waitFor(() => expect(readDebugAmountValues().sweepUtxos).toEqual(['aaaa'.repeat(16) + ':0']))
+
+    fireEvent.click(document.querySelector('#btn-sweep-clear-trigger')!)
+
+    await waitFor(() => expect(readDebugAmountValues().sweepUtxos).toBeUndefined())
   })
 
   it('applies a scanned bip21 result', async () => {

--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -18,6 +18,7 @@ import { useQueryOrderbook } from '@/hooks/useQueryOrderbook'
 import type { BalanceSummary } from '@/lib/balanceSummary'
 import { parseBip21Uri, type Bip21ParseResult } from '@/lib/bip21'
 import type { JamFeeConfigValues } from '@/lib/feeConfig'
+import * as fb from '@/lib/fidelityBondUtils'
 import { cn, delayedPromise, factorToPercentage, type WalletFileName } from '@/lib/utils'
 import type { BitcoinAddress, JarIndex } from '@/types/global'
 import { DevBadge } from '../dev/DevBadge'
@@ -94,6 +95,13 @@ const AddressFromJarSelectorDialog = ({
     />
   )
 }
+
+// Same "available" definition as `toBalanceSummary`: not frozen and not a
+// timelocked fidelity bond. Captured at the moment "Sweep" is clicked so the
+// exact utxos can be pinned via `input_utxos`, instead of the backend
+// re-deriving "everything unfrozen in the mixdepth" at broadcast time.
+const availableUtxosForSweep = (jar: Jar | undefined) =>
+  (jar?.utxos ?? []).filter((utxo) => !utxo.frozen && !fb.utxo.isLocked(utxo)).map((utxo) => utxo.utxo)
 
 const FieldPrefixSatSymbol = (
   <SatSymbol
@@ -355,6 +363,7 @@ export function SendForm({
                         if (isSweep === true) {
                           setValue('amount.isSweep', false, { shouldValidate: true })
                           setValue('amount.sweepAmount', undefined, { shouldValidate: true })
+                          setValue('amount.sweepUtxos', undefined, { shouldValidate: true })
                           setValue('amount.amount', undefined, { shouldValidate: true })
                         }
                         if (destinationJarIndex === jar.jarIndex) {
@@ -520,6 +529,7 @@ export function SendForm({
                     setValue('amount.sweepAmount', sourceJar?.balanceSummary.calculatedAvailableBalanceInSats, {
                       shouldValidate: true,
                     })
+                    setValue('amount.sweepUtxos', availableUtxosForSweep(sourceJar), { shouldValidate: true })
                     setValue('amount.amount', undefined, { shouldValidate: true })
                   }}
                 >
@@ -560,6 +570,7 @@ export function SendForm({
                   onClick={() => {
                     setValue('amount.isSweep', false, { shouldValidate: true })
                     setValue('amount.sweepAmount', undefined, { shouldValidate: true })
+                    setValue('amount.sweepUtxos', undefined, { shouldValidate: true })
                     setValue('amount.amount', undefined, { shouldValidate: true })
                   }}
                 >
@@ -570,6 +581,7 @@ export function SendForm({
               {errors.amount?.sweepAmount?.message ? (
                 <FieldError>{errors.amount.sweepAmount.message}</FieldError>
               ) : null}
+              {errors.amount?.sweepUtxos?.message ? <FieldError>{errors.amount.sweepUtxos.message}</FieldError> : null}
               {errors.amount?.isSweep?.message ? <FieldError>{errors.amount.isSweep.message}</FieldError> : null}
             </Field>
           </div>

--- a/src/components/send/SendPage.test.tsx
+++ b/src/components/send/SendPage.test.tsx
@@ -298,7 +298,7 @@ const jars: Jar[] = [
 ]
 
 const directValues: SendFormValues = {
-  amount: { amount: 1_000, isSweep: false, sweepAmount: undefined },
+  amount: { amount: 1_000, isSweep: false, sweepAmount: undefined, sweepUtxos: undefined },
   destination: { address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq', fromJar: undefined },
   isCoinJoin: false,
   source: { fromJar: 0 },

--- a/src/components/send/collaborativeSend.test.ts
+++ b/src/components/send/collaborativeSend.test.ts
@@ -8,7 +8,7 @@ const validAddress = 'bcrt1qrnz0thqslhxu86th069r9j6y7ldkgs2tzgf5wx' // regtest e
 const baseValues = (): SendFormValues => ({
   source: { fromJar: 0 },
   destination: { address: validAddress, fromJar: undefined },
-  amount: { isSweep: false, amount: 100_000, sweepAmount: undefined },
+  amount: { isSweep: false, amount: 100_000, sweepAmount: undefined, sweepUtxos: undefined },
   isCoinJoin: true,
   numCollaborators: 4,
   txFee: {
@@ -28,17 +28,33 @@ describe('buildCollaborativeSendRequest', () => {
     })
   })
 
-  it('maps sweep to amount_sats=0', () => {
+  it('maps sweep to amount_sats=0 and passes the captured utxos as input_utxos', () => {
     const request = buildCollaborativeSendRequest({
       ...baseValues(),
       amount: {
         isSweep: true,
         amount: undefined,
         sweepAmount: 500_000,
+        sweepUtxos: ['aaaa'.repeat(16) + ':0', 'bbbb'.repeat(16) + ':1'],
       },
     })
 
     expect(request.amount_sats).toBe(0)
+    expect(request.input_utxos).toEqual(['aaaa'.repeat(16) + ':0', 'bbbb'.repeat(16) + ':1'])
+  })
+
+  it('throws when sweeping without any captured utxos', () => {
+    expect(() =>
+      buildCollaborativeSendRequest({
+        ...baseValues(),
+        amount: {
+          isSweep: true,
+          amount: undefined,
+          sweepAmount: 500_000,
+          sweepUtxos: [],
+        },
+      }),
+    ).toThrow('Missing utxos to sweep.')
   })
 
   it('passes txfee when txFeeInBlocks is present', () => {
@@ -103,14 +119,14 @@ describe('buildCollaborativeSendRequest', () => {
     expect(() =>
       buildCollaborativeSendRequest({
         ...baseValues(),
-        amount: { isSweep: false, amount: 0, sweepAmount: undefined },
+        amount: { isSweep: false, amount: 0, sweepAmount: undefined, sweepUtxos: undefined },
       }),
     ).toThrow('Invalid amount.')
 
     expect(() =>
       buildCollaborativeSendRequest({
         ...baseValues(),
-        amount: { isSweep: false, amount: 1.5, sweepAmount: undefined },
+        amount: { isSweep: false, amount: 1.5, sweepAmount: undefined, sweepUtxos: undefined },
       }),
     ).toThrow('Invalid amount.')
   })
@@ -143,7 +159,7 @@ describe('buildNonCollaborativeSendRequest', () => {
     })
   })
 
-  it('maps sweep direct sends to amount_sats=0', () => {
+  it('maps sweep direct sends to amount_sats=0 and passes the captured utxos as input_utxos', () => {
     const request = buildNonCollaborativeSendRequest({
       ...baseValues(),
       isCoinJoin: false,
@@ -151,10 +167,27 @@ describe('buildNonCollaborativeSendRequest', () => {
         isSweep: true,
         amount: undefined,
         sweepAmount: 500_000,
+        sweepUtxos: ['aaaa'.repeat(16) + ':0'],
       },
     })
 
     expect(request.amount_sats).toBe(0)
+    expect(request.input_utxos).toEqual(['aaaa'.repeat(16) + ':0'])
+  })
+
+  it('throws for direct-send sweep without any captured utxos', () => {
+    expect(() =>
+      buildNonCollaborativeSendRequest({
+        ...baseValues(),
+        isCoinJoin: false,
+        amount: {
+          isSweep: true,
+          amount: undefined,
+          sweepAmount: 500_000,
+          sweepUtxos: [],
+        },
+      }),
+    ).toThrow('Missing utxos to sweep.')
   })
 
   it('passes direct-send txfee values', () => {

--- a/src/components/send/collaborativeSend.ts
+++ b/src/components/send/collaborativeSend.ts
@@ -33,6 +33,9 @@ export const buildNonCollaborativeSendRequest = (data: SendFormValues): DirectSe
   if (data.amount.isSweep === true && data.amount.amount !== undefined) {
     throw new Error('Cannot trigger non-collaborative transaction: Invalid amount given for sweep.')
   }
+  if (data.amount.isSweep === true && (data.amount.sweepUtxos === undefined || data.amount.sweepUtxos.length === 0)) {
+    throw new Error('Cannot trigger non-collaborative transaction: Missing utxos to sweep.')
+  }
 
   const txfee = txFeeValueForRequest(data)
 
@@ -41,6 +44,7 @@ export const buildNonCollaborativeSendRequest = (data: SendFormValues): DirectSe
     destination: normalizeBitcoinAddress(data.destination.address),
     mixdepth: data.source.fromJar,
     txfee,
+    input_utxos: data.amount.isSweep === true ? data.amount.sweepUtxos : undefined,
   }
 }
 
@@ -65,6 +69,9 @@ export const buildCollaborativeSendRequest = (data: SendFormValues): DoCoinjoinR
   if (!data.amount.isSweep && amountSats <= 0) {
     throw new Error('Invalid amount.')
   }
+  if (data.amount.isSweep && (data.amount.sweepUtxos === undefined || data.amount.sweepUtxos.length === 0)) {
+    throw new Error('Missing utxos to sweep.')
+  }
 
   const txfee = txFeeValueForRequest(data)
   if (txfee !== undefined && (!isValidNumber(txfee) || txfee <= 0)) {
@@ -77,5 +84,6 @@ export const buildCollaborativeSendRequest = (data: SendFormValues): DoCoinjoinR
     counterparties,
     destination: address,
     txfee,
+    input_utxos: data.amount.isSweep ? data.amount.sweepUtxos : undefined,
   }
 }

--- a/src/components/send/types.d.ts
+++ b/src/components/send/types.d.ts
@@ -15,11 +15,20 @@ export type AmountValue =
       amount: AmountSats
       isSweep: false
       sweepAmount: undefined
+      sweepUtxos: undefined
     }
   | {
       amount: undefined
       isSweep: true
       sweepAmount: AmountSats
+      /**
+       * The exact utxos (as `txid:vout` strings) that made up the source jar's
+       * available balance at the moment "Sweep" was clicked. Sent as
+       * `input_utxos` so the backend sweeps precisely these utxos instead of
+       * re-deriving "everything unfrozen in the mixdepth" at broadcast time,
+       * which can silently differ if the jar's contents changed in between.
+       */
+      sweepUtxos: string[]
     }
 
 export interface SendFormValues {

--- a/src/stories/jam/ActiveCollaborativeSendAlert.stories.tsx
+++ b/src/stories/jam/ActiveCollaborativeSendAlert.stories.tsx
@@ -43,7 +43,7 @@ const paymentAttempt: PaymentAttempt = {
   utxosHashHex: 'abc123hash',
   walletFileName: 'Satoshi.jmdat',
   data: {
-    amount: { amount: 21_000, isSweep: false as const, sweepAmount: undefined },
+    amount: { amount: 21_000, isSweep: false as const, sweepAmount: undefined, sweepUtxos: undefined },
     destination: { address: 'bcrt1qdestinationaddress123456789', fromJar: undefined },
     isCoinJoin: true,
     numCollaborators: 5,
@@ -65,7 +65,7 @@ export const WithSweepPaymentAttempt: Story = {
       ...paymentAttempt,
       data: {
         ...paymentAttempt.data,
-        amount: { amount: undefined, isSweep: true, sweepAmount: 21_000 },
+        amount: { amount: undefined, isSweep: true, sweepAmount: 21_000, sweepUtxos: ['aaaa'.repeat(16) + ':0'] },
         destination: { address: 'bcrt1qdestinationaddress123456789', fromJar: paymentAttempt.data.source.fromJar },
       },
     },


### PR DESCRIPTION
## What does this PR do?

Sweep amount was captured once when the button was clicked, but the actual utxos to spend were only decided by the backend at broadcast time. If the jar's contents changed in between (another tx confirms, a utxo gets frozen, etc), the swept amount could silently drift from what the backend actually sends.

This pins the exact utxos backing the jar's available balance at the moment "Sweep" is clicked, and sends them as `input_utxos` so the backend sweeps precisely those utxos instead of re-deriving "everything unfrozen in the mixdepth" later.

- Fixes #1422
