### PR TITLE
fix/receive-copy-share-bip21-amount

### DIFF
--- a/src/components/receive/ReceivePage.test.tsx
+++ b/src/components/receive/ReceivePage.test.tsx
@@ -204,6 +204,28 @@ describe('ReceivePage', () => {
     expect(badge).not.toHaveClass('bg-primary')
   })
 
+  it('copies the plain address when no amount is requested', async () => {
+    render(<ReceivePage walletFileName="wallet.jmdat" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'receive.button_reveal_address' }))
+
+    await waitFor(() => expect(screen.getByText('copy:bc1qexample')).toBeInTheDocument())
+  })
+
+  it('copies the full payment request once an amount is requested', async () => {
+    const user = userEvent.setup()
+
+    render(<ReceivePage walletFileName="wallet.jmdat" />)
+
+    await user.click(screen.getByRole('button', { name: 'receive.button_reveal_address' }))
+    await waitFor(() => expect(screen.getByText('copy:bc1qexample')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'receive.button_settings' }))
+    await user.click(screen.getByRole('button', { name: 'update receive form' }))
+
+    await waitFor(() => expect(screen.getByText('copy:bitcoin:bc1qexample?amount=0.00002100')).toBeInTheDocument())
+  })
+
   it('uses receive form changes for the next address request and sharing', async () => {
     const user = userEvent.setup()
     mocks.share.mockRejectedValue(new Error('cancelled'))
@@ -222,7 +244,7 @@ describe('ReceivePage', () => {
 
     expect(mocks.share).toHaveBeenCalledWith({
       title: 'Bitcoin Address',
-      text: 'bc1qexample',
+      text: 'bitcoin:bc1qexample?amount=0.00002100',
     })
     expect(mocks.toastError).toHaveBeenCalledWith('receive.error_share_address_failed')
   })

--- a/src/components/receive/ReceivePage.tsx
+++ b/src/components/receive/ReceivePage.tsx
@@ -13,10 +13,11 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { useRescanStatus } from '@/context/JamSessionInfoContext'
 import { useJars } from '@/context/JamWalletInfoContext'
 import { useApiClient } from '@/hooks/useApiClient'
+import { toBip21Uri } from '@/lib/bip21'
 import { withMutationDelay } from '@/lib/queryClient'
 import { cn, type WalletFileName } from '@/lib/utils'
 import { useDeveloperMode } from '@/store/jamSettingsStore'
-import type { AmountSats, BitcoinAddress } from '@/types/global'
+import type { AmountSats } from '@/types/global'
 import { Badge } from '../ui/badge'
 import { jarBadgeVariant } from '../ui/badge-variants'
 import { buttonVariants, jarButtonVariant } from '../ui/button-variants'
@@ -94,12 +95,24 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
     if (getAddressMutation.data?.sourceJarIndex === undefined) return
     return jars[getAddressMutation.data.sourceJarIndex]
   }, [jars, getAddressMutation.data])
-  const shareAddress = async (bitcoinAddress: BitcoinAddress) => {
+
+  // What "Copy" and "Share" hand out. With a requested amount this must be the
+  // full BIP21 payment request, otherwise the amount silently gets lost on its
+  // way to the sender - the QR code has always encoded it.
+  // Without an amount we deliberately fall back to the plain address instead of
+  // a bare `bitcoin:` URI: a copied address commonly ends up in an exchange
+  // withdrawal field, and those often reject the URI form.
+  const address = getAddressMutation.data?.address
+  const paymentRequest = useMemo(() => {
+    if (address === undefined) return ''
+    return amount !== undefined && amount > 0 ? toBip21Uri({ address, amount }) : address
+  }, [address, amount])
+  const shareAddress = async (value: string) => {
     if ('share' in navigator) {
       await navigator
         .share({
           title: 'Bitcoin Address',
-          text: bitcoinAddress,
+          text: value,
         })
         .catch(() => {
           toast.error(t('receive.error_share_address_failed'))
@@ -215,8 +228,8 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
               className={buttonVariants({
                 variant: 'outline',
               })}
-              disabled={getAddressMutation.isPending || !getAddressMutation.data?.address}
-              value={getAddressMutation.data?.address ?? ''}
+              disabled={getAddressMutation.isPending || !address}
+              value={paymentRequest}
               text={
                 <>
                   <CopyIcon />
@@ -236,8 +249,8 @@ export const ReceivePage = ({ walletFileName }: ReceivePageProps) => {
             {'share' in navigator && (
               <Button
                 variant="outline"
-                onClick={() => void shareAddress(getAddressMutation.data!.address)}
-                disabled={getAddressMutation.isPending || !getAddressMutation.data?.address}
+                onClick={() => void shareAddress(paymentRequest)}
+                disabled={getAddressMutation.isPending || !address}
               >
                 <ShareIcon />
                 {t('receive.button_share_address')}

--- a/src/components/ui/jam/BitcoinQrCode.tsx
+++ b/src/components/ui/jam/BitcoinQrCode.tsx
@@ -3,7 +3,8 @@ import { DownloadIcon } from 'lucide-react'
 import QRCode from 'qrcode'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
-import { cn, satsToBtc } from '@/lib/utils'
+import { toBip21Uri } from '@/lib/bip21'
+import { cn } from '@/lib/utils'
 import type { AmountSats, BitcoinAddress } from '@/types/global'
 
 const DEFAULT_ERROR_CORRECTION: QRCode.QRCodeErrorCorrectionLevel = 'high'
@@ -80,10 +81,7 @@ type BitcoinAddressQrCodeProps = Omit<QrCodeComponentProps, 'value' | 'children'
 export const BitcoinAddressQrCode = ({ address, amount, type, ...props }: BitcoinAddressQrCodeProps) => {
   const { t } = useTranslation()
 
-  const uri = useMemo(() => {
-    const btc = amount ? satsToBtc(String(amount)) || 0 : 0
-    return `bitcoin:${address}${btc > 0 ? `?amount=${btc.toFixed(8)}` : ''}`
-  }, [address, amount])
+  const uri = useMemo(() => toBip21Uri({ address, amount }), [address, amount])
 
   return (
     <QrCodeComponent value={uri} type={type} {...props}>

--- a/src/lib/bip21.test.ts
+++ b/src/lib/bip21.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseBip21Uri } from './bip21'
+import { parseBip21Uri, toBip21Uri } from './bip21'
 
 // Valid mainnet P2WPKH address for testing
 const VALID_ADDRESS = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'
@@ -187,5 +187,42 @@ describe('parseBip21Uri', () => {
       expect(result).toEqual({ address: VALID_ADDRESS, fromUri: false })
       expect(result).not.toHaveProperty('message')
     })
+  })
+})
+
+describe('toBip21Uri', () => {
+  it('omits the amount parameter when no amount is requested', () => {
+    expect(toBip21Uri({ address: VALID_ADDRESS })).toBe(`bitcoin:${VALID_ADDRESS}`)
+  })
+
+  it('omits the amount parameter for a zero amount', () => {
+    expect(toBip21Uri({ address: VALID_ADDRESS, amount: 0 })).toBe(`bitcoin:${VALID_ADDRESS}`)
+  })
+
+  it('appends the amount in BTC', () => {
+    expect(toBip21Uri({ address: VALID_ADDRESS, amount: 50_000 })).toBe(`bitcoin:${VALID_ADDRESS}?amount=0.00050000`)
+  })
+
+  it('renders one whole BTC', () => {
+    expect(toBip21Uri({ address: VALID_ADDRESS, amount: 100_000_000 })).toBe(
+      `bitcoin:${VALID_ADDRESS}?amount=1.00000000`,
+    )
+  })
+
+  // A naive `String(sats / 1e8)` switches to scientific notation below 1e-6 BTC
+  // and yields an amount no wallet - including our own parser - accepts.
+  it('renders small amounts in plain decimal notation', () => {
+    expect(toBip21Uri({ address: VALID_ADDRESS, amount: 1 })).toBe(`bitcoin:${VALID_ADDRESS}?amount=0.00000001`)
+    expect(toBip21Uri({ address: VALID_ADDRESS, amount: 99 })).toBe(`bitcoin:${VALID_ADDRESS}?amount=0.00000099`)
+  })
+
+  it('round-trips through parseBip21Uri', () => {
+    const uri = toBip21Uri({ address: VALID_ADDRESS, amount: 50_000 })
+    expect(parseBip21Uri(uri)).toEqual({ address: VALID_ADDRESS, amount: 50_000, fromUri: true })
+  })
+
+  it('round-trips a small amount through parseBip21Uri', () => {
+    const uri = toBip21Uri({ address: VALID_ADDRESS, amount: 1 })
+    expect(parseBip21Uri(uri)).toEqual({ address: VALID_ADDRESS, amount: 1, fromUri: true })
   })
 })

--- a/src/lib/bip21.ts
+++ b/src/lib/bip21.ts
@@ -1,5 +1,5 @@
 import { isValidAddress, normalizeBitcoinAddress } from '@/lib/formValidation'
-import { tryBtcToSat } from '@/lib/utils'
+import { satsToBtc, tryBtcToSat } from '@/lib/utils'
 import type { AmountSats, BitcoinAddress } from '@/types/global'
 
 const BITCOIN_URI_SCHEME = 'bitcoin:'
@@ -68,4 +68,22 @@ export const parseBip21Uri = (raw: string): Bip21ParseResult | undefined => {
   }
 
   return result
+}
+
+/**
+ * Builds a BIP21 payment request URI.
+ *
+ * The `amount` parameter is only appended for a positive amount, mirroring what
+ * the QR code has always encoded. Amounts are rendered with a fixed number of
+ * decimals on purpose: `toFixed` keeps small values in plain decimal notation,
+ * whereas the default number formatting would switch to scientific notation
+ * below 1e-6 BTC (100 sats) and produce a URI that {@link parseBip21Uri} - and
+ * other wallets - would reject.
+ */
+export const toBip21Uri = ({ address, amount }: { address: BitcoinAddress; amount?: AmountSats }): string => {
+  const amountBtc = amount !== undefined ? satsToBtc(String(amount)) : 0
+  if (!(amountBtc > 0)) {
+    return `${BITCOIN_URI_SCHEME}${address}`
+  }
+  return `${BITCOIN_URI_SCHEME}${address}?amount=${amountBtc.toFixed(8)}`
 }


### PR DESCRIPTION
## What does this PR do?

#1474

The requested amount only ever made it into the QR code. Copy and Share handed
out the bare address, so if you typed an amount and pasted the address into a
chat, the sender never saw the amount and nothing told you it got lost.

the reason is that the BIP21 URI was built inside `BitcoinAddressQrCode`, so
nothing else on the page could get at it. I moved that into a `toBip21Uri()`
helper in `lib/bip21.ts`, right next to `parseBip21Uri` we could already read
these URIs on the Send page, we just couldn't write one anywhere except into a
QR image. The QR now uses the helper and behaves exactly as before.

copy and share now hand out the full payment request when an amount is set.
When there's no amount they return the plain address instead of a bare
`bitcoin:` URI

as @GuTS805 pointed out in the issue, a copied address usually
ends up in an exchange withdrawal field and those often reject the URI form.
The QR keeps its `bitcoin:` prefix either way.

`ReceivePage.test.tsx` was asserting the old Share behaviour, so that assertion
is updated. Added tests for `toBip21Uri` (including round-tripping back through
`parseBip21Uri`) and two on `ReceivePage` covering both the with-amount and
no-amount copy values.

