### PR TITLE
fix(validation): accept uppercase bech32 addresses

### DIFF
--- a/src/components/send/collaborativeSend.ts
+++ b/src/components/send/collaborativeSend.ts
@@ -1,6 +1,6 @@
 import type { DirectSendRequest, DoCoinjoinRequest } from '@joinmarket-webui/joinmarket-api-ts/jm'
-import { validate as isValidBitcoinAddress } from 'bitcoin-address-validation'
 import { TX_FEE_UNITS } from '@/lib/feeConfig'
+import { isValidAddress, normalizeBitcoinAddress } from '@/lib/formValidation'
 import { isValidInteger, isValidNumber } from '@/lib/utils'
 import type { SendFormValues } from './types'
 
@@ -24,7 +24,7 @@ export const buildNonCollaborativeSendRequest = (data: SendFormValues): DirectSe
   if (data.amount === undefined) {
     throw new Error('Cannot trigger non-collaborative transaction: Invalid amount given.')
   }
-  if (data.destination === undefined || !isValidBitcoinAddress(data.destination.address)) {
+  if (data.destination === undefined || !isValidAddress(data.destination.address)) {
     throw new Error('Cannot trigger non-collaborative transaction: Invalid bitcoin address given.')
   }
   if (data.source?.fromJar === undefined) {
@@ -38,7 +38,7 @@ export const buildNonCollaborativeSendRequest = (data: SendFormValues): DirectSe
 
   return {
     amount_sats: data.amount.isSweep === true ? 0 : data.amount.amount,
-    destination: data.destination.address,
+    destination: normalizeBitcoinAddress(data.destination.address),
     mixdepth: data.source.fromJar,
     txfee,
   }
@@ -50,8 +50,9 @@ export const buildCollaborativeSendRequest = (data: SendFormValues): DoCoinjoinR
     throw new Error('Invalid source jar.')
   }
 
-  const address = data.destination.address
-  if (typeof address !== 'string' || !isValidBitcoinAddress(address)) {
+  const rawAddress: unknown = data.destination.address
+  const address = typeof rawAddress === 'string' ? normalizeBitcoinAddress(rawAddress) : rawAddress
+  if (!isValidAddress(address)) {
     throw new Error('Invalid bitcoin address.')
   }
 

--- a/src/components/sweep/destinationValidation.test.ts
+++ b/src/components/sweep/destinationValidation.test.ts
@@ -23,6 +23,16 @@ describe('buildDestinationErrors', () => {
     ])
   })
 
+  it('reports duplicates that differ only in bech32 casing', () => {
+    const address = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'
+    const errors = buildDestinationErrors([address, address.toUpperCase()], {}, t)
+
+    expect(errors).toEqual([
+      'scheduler.feedback_reused_destination_address',
+      'scheduler.feedback_reused_destination_address',
+    ])
+  })
+
   it('reports reused addresses from wallet history', () => {
     const usedAddress = '1BitcoinEaterAddressDontSend8MUo1T'
     const freshAddress = '1BitcoinEaterAddressDontSendDHyNcX'

--- a/src/components/sweep/destinationValidation.ts
+++ b/src/components/sweep/destinationValidation.ts
@@ -1,8 +1,8 @@
 import type { TFunction } from 'i18next'
 import type { AddressSummary } from '@/context/JamWalletInfoContext'
-import { isReusedAddress, isValidAddress } from '@/lib/formValidation'
+import { isReusedAddress, isValidAddress, normalizeBitcoinAddress } from '@/lib/formValidation'
 
-const normalizeAddress = (value: string): string => value.trim()
+const normalizeAddress = (value: string): string => normalizeBitcoinAddress(value)
 
 export const buildDestinationErrors = (
   addresses: string[],

--- a/src/components/sweep/destinationValidation.ts
+++ b/src/components/sweep/destinationValidation.ts
@@ -2,14 +2,12 @@ import type { TFunction } from 'i18next'
 import type { AddressSummary } from '@/context/JamWalletInfoContext'
 import { isReusedAddress, isValidAddress, normalizeBitcoinAddress } from '@/lib/formValidation'
 
-const normalizeAddress = (value: string): string => normalizeBitcoinAddress(value)
-
 export const buildDestinationErrors = (
   addresses: string[],
   addressSummary: AddressSummary,
   t: TFunction,
 ): Array<string | undefined> => {
-  const normalizedAddresses = addresses.map((address) => normalizeAddress(address))
+  const normalizedAddresses = addresses.map((address) => normalizeBitcoinAddress(address))
   const counts = normalizedAddresses.reduce((acc, address) => {
     if (!isValidAddress(address)) {
       return acc
@@ -34,5 +32,5 @@ export const buildDestinationErrors = (
 }
 
 export const normalizeDestinationAddresses = (addresses: string[]): string[] => {
-  return addresses.map((address) => normalizeAddress(address))
+  return addresses.map((address) => normalizeBitcoinAddress(address))
 }

--- a/src/lib/bip21.test.ts
+++ b/src/lib/bip21.test.ts
@@ -5,6 +5,8 @@ import { parseBip21Uri } from './bip21'
 const VALID_ADDRESS = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'
 // Valid testnet address
 const VALID_TESTNET_ADDRESS = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'
+// Valid mainnet P2TR (bech32m) address for testing
+const VALID_TAPROOT_ADDRESS = 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr'
 
 describe('parseBip21Uri', () => {
   describe('raw addresses', () => {
@@ -94,6 +96,39 @@ describe('parseBip21Uri', () => {
 
     it('returns undefined for non-bitcoin URI scheme', () => {
       expect(parseBip21Uri(`lnurl:${VALID_ADDRESS}`)).toBeUndefined()
+    })
+
+    it('keeps the query string when it contains an unencoded question mark', () => {
+      const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?amount=0.5&message=a?b`)
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, amount: 50_000_000, message: 'a?b' })
+    })
+  })
+
+  describe('uppercase URIs (as encoded in QR codes)', () => {
+    it('parses an uppercase URI and lowercases the address', () => {
+      const result = parseBip21Uri(`BITCOIN:${VALID_ADDRESS.toUpperCase()}?AMOUNT=0.001`)
+      expect(result).toEqual({ address: VALID_ADDRESS, fromUri: true, amount: 100_000 })
+    })
+
+    it('parses an uppercase taproot address', () => {
+      const result = parseBip21Uri(`BITCOIN:${VALID_TAPROOT_ADDRESS.toUpperCase()}`)
+      expect(result).toEqual({ address: VALID_TAPROOT_ADDRESS, fromUri: true })
+    })
+
+    it('parses an uppercase raw address without URI scheme', () => {
+      const result = parseBip21Uri(VALID_TAPROOT_ADDRESS.toUpperCase())
+      expect(result).toEqual({ address: VALID_TAPROOT_ADDRESS, fromUri: false })
+    })
+
+    it('reads parameter names case-insensitively', () => {
+      const result = parseBip21Uri(`bitcoin:${VALID_ADDRESS}?AMOUNT=0.01&Label=test&MESSAGE=hello`)
+      expect(result).toEqual({
+        address: VALID_ADDRESS,
+        fromUri: true,
+        amount: 1_000_000,
+        label: 'test',
+        message: 'hello',
+      })
     })
   })
 

--- a/src/lib/bip21.ts
+++ b/src/lib/bip21.ts
@@ -1,4 +1,4 @@
-import { validate as isValidBitcoinAddress } from 'bitcoin-address-validation'
+import { isValidAddress, normalizeBitcoinAddress } from '@/lib/formValidation'
 import { tryBtcToSat } from '@/lib/utils'
 import type { AmountSats, BitcoinAddress } from '@/types/global'
 
@@ -12,41 +12,56 @@ export type Bip21ParseResult = {
   fromUri: boolean
 }
 
+const readParameters = (queryString: string) => {
+  const byLowercaseName = new Map<string, string>()
+  for (const [name, value] of new URLSearchParams(queryString)) {
+    const key = name.toLowerCase()
+    if (!byLowercaseName.has(key)) {
+      byLowercaseName.set(key, value)
+    }
+  }
+  return (name: string) => byLowercaseName.get(name)
+}
+
 export const parseBip21Uri = (raw: string): Bip21ParseResult | undefined => {
   const trimmed = raw.trim()
 
   // BIP21: bitcoin:<address>?amount=<btc>&...
   if (!trimmed.toLowerCase().startsWith(BITCOIN_URI_SCHEME)) {
     // raw address (no URI scheme)
-    if (isValidBitcoinAddress(trimmed)) {
-      return { address: trimmed, fromUri: false }
+    const address = normalizeBitcoinAddress(trimmed)
+    if (isValidAddress(address)) {
+      return { address, fromUri: false }
     }
     return undefined
   }
 
   const withoutScheme = trimmed.slice(BITCOIN_URI_SCHEME.length)
-  const [addressPart, queryString] = withoutScheme.split('?', 2)
+  const queryStringIndex = withoutScheme.indexOf('?')
+  const addressPart = queryStringIndex === -1 ? withoutScheme : withoutScheme.slice(0, queryStringIndex)
+  const queryString = queryStringIndex === -1 ? '' : withoutScheme.slice(queryStringIndex + 1)
 
-  if (!addressPart || !isValidBitcoinAddress(addressPart)) {
+  const address = normalizeBitcoinAddress(addressPart)
+  if (!isValidAddress(address)) {
     return undefined
   }
 
-  const result: Bip21ParseResult = { address: addressPart, fromUri: true }
+  const result: Bip21ParseResult = { address, fromUri: true }
 
   if (queryString) {
-    const parameters = new URLSearchParams(queryString)
-    const amountBtc = parameters.get('amount')
-    if (amountBtc !== null) {
+    const getParameter = readParameters(queryString)
+    const amountBtc = getParameter('amount')
+    if (amountBtc !== undefined) {
       const satValue = tryBtcToSat(amountBtc)
       if (satValue !== undefined && satValue > 0) {
         result.amount = satValue
       }
     }
-    const label = parameters.get('label')
+    const label = getParameter('label')
     if (label) {
       result.label = label
     }
-    const message = parameters.get('message')
+    const message = getParameter('message')
     if (message) {
       result.message = message
     }

--- a/src/lib/formValidation.test.ts
+++ b/src/lib/formValidation.test.ts
@@ -6,6 +6,7 @@ import {
   isAddressOnNetwork,
   isReusedAddress,
   isValidAddress,
+  normalizeBitcoinAddress,
   sourceJarField,
   blockHeightField,
   INPUT_BLOCK_HEIGHT_MIN,
@@ -13,6 +14,8 @@ import {
 
 const mainnetAddress = '1BitcoinEaterAddressDontSend8MUo1T'
 const testnetAddress = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn'
+const mainnetBech32Address = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'
+const mainnetTaprootAddress = 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr'
 const regtestBech32Address = 'bcrt1q6rz28mcfaxtmd6v789l9rrlrusdprr9pz3cppk'
 const testnetBech32Address = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'
 // bech32m/taproot pair - same witness program, differing only by HRP (tb1p vs bcrt1p)
@@ -23,6 +26,33 @@ const regtestLegacyAddressLabelledTestnet = 'mkpZhYtJu2r87Js3pDiWJDmPte2NRZ8bJV'
 const addressSummary = {
   [mainnetAddress]: { address: mainnetAddress, used: false },
 } as unknown as AddressSummary
+
+describe('normalizeBitcoinAddress', () => {
+  it('lowercases an all-uppercase bech32 address', () => {
+    expect(normalizeBitcoinAddress(mainnetBech32Address.toUpperCase())).toBe(mainnetBech32Address)
+    expect(normalizeBitcoinAddress(mainnetTaprootAddress.toUpperCase())).toBe(mainnetTaprootAddress)
+    expect(normalizeBitcoinAddress(testnetBech32Address.toUpperCase())).toBe(testnetBech32Address)
+    expect(normalizeBitcoinAddress(regtestTaprootAddress.toUpperCase())).toBe(regtestTaprootAddress)
+  })
+
+  it('leaves base58 addresses untouched - they are case-sensitive', () => {
+    expect(normalizeBitcoinAddress(mainnetAddress)).toBe(mainnetAddress)
+    expect(normalizeBitcoinAddress(mainnetAddress.toUpperCase())).toBe(mainnetAddress.toUpperCase())
+    expect(normalizeBitcoinAddress(testnetAddress)).toBe(testnetAddress)
+  })
+
+  it('leaves lowercase and mixed-case input alone', () => {
+    expect(normalizeBitcoinAddress(mainnetBech32Address)).toBe(mainnetBech32Address)
+    const mixedCase = 'BC1Qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'
+    expect(normalizeBitcoinAddress(mixedCase)).toBe(mixedCase)
+    expect(isValidAddress(mixedCase)).toBe(false)
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeBitcoinAddress(`  ${mainnetBech32Address.toUpperCase()}  `)).toBe(mainnetBech32Address)
+    expect(normalizeBitcoinAddress(`  ${mainnetAddress}  `)).toBe(mainnetAddress)
+  })
+})
 
 describe('isValidAddress', () => {
   it.each([
@@ -35,6 +65,17 @@ describe('isValidAddress', () => {
     regtestLegacyAddressLabelledTestnet,
   ])('accepts valid addresses', (address) => {
     expect(isValidAddress(address)).toBe(true)
+  })
+
+  it.each([
+    mainnetBech32Address,
+    mainnetTaprootAddress,
+    testnetBech32Address,
+    testnetTaprootAddress,
+    regtestBech32Address,
+    regtestTaprootAddress,
+  ])('accepts the uppercase form of bech32 addresses', (address) => {
+    expect(isValidAddress(address.toUpperCase())).toBe(true)
   })
 
   it('reject invalid addresses', () => {
@@ -97,6 +138,15 @@ describe('isReusedAddress', () => {
     expect(isReusedAddress(mainnetAddress, usedSummary)).toBe(true)
     expect(isReusedAddress(mainnetAddress, addressSummary)).toBe(false)
     expect(isReusedAddress('unknown-address', addressSummary)).toBe(false)
+  })
+
+  it('detects reuse regardless of bech32 casing', () => {
+    const usedSummary = {
+      [mainnetBech32Address]: { address: mainnetBech32Address, used: true },
+    } as unknown as AddressSummary
+
+    expect(isReusedAddress(mainnetBech32Address, usedSummary)).toBe(true)
+    expect(isReusedAddress(mainnetBech32Address.toUpperCase(), usedSummary)).toBe(true)
   })
 })
 

--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -10,12 +10,22 @@ import type { AddressSummary } from '@/context/JamWalletInfoContext'
 import type { BitcoinAddress, BlockHeight, JarIndex } from '@/types/global'
 import { isValidInteger } from './utils'
 
+const BECH32_HRP_PREFIXES = ['bc1', 'tb1', 'bcrt1']
+
+export const normalizeBitcoinAddress = (value: string): string => {
+  const trimmed = value.trim()
+  if (trimmed !== trimmed.toUpperCase()) return trimmed
+
+  const lowercased = trimmed.toLowerCase()
+  return BECH32_HRP_PREFIXES.some((prefix) => lowercased.startsWith(prefix)) ? lowercased : trimmed
+}
+
 /**
  * Shared bitcoin-address predicates used across form schemas (send, sweep, ...).
  * Keeping these in one place ensures every form validates addresses the same way.
  */
 export const isValidAddress = (value: unknown): value is BitcoinAddress =>
-  typeof value === 'string' && isValidBitcoinAddress(value)
+  typeof value === 'string' && isValidBitcoinAddress(normalizeBitcoinAddress(value))
 
 // p2pkh/p2sh addresses (base58) share the same version bytes on testnet and regtest, so
 // address validation can't tell them apart and always labels them "testnet".
@@ -40,7 +50,7 @@ const isAmbiguousAddressForNetwork = (info: AddressInfo, expectedNetwork: Networ
 
 export const isAddressOnNetwork = (value: string, expectedNetwork: Network): boolean => {
   try {
-    const addressInfo = getAddressInfo(value)
+    const addressInfo = getAddressInfo(normalizeBitcoinAddress(value))
     if (addressInfo.network === expectedNetwork) return true
     return isAmbiguousAddressForNetwork(addressInfo, expectedNetwork)
   } catch (_ignoredOnPurpose) {
@@ -49,7 +59,7 @@ export const isAddressOnNetwork = (value: string, expectedNetwork: Network): boo
 }
 
 export const isReusedAddress = (value: string, addressSummary: AddressSummary): boolean =>
-  addressSummary[value]?.used === true
+  addressSummary[normalizeBitcoinAddress(value)]?.used === true
 
 /**
  * Shared "source jar" (`fromJar`) field validator.
@@ -88,6 +98,7 @@ export const destinationAddressField = ({
   yup
     .string()
     .trim()
+    .transform((value: unknown) => (typeof value === 'string' ? normalizeBitcoinAddress(value) : value))
     .required(messages.invalid)
     .test('valid-address-test', messages.invalid, (value) => isValidAddress(value))
     // The network and reuse checks only run once the address itself is valid, so an invalid

--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -10,14 +10,16 @@ import type { AddressSummary } from '@/context/JamWalletInfoContext'
 import type { BitcoinAddress, BlockHeight, JarIndex } from '@/types/global'
 import { isValidInteger } from './utils'
 
-const BECH32_HRP_PREFIXES = ['bc1', 'tb1', 'bcrt1']
-
 export const normalizeBitcoinAddress = (value: string): string => {
   const trimmed = value.trim()
   if (trimmed !== trimmed.toUpperCase()) return trimmed
 
   const lowercased = trimmed.toLowerCase()
-  return BECH32_HRP_PREFIXES.some((prefix) => lowercased.startsWith(prefix)) ? lowercased : trimmed
+  try {
+    return getAddressInfo(lowercased).bech32 ? lowercased : trimmed
+  } catch (_ignoredOnPurpose) {
+    return trimmed
+  }
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Bech32 addresses are case-insensitive BIP-173 requires decoders to accept the all-uppercase form, and recommends it inside QR codes since alphanumeric mode encodes it more densely. Jam compared addresses as raw strings everywhere, which broke three things:

- **An uppercase taproot address is rejected as invalid.** `bitcoin-address-validation` selects bech32m vs bech32 with a case-sensitive `startsWith('bc1p')`, so `BC1P…` gets checksummed with the wrong variant. Uppercase `BC1Q…` works fine, which makes it look arbitrary same paste, works for segwit v0, fails for taproot.
- **The reuse warning silently misse.** `isReusedAddress` does a plain `addressSummary[value]` lookup, and that map is keyed by the lowercase addresses the API returns.
- **The sweep duplicate-destination check misses too** It counts exact strings, so `bc1q…` in one field and `BC1Q…` in another aren't seen as the same destination, and two tumbler phases could pay one address.

Adds `normalizeBitcoinAddress()` to `formValidation.ts`, which lowercases only when the string is all-uppercase *and* carries a bech32 HRP base58 is case-sensitive so it's left untouched, and mixed case stays invalid per BIP-173. It's applied at the input boundaries so the canonical form is what the form stores and submits, plus in the shared predicates as a backstop.

Two smaller things in `bip21.ts` while I was in there:

- Parameter names are read case-insensitively now. A wallet that uppercases a whole QR URI uppercases `AMOUNT=` too, and the old code dropped the amount while still filling in the address. **This goes slightly beyond BIP21, which only defines lowercase names** .
- `split('?', 2)` truncated the query instead of keeping the remainder, so anything after a second `?` was lost.

Tests cover uppercase forms of all six bech32 flavours, base58 and mixed-case safety, case-insensitive reuse detection, uppercase BIP21 URIs, and case-differing sweep duplicates.

#1465 
