### PR TITLE
fix(earn): pin the reviewed utxos when creating a fidelity bond

### DIFF
--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.test.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.test.ts
@@ -191,12 +191,64 @@ describe('useCreateFidelityBondWizard', () => {
         mixdepth: 0,
         amount_sats: 0,
         destination: 'bcrt1qtimelockdestination',
+        input_utxos: ['only:0'],
       },
     })
     expect(result.current.step).toBe('success')
     expect(result.current.txResult).toEqual({ txid: 'created-tx' })
     expect(mocks.walletInfoRefetch).toHaveBeenCalled()
     expect(mocks.toastSuccess).toHaveBeenCalledWith('earn.fidelity_bond.create_fidelity_bond.success_text')
+  })
+
+  it('sweeps only the reviewed utxos when new funds arrive in the jar before confirming', async () => {
+    mocks.walletInfo.jars = [jar(0, [utxo({ utxo: 'reviewed:0', value: 25_000 })])]
+    const { result, rerender } = renderHook(() => useCreateFidelityBondWizard(true, vi.fn(), 'wallet.jmdat'))
+
+    act(() => result.current.setSelectedLockdate(minLockdateOption()))
+    await act(async () => result.current.handleNext())
+    act(() => result.current.toggleUtxoSelection(result.current.availableUtxos[0]))
+    await act(async () => result.current.handleNext())
+
+    expect(result.current.step).toBe('review')
+    expect(result.current.totalAmount).toBe(25_000)
+
+    mocks.walletInfo.jars = [
+      jar(0, [utxo({ utxo: 'reviewed:0', value: 25_000 }), utxo({ utxo: 'arrived-late:0', value: 80_000 })]),
+    ]
+    rerender()
+
+    act(() => result.current.setConfirmationChecked(true))
+    await act(async () => result.current.handleNext())
+
+    expect(mocks.directSendMutateAsync).toHaveBeenCalledWith({
+      path: { walletname: 'wallet.jmdat' },
+      body: {
+        mixdepth: 0,
+        amount_sats: 0,
+        destination: 'bcrt1qtimelockdestination',
+        input_utxos: ['reviewed:0'],
+      },
+    })
+  })
+
+  it('does not broadcast when the reviewed utxo is no longer in the jar', async () => {
+    mocks.walletInfo.jars = [jar(0, [utxo({ utxo: 'reviewed:0', value: 25_000 })])]
+    const { result, rerender } = renderHook(() => useCreateFidelityBondWizard(true, vi.fn(), 'wallet.jmdat'))
+
+    act(() => result.current.setSelectedLockdate(minLockdateOption()))
+    await act(async () => result.current.handleNext())
+    act(() => result.current.toggleUtxoSelection(result.current.availableUtxos[0]))
+    await act(async () => result.current.handleNext())
+
+    expect(result.current.step).toBe('review')
+
+    mocks.walletInfo.jars = [jar(0, [utxo({ utxo: 'spent-elsewhere:0', value: 25_000 })])]
+    rerender()
+
+    act(() => result.current.setConfirmationChecked(true))
+    await act(async () => result.current.handleNext())
+
+    expect(mocks.directSendMutateAsync).not.toHaveBeenCalled()
   })
 
   it('freezes unselected utxos before review and supports back navigation', async () => {

--- a/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
+++ b/src/components/earn/CreateFidelityBondDialog/useCreateFidelityBondWizard.ts
@@ -272,7 +272,7 @@ export function useCreateFidelityBondWizard(
   }
 
   const handleCreateFidelityBond = async () => {
-    if (!address || selectedJar === undefined) return
+    if (!address || selectedJar === undefined || selectedUtxos.length === 0) return
 
     setStep('creating')
 
@@ -286,6 +286,9 @@ export function useCreateFidelityBondWizard(
           mixdepth: selectedJar.jarIndex,
           amount_sats: 0, // 0 := sweep!
           destination: address,
+          // Pin the reviewed utxos so the sweep spends exactly those, instead of
+          // whatever is unfrozen in the mixdepth once the user confirms.
+          input_utxos: selectedUtxos.map((utxo) => utxo.utxo),
         },
       })
       broadcasted = true


### PR DESCRIPTION
## What does this PR do?

The create-bond wizard froze every other utxo in the jar and then swept the whole mixdepth, because `direct-send` only took a `mixdepth`. That freeze is a snapshot taken before the review step, and nothing re-checked it before broadcasting — so anything unfrozen landing in the jar while the user read the warning and ticked the confirmation checkbox got locked into the bond too, for the full bond duration. The review screen shows the sum of the *selected* utxos, so the amount the user confirms could be less than what actually got locked.

`direct-send` now accepts an explicit `input_utxos` list, so the sweep names the reviewed utxos directly and spends exactly those, regardless of what else is sitting unfrozen in the mixdepth at broadcast time. It also bails out instead of broadcasting if the reviewed utxo is no longer in the jar, since an empty `input_utxos` is rejected by the API and the old code would have swept the whole mixdepth in that case.

- Fixes #1460

### Note on the freeze step

I left the `utxosToFreeze` machinery and the "Freeze Remaining UTXOs" step in place. It's redundant now that the sweep names its inputs, but removing it touches the wizard steps, the i18n keys and a fair amount of test setup, so it felt better as a separate change than bundled into a fund-safety fix. Happy to do it here instead if you'd prefer.

### Tests

Two new tests in `useCreateFidelityBondWizard.test.ts`:

- a utxo arriving in the jar between the review step and confirmation is not swept into the bond
- no broadcast happens if the reviewed utxo is gone from the jar by the time the user confirms

I checked both actually pin the behaviour down — reverting the fix makes them fail (along with the existing direct-send assertion), rather than passing regardless.

## Visual Demo

No UI changes — this only affects which utxos the broadcast spends.
