### PR TITLE
feat(sweep): show days and hours in wait duration

### DIFF
--- a/src/components/sweep/scheduleUtils.test.ts
+++ b/src/components/sweep/scheduleUtils.test.ts
@@ -565,8 +565,12 @@ describe('scheduleUtils', () => {
 describe('formatDuration', () => {
   // Minimal stand-in for i18next: renders the key with its interpolated values,
   // so each assertion shows both which key was picked and what was passed to it.
+  // Keys are sorted so the assertions stay focused on which translation key was
+  // selected and with what values -- i18next treats option key order as
+  // irrelevant, so reordering the object literal must not break these tests.
   const t = ((key: string, values: Record<string, string> = {}) =>
     `${key}(${Object.entries(values)
+      .toSorted(([a], [b]) => a.localeCompare(b))
       .map(([k, v]) => `${k}=${v}`)
       .join(',')})`) as unknown as Parameters<typeof formatDuration>[1]
 

--- a/src/components/sweep/scheduleUtils.test.ts
+++ b/src/components/sweep/scheduleUtils.test.ts
@@ -1,6 +1,6 @@
 import type { TumblerPlanResponse } from '@joinmarket-webui/joinmarket-api-ts/jm'
 import { describe, expect, it } from 'vitest'
-import { toSchedule } from './scheduleUtils'
+import { formatDuration, toSchedule } from './scheduleUtils'
 
 describe('scheduleUtils', () => {
   it('creates schedule from tumbler plan', () => {
@@ -559,5 +559,49 @@ describe('scheduleUtils', () => {
         transactionId: '1f95d0ff8b43645777b60bc23544b955be7e4d8984bb66856747f1fe5674df00',
       },
     ])
+  })
+})
+
+describe('formatDuration', () => {
+  // Minimal stand-in for i18next: renders the key with its interpolated values,
+  // so each assertion shows both which key was picked and what was passed to it.
+  const t = ((key: string, values: Record<string, string> = {}) =>
+    `${key}(${Object.entries(values)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(',')})`) as unknown as Parameters<typeof formatDuration>[1]
+
+  it('renders seconds below a minute', () => {
+    expect(formatDuration(0, t)).toBe('global.duration_seconds(seconds=0)')
+    expect(formatDuration(45, t)).toBe('global.duration_seconds(seconds=45)')
+  })
+
+  it('clamps negative input to zero', () => {
+    expect(formatDuration(-10, t)).toBe('global.duration_seconds(seconds=0)')
+  })
+
+  it('rounds fractional seconds up', () => {
+    expect(formatDuration(20.88, t)).toBe('global.duration_seconds(seconds=21)')
+  })
+
+  it('renders minutes, dropping seconds when they are zero', () => {
+    expect(formatDuration(60, t)).toBe('global.duration_minutes(minutes=1)')
+    expect(formatDuration(125, t)).toBe('global.duration_minutes_seconds(minutes=2,seconds=5)')
+  })
+
+  it('drops seconds from an hour upwards', () => {
+    expect(formatDuration(3600, t)).toBe('global.duration_hours(hours=1)')
+    // 2h 30m 15s -> the trailing 15s is not shown
+    expect(formatDuration(9015, t)).toBe('global.duration_hours_minutes(hours=2,minutes=30)')
+  })
+
+  it('drops minutes from a day upwards', () => {
+    expect(formatDuration(86400, t)).toBe('global.duration_days(days=1)')
+    expect(formatDuration(90000, t)).toBe('global.duration_days_hours(days=1,hours=1)')
+  })
+
+  it('renders the long wait from the issue as days instead of thousands of minutes', () => {
+    // 9,119m 3s -- previously rendered as "9,119m 3s"
+    const seconds = 9119 * 60 + 3
+    expect(formatDuration(seconds, t)).toBe('global.duration_days_hours(days=6,hours=7)')
   })
 })

--- a/src/components/sweep/scheduleUtils.ts
+++ b/src/components/sweep/scheduleUtils.ts
@@ -306,11 +306,44 @@ const toScheduleDerivedStatus = (
   return undefined
 }
 
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
+const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
+
 // TODO: move to utils and use Intl.DurationFormat (es2025) if available
 export const formatDuration = (seconds: number, t: TFunction): string => {
   const roundedSeconds = Math.max(0, Math.ceil(seconds))
-  const minutes = Math.floor(roundedSeconds / 60)
-  const remainingSeconds = roundedSeconds % 60
+
+  // Show at most the two largest non-zero units, so long waits stay readable:
+  // seconds are dropped from an hour upwards, minutes from a day upwards.
+  if (roundedSeconds >= SECONDS_PER_DAY) {
+    const days = Math.floor(roundedSeconds / SECONDS_PER_DAY)
+    const hours = Math.floor((roundedSeconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR)
+
+    if (hours === 0) {
+      return t('global.duration_days', { days: days.toLocaleString() })
+    }
+    return t('global.duration_days_hours', {
+      days: days.toLocaleString(),
+      hours: hours.toLocaleString(),
+    })
+  }
+
+  if (roundedSeconds >= SECONDS_PER_HOUR) {
+    const hours = Math.floor(roundedSeconds / SECONDS_PER_HOUR)
+    const minutes = Math.floor((roundedSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE)
+
+    if (minutes === 0) {
+      return t('global.duration_hours', { hours: hours.toLocaleString() })
+    }
+    return t('global.duration_hours_minutes', {
+      hours: hours.toLocaleString(),
+      minutes: minutes.toLocaleString(),
+    })
+  }
+
+  const minutes = Math.floor(roundedSeconds / SECONDS_PER_MINUTE)
+  const remainingSeconds = roundedSeconds % SECONDS_PER_MINUTE
 
   if (minutes === 0) {
     return t('global.duration_seconds', { seconds: remainingSeconds.toLocaleString() })

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -34,6 +34,10 @@
     "duration_seconds": "{{ seconds }}s",
     "duration_minutes": "{{ minutes }}m",
     "duration_minutes_seconds": "{{ minutes }}m {{ seconds }}s",
+    "duration_hours": "{{ hours }}h",
+    "duration_hours_minutes": "{{ hours }}h {{ minutes }}m",
+    "duration_days": "{{ days }}d",
+    "duration_days_hours": "{{ days }}d {{ hours }}h",
     "errors": {
       "error_loading_wallet_failed": "Loading wallet failed. {{ reason }}",
       "error_reloading_wallet_failed": "Reloading wallet failed. {{ reason }}",


### PR DESCRIPTION
Fixes #1472

### Problem

On the Sweep page a long wait before the next action rendered as `9,119m 3s`. You cannot read that without doing the arithmetic — it is about six days.

`formatDuration()` in `src/components/sweep/scheduleUtils.ts` only handled minutes and seconds, so everything accumulated into minutes no matter how long the wait was.

### Change

Show at most the two largest non-zero units. Seconds are dropped from an hour upwards, minutes from a day upwards, as the issue asks.

| Duration | Before | After |
|---|---|---|
| 45s | `45s` | `45s` |
| 2m 5s | `2m 5s` | `2m 5s` |
| 2h 30m 15s | `150m 15s` | `2h 30m` |
| ~6 days | `9,119m 3s` | `6d 7h` |

Short durations render exactly as before. The existing behaviour is preserved: negative input is still clamped to zero, fractional seconds still round up, and numbers still go through `toLocaleString()`.

### Translations

The four new keys are added to `en` only, matching how the existing `duration_*` keys are handled — they live in `en/translation.json` alone and the other locales fall back to it.

### Tests

`formatDuration` had no tests, so this adds the first ones — seven cases covering the boundaries (below a minute, negative input, fractional rounding, the hour boundary, the day boundary) and the exact duration from the issue.

The `t()` double renders the key together with its interpolated values, so each assertion shows both which key was selected and what was passed to it. If key selection regresses, the failure names the key.

### Verification

```
npx vitest run --project unit src/components/sweep/scheduleUtils.test.ts
  → 11 passed (4 existing + 7 new)
npx tsc -b        → clean
npx prettier      → clean
npx eslint        → clean
```

### Note

I left the `// TODO: move to utils and use Intl.DurationFormat (es2025) if available` comment in place — this change doesn't address it, and `Intl.DurationFormat` would be a separate refactor.
