### PR TITLE
fix: use utxos hash in displaywallet query key

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -97,6 +97,7 @@ vi.mock('@tanstack/react-query', () => ({
 
 vi.mock('@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query', () => ({
   lockwalletOptions: () => ({ queryKey: ['lock'] }),
+  displaywalletOptions: () => ({ queryKey: [{ _id: 'displaywallet' }], queryFn: vi.fn() }),
 }))
 
 vi.mock('@joinmarket-webui/joinmarket-api-ts/jm', () => ({
@@ -281,49 +282,35 @@ describe('WalletInfoAutoReload', () => {
     holders.utxosHashHex = 'initial-hash'
   })
 
-  it('skips refetch on initial mount but refetches on subsequent utxosHashHex changes', async () => {
+  it('does not call refetchWalletBalance on initial mount', () => {
+    render(
+      <StrictMode>
+        <WalletInfoAutoReload />
+      </StrictMode>,
+    )
+
+    // displaywallet now refetches automatically via React Query when utxosHashHex
+    // changes its query key — WalletInfoAutoReload no longer needs a manual effect
+    // for UTXO changes.
+    expect(refetchWalletBalance).not.toHaveBeenCalled()
+  })
+
+  it('does not call refetchWalletBalance when utxosHashHex changes (query key handles it)', () => {
     const { rerender } = render(
       <StrictMode>
         <WalletInfoAutoReload />
       </StrictMode>,
     )
 
-    // 1. Verify refetchWalletBalance is NOT called because of the initial mount
-    expect(refetchWalletBalance).not.toHaveBeenCalled()
-
-    // 2. A subsequent utxosHashHex change DOES call refetchWalletBalance
+    // Changing utxosHashHex no longer triggers a manual refetchWalletBalance call.
+    // React Query sees a new displaywallet query key and handles the fetch automatically.
     holders.utxosHashHex = 'changed-hash-1'
     rerender(
       <StrictMode>
         <WalletInfoAutoReload />
       </StrictMode>,
     )
-    await waitFor(() => expect(refetchWalletBalance).toHaveBeenCalledTimes(1))
 
-    // 3. Multiple subsequent UTXO hash changes continue to trigger refetches
-    holders.utxosHashHex = 'changed-hash-2'
-    rerender(
-      <StrictMode>
-        <WalletInfoAutoReload />
-      </StrictMode>,
-    )
-    await waitFor(() => expect(refetchWalletBalance).toHaveBeenCalledTimes(2))
-
-    // 4. Test that the existing refetch behavior arguments remain unchanged
-    // It should be called with { delayBefore: 210, signal: <AbortSignal> }
-    expect(refetchWalletBalance).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        delayBefore: 210,
-        signal: expect.any(AbortSignal) as unknown as AbortSignal,
-      }),
-    )
-
-    // 6. Test that same hash doesn't trigger another refetch
-    rerender(
-      <StrictMode>
-        <WalletInfoAutoReload />
-      </StrictMode>,
-    )
-    expect(refetchWalletBalance).toHaveBeenCalledTimes(2)
+    expect(refetchWalletBalance).not.toHaveBeenCalled()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -401,7 +401,6 @@ function LoadFeeConfigData({ walletFileName }: { walletFileName: WalletFileName 
 
 const RELOAD_WALLET_INFO_DELAY: {
   AFTER_RESCAN: Milliseconds
-  AFTER_UTXO_CHANGE: Milliseconds
   AFTER_BLOCK_HEIGHT_CHANGE: Milliseconds
   AFTER_TAKER_STOPPED: Milliseconds
   AFTER_TX_MESSAGE: Milliseconds
@@ -414,13 +413,10 @@ const RELOAD_WALLET_INFO_DELAY: {
   // takes effect after rescanning the chain, which should happen quite infrequently.
   AFTER_RESCAN: 8_000,
 
-  // Small delay is sufficient after utxo change (e.g. normal unlock of wallet)
-  AFTER_UTXO_CHANGE: 210,
-
   // Small delay is sufficient after block height change
   AFTER_BLOCK_HEIGHT_CHANGE: 210,
 
-  // Small delay is sufficient after block height change
+  // Small delay is sufficient after taker stopped
   AFTER_TAKER_STOPPED: 210,
 
   // Small delay is sufficient after an incoming tx message via websocket
@@ -449,9 +445,7 @@ export const WalletInfoAutoReload = () => {
   const jmTxs = useStore(jmTxStore, (state) => state.state)
   const previousJmTxsRef = useRef<JmTxInfos>(jmTxs)
 
-  const { refetch: refetchWalletBalance, utxosHashHex } = useJamWalletInfoContext()
-
-  const previousUtxosHashHexRef = useRef(utxosHashHex)
+  const { refetch: refetchWalletBalance } = useJamWalletInfoContext()
 
   useEffect(
     function refetchWalletInfoAfterRescanFinished() {
@@ -500,30 +494,6 @@ export const WalletInfoAutoReload = () => {
       return () => abortCtrl.abort('useEffect(AFTER_BLOCK_HEIGHT_CHANGE) ended')
     },
     [refetchWalletBalance, currentBlockHeight],
-  )
-
-  useEffect(
-    function refetchWalletInfoAfterUtxoChange() {
-      if (previousUtxosHashHexRef.current === utxosHashHex) {
-        return
-      }
-
-      previousUtxosHashHexRef.current = utxosHashHex
-
-      const delayBefore = RELOAD_WALLET_INFO_DELAY.AFTER_UTXO_CHANGE
-      console.debug(
-        'Trigger refetch looking for funds AFTER_UTXO_CHANGE (%s) with delay %d...',
-        utxosHashHex,
-        delayBefore,
-      )
-
-      const abortCtrl = new AbortController()
-      refetchWalletBalance({ delayBefore, signal: abortCtrl.signal }).catch((error: unknown) => {
-        console.error('Error while auto-reloading wallet info AFTER_UTXO_CHANGE finished', error)
-      })
-      return () => abortCtrl.abort('useEffect(AFTER_UTXO_CHANGE) ended')
-    },
-    [refetchWalletBalance, utxosHashHex],
   )
 
   useEffect(

--- a/src/hooks/useQueryDisplayWallet.test.tsx
+++ b/src/hooks/useQueryDisplayWallet.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query', () => ({
 }))
 
 vi.mock('@tanstack/react-query', () => ({
+  keepPreviousData: (data: unknown) => data,
   useQuery: (options: { queryKey: unknown }) => {
     capturedQueryKeys.push(options.queryKey)
     return { data: undefined }

--- a/src/hooks/useQueryDisplayWallet.test.tsx
+++ b/src/hooks/useQueryDisplayWallet.test.tsx
@@ -1,0 +1,105 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WalletFileName } from '@/lib/utils'
+import { useQueryDisplayWallet } from './useQueryDisplayWallet'
+
+// ---- Minimal stubs ----------------------------------------------------------------
+
+const capturedQueryKeys: unknown[] = []
+
+vi.mock('@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query', () => ({
+  displaywalletOptions: ({ path }: { path: { walletname: string } }) => ({
+    queryKey: [{ _id: 'displaywallet', path }],
+    queryFn: vi.fn(),
+  }),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (options: { queryKey: unknown }) => {
+    capturedQueryKeys.push(options.queryKey)
+    return { data: undefined }
+  },
+}))
+
+vi.mock('@/hooks/useApiClient', () => ({
+  useApiClient: () => ({}),
+}))
+
+vi.mock('@/lib/queryClient', () => ({
+  withQueryDelay: (queryFn_: unknown) => queryFn_,
+}))
+
+vi.mock('@/constants/debugFeatures', () => ({
+  isDevMode: () => false,
+}))
+
+vi.mock('@/store/jmSessionStore', () => ({
+  jmSessionStore: {
+    getState: () => ({ state: { session: 'active' } }),
+  },
+}))
+
+vi.mock('zustand', () => ({
+  useStore: (_store: unknown, selector: (s: { state: { session: string } }) => unknown) =>
+    selector({ state: { session: 'active' } }),
+}))
+
+// ---- Helpers ----------------------------------------------------------------------
+
+const walletFileName = 'test.jmdat' as WalletFileName
+
+// ---- Tests -----------------------------------------------------------------------
+
+describe('useQueryDisplayWallet — query key participates in React Query identity', () => {
+  beforeEach(() => {
+    capturedQueryKeys.length = 0
+  })
+
+  it('includes utxosHashHex in the query key', () => {
+    renderHook(() => useQueryDisplayWallet({ walletFileName, utxosHashHex: 'hash-abc' }))
+
+    expect(capturedQueryKeys).toHaveLength(1)
+    const key = capturedQueryKeys[0] as unknown[]
+    // The generated key is the first element; utxosHashHex is appended as the last element
+    expect(key.at(-1)).toBe('hash-abc')
+  })
+
+  it('different utxosHashHex values produce different query keys', () => {
+    renderHook(() => useQueryDisplayWallet({ walletFileName, utxosHashHex: 'hash-1' }))
+    renderHook(() => useQueryDisplayWallet({ walletFileName, utxosHashHex: 'hash-2' }))
+
+    expect(capturedQueryKeys).toHaveLength(2)
+    const key1 = capturedQueryKeys[0] as unknown[]
+    const key2 = capturedQueryKeys[1] as unknown[]
+
+    // The keys must differ — React Query will treat them as distinct queries
+    expect(key1.at(-1)).toBe('hash-1')
+    expect(key2.at(-1)).toBe('hash-2')
+    expect(JSON.stringify(key1)).not.toBe(JSON.stringify(key2))
+  })
+
+  it('same utxosHashHex produces the same query key', () => {
+    renderHook(() => useQueryDisplayWallet({ walletFileName, utxosHashHex: 'stable-hash' }))
+    renderHook(() => useQueryDisplayWallet({ walletFileName, utxosHashHex: 'stable-hash' }))
+
+    expect(capturedQueryKeys).toHaveLength(2)
+    // Both keys are identical — React Query reuses the cached result
+    expect(JSON.stringify(capturedQueryKeys[0])).toBe(JSON.stringify(capturedQueryKeys[1]))
+  })
+
+  it('uses empty string as default utxosHashHex when not provided', () => {
+    renderHook(() => useQueryDisplayWallet({ walletFileName }))
+
+    expect(capturedQueryKeys).toHaveLength(1)
+    const key = capturedQueryKeys[0] as unknown[]
+    expect(key.at(-1)).toBe('')
+  })
+
+  it('does not put utxosHashHex only in meta — it must be in the array', () => {
+    renderHook(() => useQueryDisplayWallet({ walletFileName, utxosHashHex: 'meta-test' }))
+
+    const key = capturedQueryKeys[0] as unknown[]
+    // Verify utxosHashHex is a direct element of the key array, not buried in an object
+    expect(key).toContain('meta-test')
+  })
+})

--- a/src/hooks/useQueryDisplayWallet.ts
+++ b/src/hooks/useQueryDisplayWallet.ts
@@ -1,6 +1,6 @@
 import { displaywalletOptions } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import type { DisplaywalletResponse, WalletDisplayResponse } from '@joinmarket-webui/joinmarket-api-ts/jm'
-import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { keepPreviousData, useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { useStore } from 'zustand'
 import { isDevMode } from '@/constants/debugFeatures'
 import { useApiClient } from '@/hooks/useApiClient'
@@ -46,6 +46,11 @@ export function useQueryDisplayWallet({
       throttle: isDevMode() ? 2_100 : 0,
     }),
     enabled: !!walletFileName && !!jmSession,
+    // When the query key changes (utxosHashHex changes), keep the previous
+    // successful data visible while the new request is in-flight.
+    // This prevents `isLoading` from temporarily becoming true and causing
+    // the wallet balance and jars to be replaced by a spinner.
+    placeholderData: keepPreviousData,
   })
 
   return {

--- a/src/hooks/useQueryDisplayWallet.ts
+++ b/src/hooks/useQueryDisplayWallet.ts
@@ -36,11 +36,11 @@ export function useQueryDisplayWallet({
   // each distinct UTXO state as a distinct query identity. When the UTXO set
   // changes (utxosHashHex changes), React Query automatically fetches the
   // displaywallet endpoint — no manual refetch effect needed.
-  const queryKey = [...displaywalletQueryOptions.queryKey, utxosHashHex] as const
+  const queryKey = [...displaywalletQueryOptions.queryKey, utxosHashHex]
 
   const queryResult = useQuery({
     ...displaywalletQueryOptions,
-    queryKey,
+    queryKey: queryKey as unknown as typeof displaywalletQueryOptions.queryKey,
     queryFn: withQueryDelay(displaywalletQueryOptions.queryFn, {
       // simulate slow mainnet responses in dev mode
       throttle: isDevMode() ? 2_100 : 0,

--- a/src/hooks/useQueryDisplayWallet.ts
+++ b/src/hooks/useQueryDisplayWallet.ts
@@ -30,13 +30,17 @@ export function useQueryDisplayWallet({
   const displaywalletQueryOptions = displaywalletOptions({
     client,
     path: { walletname: walletFileName },
-    meta: {
-      cacheBuster: utxosHashHex,
-    },
   })
+
+  // Extend the generated query key with utxosHashHex so that React Query treats
+  // each distinct UTXO state as a distinct query identity. When the UTXO set
+  // changes (utxosHashHex changes), React Query automatically fetches the
+  // displaywallet endpoint — no manual refetch effect needed.
+  const queryKey = [...displaywalletQueryOptions.queryKey, utxosHashHex] as const
 
   const queryResult = useQuery({
     ...displaywalletQueryOptions,
+    queryKey,
     queryFn: withQueryDelay(displaywalletQueryOptions.queryFn, {
       // simulate slow mainnet responses in dev mode
       throttle: isDevMode() ? 2_100 : 0,


### PR DESCRIPTION
## Summary

Follow-up to #1448.

This PR replaces the manual `AFTER_UTXO_CHANGE` wallet refetch mechanism with a React Query query-key dependency.

## Changes

- Make `utxosHashHex` part of the `displaywallet` query identity.
- Remove the `meta.cacheBuster` dependency for this behavior.
- Remove the manual `AFTER_UTXO_CHANGE` refetch path.
- Simplify the wallet auto-reload flow.
- Add/update tests for the query-key based behavior.

## Result

Previous flow:

UTXO change
? AFTER_UTXO_CHANGE
? manual refetch

New flow:

UTXO change
? utxosHashHex changes
? displaywallet query key changes
? React Query handles the fetch

## Validation

- Focused tests: PASS
- Typecheck: PASS
- Lint: PASS
- Build: PASS
- git diff --check: PASS

This is the follow-up approach discussed during review of #1448.