### PR TITLE
feat(jar-details): freeze and unfreeze selected utxos in one request

### DIFF
--- a/src/components/wallet/WalletJarsDetailsContent.test.tsx
+++ b/src/components/wallet/WalletJarsDetailsContent.test.tsx
@@ -5,9 +5,10 @@ import type { AccountMeta, AccountSummary, AddressMeta, AddressSummary, Jar } fr
 import type { Utxo } from '@/hooks/useQueryUtxos'
 import { WalletJarsDetailsContent } from './WalletJarsDetailsContent'
 
-const { walletInfoRefetch, toastMocks, ...mocks } = vi.hoisted(() => ({
+const { walletInfoRefetch, toastMocks, freezebatchMutationFn, ...mocks } = vi.hoisted(() => ({
   walletInfoRefetch: vi.fn(),
-  toastMocks: { success: vi.fn(), warning: vi.fn() },
+  freezebatchMutationFn: vi.fn(),
+  toastMocks: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
   rescanning: false,
   takerRunning: false,
   makerRunning: false,
@@ -21,6 +22,9 @@ vi.mock('sonner', () => ({
     warning: (message: string) => {
       toastMocks.warning(message)
     },
+    error: (message: string) => {
+      toastMocks.error(message)
+    },
     dismiss: () => {},
   },
 }))
@@ -33,7 +37,7 @@ vi.mock('react-i18next', () => ({
 }))
 
 vi.mock('@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query', () => ({
-  freezeMutation: vi.fn(() => ({ mutationFn: vi.fn() })),
+  freezebatchMutation: vi.fn(() => ({ mutationFn: freezebatchMutationFn })),
 }))
 
 vi.mock('@tanstack/react-query', () => ({
@@ -160,8 +164,11 @@ describe('WalletJarsDetailsContent', () => {
   beforeEach(() => {
     walletInfoRefetch.mockReset()
     walletInfoRefetch.mockResolvedValue({})
+    freezebatchMutationFn.mockReset()
+    freezebatchMutationFn.mockResolvedValue({})
     toastMocks.success.mockReset()
     toastMocks.warning.mockReset()
+    toastMocks.error.mockReset()
     mocks.rescanning = false
     mocks.takerRunning = false
     mocks.makerRunning = false
@@ -254,6 +261,11 @@ describe('WalletJarsDetailsContent', () => {
     await waitFor(() =>
       expect(toastMocks.success).toHaveBeenCalledWith('jar_details.utxo_list.toast_freeze_success:{"count":1}'),
     )
+    expect(freezebatchMutationFn).toHaveBeenCalledTimes(1)
+    expect(freezebatchMutationFn).toHaveBeenCalledWith({
+      path: { walletname: 'wallet.jmdat' },
+      body: { entries: [{ 'utxo-string': 'wallet-tx-b:1', freeze: true }] },
+    })
     expect(walletInfoRefetch).toHaveBeenCalled()
   })
 
@@ -273,7 +285,28 @@ describe('WalletJarsDetailsContent', () => {
     await waitFor(() =>
       expect(toastMocks.success).toHaveBeenCalledWith('jar_details.utxo_list.toast_unfreeze_success:{"count":1}'),
     )
+    expect(freezebatchMutationFn).toHaveBeenCalledTimes(1)
+    expect(freezebatchMutationFn).toHaveBeenCalledWith({
+      path: { walletname: 'wallet.jmdat' },
+      body: { entries: [{ 'utxo-string': 'wallet-tx-c:2', freeze: false }] },
+    })
     expect(walletInfoRefetch).toHaveBeenCalled()
+  })
+
+  it('reports a failed batch without refetching', async () => {
+    const user = userEvent.setup()
+    freezebatchMutationFn.mockRejectedValue(new Error('batch rejected'))
+    render(<WalletJarsDetailsContent enabled walletFileName="wallet.jmdat" selectedJarIndex={1} />)
+
+    const dataRow = screen.getAllByRole('row').find((row) => within(row).queryByText('bc1qwallet-b'))!
+    await user.click(within(dataRow).getByRole('checkbox'))
+    await user.click(screen.getByRole('button', { name: 'jar_details.utxo_list.button_freeze' }))
+
+    await waitFor(() =>
+      expect(toastMocks.error).toHaveBeenCalledWith('jar_details.utxo_list.toast_freeze_error:{"count":1}'),
+    )
+    expect(toastMocks.success).not.toHaveBeenCalled()
+    expect(walletInfoRefetch).not.toHaveBeenCalled()
   })
 
   it.each(['taker', 'maker', 'rescan'])('disables freeze/unfreeze if rescan/maker/taker is running', async (value) => {

--- a/src/components/wallet/WalletJarsDetailsContent.tsx
+++ b/src/components/wallet/WalletJarsDetailsContent.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { freezeMutation } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
+import { freezebatchMutation } from '@joinmarket-webui/joinmarket-api-ts/@tanstack/react-query'
 import { useMutation } from '@tanstack/react-query'
 import type { RowSelectionState } from '@tanstack/react-table'
 import type { TFunction } from 'i18next'
@@ -64,37 +64,26 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
 
   const client = useApiClient()
 
-  const freezeOrUnfreezeUtxo = useMutation({
-    ...freezeMutation({ client }),
+  const freezeOrUnfreezeUtxos = useMutation({
+    ...freezebatchMutation({ client }),
     retry: false,
   })
 
-  const freezeOrUnfreezeUtxos = useMutation({
-    mutationFn: async ({ values, freeze }: { values: Utxo[]; freeze: boolean }) => {
-      return Promise.allSettled(
-        values.map((utxo) =>
-          freezeOrUnfreezeUtxo
-            .mutateAsync({
-              path: {
-                walletname: walletFileName,
-              },
-              body: {
-                'utxo-string': utxo.utxo,
-                freeze,
-              },
-            })
-            .then((it) => ({ ...it, utxo })),
-        ),
-      )
-    },
-  })
+  // The batch endpoint applies every entry or none of them, so a rejected
+  // promise means nothing was changed - there is no partial outcome to report.
+  const freezeOrUnfreezeAll = (values: Utxo[], freeze: boolean) =>
+    freezeOrUnfreezeUtxos
+      .mutateAsync({
+        path: { walletname: walletFileName },
+        body: { entries: values.map((utxo) => ({ 'utxo-string': utxo.utxo, freeze })) },
+      })
+      .then(() => walletInfoRefetch())
+
   const freezeUtxos = useMutation({
-    mutationFn: (values: Utxo[]) =>
-      freezeOrUnfreezeUtxos.mutateAsync({ values, freeze: true }).then((it) => walletInfoRefetch().then(() => it)),
+    mutationFn: (values: Utxo[]) => freezeOrUnfreezeAll(values, true),
   })
   const unfreezeUtxos = useMutation({
-    mutationFn: (values: Utxo[]) =>
-      freezeOrUnfreezeUtxos.mutateAsync({ values, freeze: false }).then((it) => walletInfoRefetch().then(() => it)),
+    mutationFn: (values: Utxo[]) => freezeOrUnfreezeAll(values, false),
   })
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
@@ -151,21 +140,10 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
     }
 
     try {
-      const result = await freezeUtxos.mutateAsync(eligibleUtxos)
-      const fulfilled = result.filter((it) => it.status === 'fulfilled')
-      const rejected = result.filter((it) => it.status === 'rejected')
-      if (rejected.length === 0) {
-        toast.success(t('jar_details.utxo_list.toast_freeze_success', { count: fulfilled.length }))
-      } else {
-        const errorMessage = t('jar_details.utxo_list.toast_freeze_error', { count: rejected.length })
-        if (fulfilled.length > 0) {
-          toast.warning(errorMessage)
-        } else {
-          toast.error(errorMessage)
-        }
-      }
+      await freezeUtxos.mutateAsync(eligibleUtxos)
+      toast.success(t('jar_details.utxo_list.toast_freeze_success', { count: eligibleUtxos.length }))
     } catch (_ignoredOnPurpose) {
-      toast.error(t('jar_details.utxo_list.toast_freeze_error', { count: selectedUtxos.length }))
+      toast.error(t('jar_details.utxo_list.toast_freeze_error', { count: eligibleUtxos.length }))
     }
   }
 
@@ -182,21 +160,10 @@ export const UtxosContent = ({ enabled, walletFileName, addressSummary, jar }: U
     }
 
     try {
-      const result = await unfreezeUtxos.mutateAsync(eligibleUtxos)
-      const fulfilled = result.filter((it) => it.status === 'fulfilled')
-      const rejected = result.filter((it) => it.status === 'rejected')
-      if (rejected.length === 0) {
-        toast.success(t('jar_details.utxo_list.toast_unfreeze_success', { count: fulfilled.length }))
-      } else {
-        const errorMessage = t('jar_details.utxo_list.toast_unfreeze_error', { count: rejected.length })
-        if (fulfilled.length > 0) {
-          toast.warning(errorMessage)
-        } else {
-          toast.error(errorMessage)
-        }
-      }
+      await unfreezeUtxos.mutateAsync(eligibleUtxos)
+      toast.success(t('jar_details.utxo_list.toast_unfreeze_success', { count: eligibleUtxos.length }))
     } catch (_ignoredOnPurpose) {
-      toast.error(t('jar_details.utxo_list.toast_unfreeze_error', { count: selectedUtxos.length }))
+      toast.error(t('jar_details.utxo_list.toast_unfreeze_error', { count: eligibleUtxos.length }))
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Freezing or unfreezing n selected utxos in the jar details view fired n parallel requests through `Promise.allSettled`. That also meant a batch could land half-applied, so the UI had to count fulfilled vs rejected and show a third "some of them worked" state.

The wallet API now has a `freeze-batch` endpoint that applies every entry or none of them, so this sends a single request and both handlers collapse to a plain success or error path.

- Closes #1437

### Behaviour change

Partial outcomes are no longer possible. Previously a batch could end up with some utxos frozen and some not, and the toast reported the split. Now it either all lands or nothing does, and the toast is success or error. No i18n keys are orphaned by this, both `toast_*_error` keys are still used on the error path.

One small fix came along with it: the error toast counted `selectedUtxos` while the request actually operated on `eligibleUtxos`, which differ whenever same-address utxos get auto-included. Both counts now use `eligibleUtxos`.

### Scope

I left the freeze loops in `useCreateFidelityBondWizard.ts` and `useFidelityBondSweep.ts` alone for now. There's an open question on #1467 about whether the "Freeze Remaining UTXOs" step should go away entirely, and batching loops that might be deleted seemed like wasted churn. Happy to follow up once that's settled.

### Tests

`WalletJarsDetailsContent.test.tsx` now asserts a single batch request goes out with the right entries and freeze flag, plus a new test that a rejected batch surfaces an error and does not refetch wallet info. I checked the assertions actually bite by hardcoding the freeze flag, which fails the unfreeze test rather than passing regardless.

## Visual Demo

No UI changes. Same buttons, same toasts, only the request shape and the partial-state case differ.
